### PR TITLE
Neutralize metaboards (~5s per request saved)

### DIFF
--- a/src/raindex/config.rs
+++ b/src/raindex/config.rs
@@ -10,6 +10,37 @@ pub(crate) struct RaindexProvider {
     db_path: Option<PathBuf>,
 }
 
+/// Neutralizes the `metaboards` section in YAML settings so the library's
+/// `fetch_orders_dotrain_sources()` skips network requests to the Goldsky
+/// metaboard subgraph. That function fetches `DotrainSourceV1` metadata per
+/// order (~5s for 20 orders). Our API never uses `DotrainSourceV1`, so
+/// replacing the metaboard keys with non-matching names causes each order's
+/// `fetch_dotrain_source()` to return `Ok(())` immediately.
+fn neutralize_metaboards(yaml: &str) -> String {
+    let mut result = String::with_capacity(yaml.len() + 64);
+    let mut in_metaboards = false;
+
+    for line in yaml.lines() {
+        if !in_metaboards && line.starts_with("metaboards:") {
+            in_metaboards = true;
+            result.push_str("metaboards:\n  _disabled: https://localhost\n");
+            continue;
+        }
+
+        if in_metaboards {
+            if line.is_empty() || line.starts_with(' ') || line.starts_with('\t') {
+                continue;
+            }
+            in_metaboards = false;
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    result
+}
+
 impl RaindexProvider {
     pub(crate) async fn load(
         registry_url: &str,
@@ -37,8 +68,10 @@ impl RaindexProvider {
                     .await
                     .map_err(|e| RaindexProviderError::RegistryLoad(e.to_string()))?;
 
-                let client = registry
-                    .get_raindex_client(db.clone())
+                // Build the client with metaboard lookups disabled to avoid ~5s
+                // of network calls in fetch_orders_dotrain_sources().
+                let settings = neutralize_metaboards(&registry.settings());
+                let client = RaindexClient::new(vec![settings], None, db.clone())
                     .await
                     .map_err(|e| RaindexProviderError::ClientInit(e.to_string()))?;
 
@@ -138,6 +171,51 @@ mod tests {
     async fn test_load_succeeds_with_valid_registry() {
         let config = crate::test_helpers::mock_raindex_config().await;
         assert!(!config.registry_url().is_empty());
+    }
+
+    #[test]
+    fn test_neutralize_metaboards_replaces_entries() {
+        let yaml = "\
+version: 4
+networks:
+  base:
+    chain-id: 8453
+metaboards:
+  base: https://api.goldsky.com/metaboard
+  ethereum: https://api.goldsky.com/metaboard-eth
+orderbooks:
+  base:
+    address: 0xabc
+";
+        let result = neutralize_metaboards(yaml);
+        assert!(result.contains("metaboards:\n  _disabled: https://localhost\n"));
+        assert!(!result.contains("api.goldsky.com"));
+        assert!(result.contains("orderbooks:"));
+        assert!(result.contains("networks:"));
+    }
+
+    #[test]
+    fn test_neutralize_metaboards_no_section() {
+        let yaml = "\
+version: 4
+networks:
+  base:
+    chain-id: 8453
+";
+        let result = neutralize_metaboards(yaml);
+        assert_eq!(result.trim(), yaml.trim());
+        assert!(!result.contains("metaboards"));
+    }
+
+    #[test]
+    fn test_neutralize_metaboards_at_end_of_file() {
+        let yaml = "\
+version: 4
+metaboards:
+  base: https://api.goldsky.com/metaboard";
+        let result = neutralize_metaboards(yaml);
+        assert!(result.contains("metaboards:\n  _disabled: https://localhost\n"));
+        assert!(!result.contains("api.goldsky.com"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `neutralize_metaboards()` to replace Goldsky metaboard subgraph URLs with a localhost stub
- The library's `fetch_orders_dotrain_sources()` calls each order's metaboard (~5s for 20 orders) — our API never uses `DotrainSourceV1`, so this is pure waste
- Switches `load()` to use `RaindexClient::new(vec![neutralized_settings], None, db)` instead of `registry.get_raindex_client()`
- Includes 3 unit tests for the neutralization logic

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test` passes (3 new tests for neutralize_metaboards)
- [ ] Time `/v1/orders/token/{addr}` before/after — expect ~5s improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Metaboards configuration entries are now automatically replaced with a disabled redirect to localhost during startup, ensuring those entries are not activated.

* **Tests**
  * Added tests covering configuration processing: replacement of metaboards, behavior when the section is absent, and replacement when the entry appears at end-of-file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->