### PR TITLE
Batch order quote lookups per page

### DIFF
--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -8,7 +8,6 @@ use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::ValidatedAddress;
 use crate::types::orders::{OrdersListResponse, OrdersPaginationParams};
 use alloy::primitives::Address;
-use futures::future::join_all;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rocket::serde::json::Json;
 use rocket::State;
@@ -34,8 +33,11 @@ pub(crate) async fn process_get_orders_by_owner(
         .get_orders_list(filters, Some(page_num), Some(effective_page_size))
         .await?;
 
-    let quote_futures: Vec<_> = orders.iter().map(|o| ds.get_order_quotes(o)).collect();
-    let quote_results = join_all(quote_futures).await;
+    tracing::info!(
+        quoted_orders = orders.len(),
+        "fetching batched quotes for orders by owner"
+    );
+    let quote_results = ds.get_order_quotes_batch(&orders).await;
 
     let mut summaries = Vec::with_capacity(orders.len());
     for (order, quotes_result) in orders.iter().zip(quote_results) {

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -8,7 +8,6 @@ use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::ValidatedAddress;
 use crate::types::orders::{OrderSide, OrdersByTokenParams, OrdersListResponse};
 use alloy::primitives::Address;
-use futures::future::join_all;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rain_orderbook_common::raindex_client::orders::GetOrdersTokenFilter;
 use rocket::serde::json::Json;
@@ -51,8 +50,11 @@ pub(crate) async fn process_get_orders_by_token(
         .get_orders_list(filters, Some(page_num), Some(effective_page_size))
         .await?;
 
-    let quote_futures: Vec<_> = orders.iter().map(|o| ds.get_order_quotes(o)).collect();
-    let quote_results = join_all(quote_futures).await;
+    tracing::info!(
+        quoted_orders = orders.len(),
+        "fetching batched quotes for orders by token"
+    );
+    let quote_results = ds.get_order_quotes_batch(&orders).await;
 
     let mut summaries = Vec::with_capacity(orders.len());
     for (order, quotes_result) in orders.iter().zip(quote_results) {

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -6,10 +6,14 @@ use crate::error::ApiError;
 use crate::types::common::TokenRef;
 use crate::types::orders::{OrderSummary, OrdersPagination};
 use async_trait::async_trait;
-use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
+use futures::future::join_all;
+use rain_orderbook_common::raindex_client::order_quotes::{
+    get_order_quotes_batch as fetch_order_quotes_batch, RaindexOrderQuote,
+};
 use rain_orderbook_common::raindex_client::orders::{GetOrdersFilters, RaindexOrder};
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rocket::Route;
+use std::collections::BTreeMap;
 
 pub(crate) const DEFAULT_PAGE_SIZE: u32 = 20;
 pub(crate) const MAX_PAGE_SIZE: u16 = 50;
@@ -27,6 +31,17 @@ pub(crate) trait OrdersListDataSource: Send + Sync {
         &self,
         order: &RaindexOrder,
     ) -> Result<Vec<RaindexOrderQuote>, ApiError>;
+
+    async fn get_order_quotes_batch(
+        &self,
+        orders: &[RaindexOrder],
+    ) -> Vec<Result<Vec<RaindexOrderQuote>, ApiError>> {
+        let quote_futures: Vec<_> = orders
+            .iter()
+            .map(|order| self.get_order_quotes(order))
+            .collect();
+        join_all(quote_futures).await
+    }
 }
 
 pub(crate) struct RaindexOrdersListDataSource<'a> {
@@ -60,6 +75,75 @@ impl<'a> OrdersListDataSource for RaindexOrdersListDataSource<'a> {
             tracing::error!(error = %e, "failed to query order quotes");
             ApiError::Internal("failed to query order quotes".into())
         })
+    }
+
+    async fn get_order_quotes_batch(
+        &self,
+        orders: &[RaindexOrder],
+    ) -> Vec<Result<Vec<RaindexOrderQuote>, ApiError>> {
+        if orders.is_empty() {
+            return vec![];
+        }
+
+        let mut grouped_orders: BTreeMap<u32, Vec<(usize, RaindexOrder)>> = BTreeMap::new();
+        for (index, order) in orders.iter().cloned().enumerate() {
+            grouped_orders
+                .entry(order.chain_id())
+                .or_default()
+                .push((index, order));
+        }
+
+        let mut ordered_results = Vec::with_capacity(orders.len());
+        ordered_results.resize_with(orders.len(), || None);
+
+        for (chain_id, indexed_orders) in grouped_orders {
+            let group_orders: Vec<RaindexOrder> = indexed_orders
+                .iter()
+                .map(|(_, order)| order.clone())
+                .collect();
+
+            match fetch_order_quotes_batch(&group_orders, None, None).await {
+                Ok(group_quotes) => {
+                    tracing::info!(
+                        chain_id,
+                        order_count = group_orders.len(),
+                        "queried order quotes in batch"
+                    );
+                    for ((index, _), quotes) in indexed_orders.into_iter().zip(group_quotes) {
+                        ordered_results[index] = Some(Ok(quotes));
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        chain_id,
+                        order_count = group_orders.len(),
+                        error = %error,
+                        "batch quote fetch failed; falling back to per-order quotes"
+                    );
+
+                    let fallback_results = join_all(
+                        group_orders
+                            .iter()
+                            .map(|order| self.get_order_quotes(order)),
+                    )
+                    .await;
+                    for ((index, _), quotes_result) in
+                        indexed_orders.into_iter().zip(fallback_results)
+                    {
+                        ordered_results[index] = Some(quotes_result);
+                    }
+                }
+            }
+        }
+
+        ordered_results
+            .into_iter()
+            .map(|entry| {
+                entry.unwrap_or_else(|| {
+                    Err(ApiError::Internal("failed to query order quotes".into()))
+                })
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary
- batch order quote lookups per page instead of faning out one quote call per order
- keep the existing per-order fallback path when a batch quote fails
- reuse the batched path for both `/v1/orders/token/{address}` and `/v1/orders/owner/{address}`

## Why
The current endpoints quote each returned order independently. On larger pages that creates avoidable RPC fan-out and significantly higher tail latency. This change reduces the number of quote calls per request while preserving the existing response shape and fallback behavior.

## Validation
- code ported from the equivalent optimization in albionlabs/albion.rest.api
- local `cargo fmt` ran successfully
- full `cargo check` could not be completed in this clone because the nested `rain.orderbook` workspace is missing generated contract artifacts (`out/...json`) required by its bindings build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized quote retrieval for order lists through intelligent batching of quote requests, reducing API calls and latency when displaying multiple orders. Requests are grouped by chain and processed in single batch operations while preserving existing error handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->