### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref }}-ci
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  rust-checks:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        task: [rs-test, rainix-rs-static]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 10G
+
+      - run: ./prep.sh
+
+      - name: Run ${{ matrix.task }}
+        run: nix develop -c ${{ matrix.task }}


### PR DESCRIPTION
## Motivation

The repository needs automated CI checks to ensure code quality and catch issues early. Following the same patterns used in rain.orderbook, we need workflows that run on every PR and push to main.

## Solution

Add a GitHub Actions CI workflow that:

- Runs `prep.sh` to set up submodule preludes before tasks
- Executes `rs-test` for cargo tests
- Executes `rainix-rs-static` for formatting and linting checks
- Uses nix with caching for reproducible builds
- Runs on PRs and pushes to main branch

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)