### PR TITLE
Update rain.orderbook and registry configs for settings v5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,14 +6450,11 @@ dependencies = [
  "alloy",
  "eyre",
  "foundry-evm",
- "once_cell",
  "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3)",
  "rain_interpreter_bindings",
- "reqwest 0.11.27",
  "revm 24.0.1",
  "revm 25.0.0",
  "serde",
- "serde_json",
  "thiserror 1.0.69",
  "wasm-bindgen-utils 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6571,14 +6568,6 @@ name = "rain_interpreter_dispair"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
- "rain_interpreter_bindings",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -6589,8 +6578,6 @@ dependencies = [
  "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
  "rain_interpreter_bindings",
  "rain_interpreter_dispair",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6725,11 +6712,13 @@ dependencies = [
  "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
  "anyhow",
  "clap",
+ "futures",
  "getrandom 0.2.16",
  "once_cell",
  "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3)",
  "rain-interpreter-eval",
  "rain-math-float",
+ "rain-metadata 0.0.2-alpha.6",
  "rain_orderbook_bindings",
  "rain_orderbook_subgraph_client",
  "reqwest 0.12.20",

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -1,6 +1,6 @@
 log_dir = "./logs"
 database_url = "sqlite:./data/st0x.db"
-registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+registry_url = "https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/4576454c0860c2bbf5726b3d1fcdc60771e377a7/registry"
 rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "./docs/book"

--- a/config/rest-api.toml
+++ b/config/rest-api.toml
@@ -1,6 +1,6 @@
 log_dir = "/mnt/data/st0x-rest-api/logs"
 database_url = "sqlite:///mnt/data/st0x-rest-api/st0x.db"
-registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+registry_url = "https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/4576454c0860c2bbf5726b3d1fcdc60771e377a7/registry"
 rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "/var/lib/st0x-docs"

--- a/src/routes/order/mod.rs
+++ b/src/routes/order/mod.rs
@@ -98,7 +98,7 @@ pub(crate) mod test_fixtures {
     pub fn stub_raindex_client() -> serde_json::Value {
         json!({
             "orderbook_yaml": {
-                "documents": ["version: 4\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\ndeployers:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
+                "documents": ["version: 5\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\nrainlangs:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
                 "profile": "strict"
             }
         })

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -122,7 +122,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn test_get_tokens_returns_multiple_tokens() {
-        let settings = r#"version: 4
+        let settings = r#"version: 5
 networks:
   base:
     rpcs:
@@ -137,7 +137,7 @@ orderbooks:
     network: base
     subgraph: base
     deployment-block: 0
-deployers:
+rainlangs:
   base:
     address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
     network: base
@@ -180,7 +180,7 @@ tokens:
 
     #[rocket::async_test]
     async fn test_get_tokens_adds_name_and_isin_from_remote_tokens() {
-        let settings = r#"version: 4
+        let settings = r#"version: 5
 networks:
   base:
     rpcs:
@@ -195,7 +195,7 @@ orderbooks:
     network: base
     subgraph: base
     deployment-block: 0
-deployers:
+rainlangs:
   base:
     address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
     network: base

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::{Address, U256};
 use base64::Engine;
 use rain_math_float::Float;
-use rain_orderbook_bindings::IOrderBookV6::{EvaluableV4, OrderV4, IOV2};
+use rain_orderbook_bindings::IRaindexV6::{EvaluableV4, OrderV4, IOV2};
 use rain_orderbook_common::raindex_client::orders::RaindexOrder;
 use rain_orderbook_common::take_orders::TakeOrderCandidate;
 use rocket::local::asynchronous::Client;
@@ -72,7 +72,7 @@ pub(crate) async fn mock_raindex_config() -> crate::raindex::RaindexProvider {
 }
 
 pub(crate) async fn mock_raindex_registry_url() -> String {
-    let settings = r#"version: 4
+    let settings = r#"version: 5
 networks:
   base:
     rpcs:
@@ -87,7 +87,7 @@ orderbooks:
     network: base
     subgraph: base
     deployment-block: 0
-deployers:
+rainlangs:
   base:
     address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
     network: base
@@ -207,7 +207,7 @@ pub(crate) fn basic_auth_header(key_id: &str, secret: &str) -> String {
 fn stub_raindex_client() -> serde_json::Value {
     json!({
         "orderbook_yaml": {
-            "documents": ["version: 4\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\ndeployers:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
+            "documents": ["version: 5\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\nrainlangs:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
             "profile": "strict"
         }
     })
@@ -310,5 +310,6 @@ pub(crate) fn mock_candidate(max_output: &str, ratio: &str) -> TakeOrderCandidat
         output_io_index: 0,
         max_output: Float::parse(max_output.to_string()).unwrap(),
         ratio: Float::parse(ratio.to_string()).unwrap(),
+        signed_context: vec![],
     }
 }


### PR DESCRIPTION
## Dependent PR
- https://github.com/ST0x-Technology/st0x.registry/pull/2

## Motivation

The latest `rain.orderbook` changes require the v5 settings/registry schema. This repo was still using older test fixtures and older registry commit references, which broke local compatibility and prevented the server from loading the updated registry cleanly.

## Solution

- Update the `rain.orderbook` submodule to `eceec3b3dda37f2f81486df290239c1b9a614478`
- Refresh local test helpers and embedded YAML fixtures from settings spec `version: 4` / `deployers` to `version: 5` / `rainlangs`
- Update test bindings usage from `IOrderBookV6` to `IRaindexV6`
- Add empty `signed_context` fixture data where required by the newer take-order candidate shape
- Update both `config/dev.toml` and `config/rest-api.toml` to the ST0x registry commit `4576454c0860c2bbf5726b3d1fcdc60771e377a7`

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry configuration to point to a new data source repository.
  * Updated orderbook submodule to latest version.
  * Updated test fixtures and mock data to reflect schema version changes for internal testing compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->