### PR TITLE
Validate swap tokens against curated token list

### DIFF
--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -50,6 +50,9 @@ async fn process_swap_calldata(
     ds: &dyn SwapDataSource,
     req: SwapCalldataRequest,
 ) -> Result<SwapCalldataResponse, ApiError> {
+    ds.validate_supported_tokens(req.input_token, req.output_token)
+        .await?;
+
     let take_req = TakeOrdersRequest {
         taker: req.taker.to_string(),
         chain_id: crate::CHAIN_ID,
@@ -116,6 +119,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_calldata_ready() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Ok(ready_response()),
@@ -134,6 +138,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_calldata_needs_approval() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Ok(approval_response()),
@@ -152,6 +157,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_calldata_not_found() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Err(ApiError::NotFound(
@@ -165,6 +171,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_calldata_bad_request() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Err(ApiError::BadRequest("invalid parameters".into())),
@@ -176,12 +183,29 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_calldata_internal_error() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Err(ApiError::Internal("failed to generate calldata".into())),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_rejects_unsupported_tokens() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::BadRequest(
+                "unsupported token for this API".into(),
+            )),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+        let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(msg)) if msg.contains("unsupported token"))
+        );
     }
 
     #[rocket::async_test]
@@ -194,5 +218,20 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[rocket::async_test]
+    async fn test_swap_calldata_400_for_unsupported_tokens() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v1/swap/calldata")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100","maximumIoRatio":"2.5"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::BadRequest);
     }
 }

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -18,6 +18,12 @@ use rocket::Route;
 
 #[async_trait]
 pub(crate) trait SwapDataSource: Send + Sync {
+    async fn validate_supported_tokens(
+        &self,
+        input_token: Address,
+        output_token: Address,
+    ) -> Result<(), ApiError>;
+
     async fn get_orders_for_pair(
         &self,
         input_token: Address,
@@ -43,6 +49,36 @@ pub(crate) struct RaindexSwapDataSource<'a> {
 
 #[async_trait]
 impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
+    async fn validate_supported_tokens(
+        &self,
+        input_token: Address,
+        output_token: Address,
+    ) -> Result<(), ApiError> {
+        let tokens = self.client.get_all_tokens().map_err(|e| {
+            tracing::error!(error = %e, "failed to retrieve curated tokens");
+            ApiError::Internal("failed to retrieve curated tokens".into())
+        })?;
+
+        let input_supported = tokens.values().any(|token| token.address == input_token);
+        let output_supported = tokens.values().any(|token| token.address == output_token);
+
+        if input_supported && output_supported {
+            tracing::info!(input_token = %input_token, output_token = %output_token, "validated supported swap tokens");
+            return Ok(());
+        }
+
+        tracing::warn!(
+            input_token = %input_token,
+            output_token = %output_token,
+            input_supported,
+            output_supported,
+            "swap request rejected for unsupported curated tokens"
+        );
+        Err(ApiError::BadRequest(
+            "unsupported token for this API".into(),
+        ))
+    }
+
     async fn get_orders_for_pair(
         &self,
         input_token: Address,
@@ -170,6 +206,7 @@ pub(crate) mod test_fixtures {
     use rain_orderbook_common::take_orders::TakeOrderCandidate;
 
     pub struct MockSwapDataSource {
+        pub supported_tokens: Result<(), ApiError>,
         pub orders: Result<Vec<RaindexOrder>, ApiError>,
         pub candidates: Vec<TakeOrderCandidate>,
         pub calldata_result: Result<SwapCalldataResponse, ApiError>,
@@ -177,6 +214,14 @@ pub(crate) mod test_fixtures {
 
     #[async_trait]
     impl SwapDataSource for MockSwapDataSource {
+        async fn validate_supported_tokens(
+            &self,
+            _input_token: Address,
+            _output_token: Address,
+        ) -> Result<(), ApiError> {
+            self.supported_tokens.clone()
+        }
+
         async fn get_orders_for_pair(
             &self,
             _input_token: Address,

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -51,6 +51,9 @@ async fn process_swap_quote(
     ds: &dyn SwapDataSource,
     req: SwapQuoteRequest,
 ) -> Result<SwapQuoteResponse, ApiError> {
+    ds.validate_supported_tokens(req.input_token, req.output_token)
+        .await?;
+
     let orders = ds
         .get_orders_for_pair(req.input_token, req.output_token)
         .await?;
@@ -140,6 +143,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_success() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -157,6 +161,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_multi_leg() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![mock_candidate("50", "2"), mock_candidate("50", "3")],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -172,6 +177,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_partial_fill() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![mock_candidate("30", "2")],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -186,6 +192,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_picks_best_ratio() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![
                 mock_candidate("1000", "3"),
@@ -203,6 +210,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_no_liquidity() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -214,6 +222,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_no_candidates() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -225,6 +234,7 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_invalid_output_amount() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Ok(vec![mock_order()]),
             candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::Internal("unused".into())),
@@ -236,12 +246,29 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_query_failure() {
         let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
             orders: Err(ApiError::Internal("failed".into())),
             candidates: vec![],
             calldata_result: Err(ApiError::Internal("unused".into())),
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_rejects_unsupported_tokens() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::BadRequest(
+                "unsupported token for this API".into(),
+            )),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let result = process_swap_quote(&ds, quote_request("100")).await;
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(msg)) if msg.contains("unsupported token"))
+        );
     }
 
     #[rocket::async_test]
@@ -254,5 +281,20 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[rocket::async_test]
+    async fn test_swap_quote_400_for_unsupported_tokens() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v1/swap/quote")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::BadRequest);
     }
 }


### PR DESCRIPTION
Closes #80.

## Motivation

The swap endpoints currently accept any token addresses and only constrain routing by matching orderbook liquidity on the requested pair. That means `/v1/swap/quote` and `/v1/swap/calldata` can evaluate requests for tokens that are outside the curated ST0x token universe exposed by `/v1/tokens`.

This change implements the agreed fix for #80: reject swap requests unless both input and output tokens are present in the curated token list already loaded from the active registry.

## Solution

- add a shared `validate_supported_tokens` step to the swap datasource abstraction
- validate both swap quote and calldata requests before any order lookup or calldata generation
- read the curated tokens from the in-memory Raindex registry client via `get_all_tokens()`
- return `400 Bad Request` for unsupported tokens while preserving existing `404` behavior for supported pairs with no liquidity
- add processing-level and endpoint-level tests for the unsupported-token rejection path in both swap routes

## Checks

By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)

Run in this worktree:
- `nix develop -c cargo fmt`
- `nix develop -c cargo check`
- `nix develop -c cargo test routes::swap::`
- `nix develop -c rainix-rs-static`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation for token pairs in swap operations to prevent errors downstream.
  * Users now receive a clear `400 Bad Request` error with "unsupported token" message when attempting to swap tokens that aren't supported by the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->