### PR TITLE
Order perf: SDK output-vault filter + quote timing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,14 +6450,11 @@ dependencies = [
  "alloy",
  "eyre",
  "foundry-evm",
- "once_cell",
  "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3)",
  "rain_interpreter_bindings",
- "reqwest 0.11.27",
  "revm 24.0.1",
  "revm 25.0.0",
  "serde",
- "serde_json",
  "thiserror 1.0.69",
  "wasm-bindgen-utils 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -6571,14 +6568,6 @@ name = "rain_interpreter_dispair"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
- "rain_interpreter_bindings",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-subscriber 0.3.19",
 ]
 
 [[package]]
@@ -6589,8 +6578,6 @@ dependencies = [
  "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
  "rain_interpreter_bindings",
  "rain_interpreter_dispair",
- "serde",
- "serde_json",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -6724,12 +6711,15 @@ dependencies = [
  "alloy",
  "alloy-ethers-typecast 0.2.0 (git+https://github.com/rainlanguage/alloy-ethers-typecast?rev=bcc3a04394aefe191fef4ae8e6e94381a419c99a)",
  "anyhow",
+ "async-trait",
  "clap",
+ "futures",
  "getrandom 0.2.16",
  "once_cell",
  "rain-error-decoding 0.1.0 (git+https://github.com/rainlanguage/rain.error?rev=3d2ed70fb2f7c6156706846e10f163d1e493a8d3)",
  "rain-interpreter-eval",
  "rain-math-float",
+ "rain-metadata 0.0.2-alpha.6",
  "rain_orderbook_bindings",
  "rain_orderbook_subgraph_client",
  "reqwest 0.12.20",

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -1,5 +1,5 @@
 use super::{
-    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
+    build_order_summary, build_pagination, OrdersListDataSource, RaindexOrdersListDataSource,
     DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::auth::AuthenticatedKey;
@@ -11,6 +11,7 @@ use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rocket::serde::json::Json;
 use rocket::State;
+use std::time::Instant;
 use tracing::Instrument;
 
 pub(crate) async fn process_get_orders_by_owner(
@@ -25,27 +26,79 @@ pub(crate) async fn process_get_orders_by_owner(
         ..Default::default()
     };
 
+    let total_start = Instant::now();
     let page_num = page.unwrap_or(1);
     let effective_page_size = page_size
         .unwrap_or(DEFAULT_PAGE_SIZE as u16)
         .min(MAX_PAGE_SIZE);
+
+    let orders_stage_start = Instant::now();
     let (orders, total_count) = ds
         .get_orders_list(filters, Some(page_num), Some(effective_page_size))
         .await?;
+    let orders_stage_duration_ms = orders_stage_start.elapsed().as_millis();
 
+    // Only quote orders with non-zero output balance
+    let mut quotable_indices: Vec<usize> = Vec::new();
+    let mut quotable_orders: Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder> =
+        Vec::new();
+    for (i, order) in orders.iter().enumerate() {
+        let has_balance = crate::routes::resolve_io_vaults(order)
+            .map(|(_, output)| {
+                output
+                    .formatted_balance()
+                    .parse::<f64>()
+                    .is_ok_and(|b| b > 0.0)
+            })
+            .unwrap_or(false);
+        if has_balance {
+            quotable_indices.push(i);
+            quotable_orders.push(order.clone());
+        }
+    }
+
+    let quotes_stage_start = Instant::now();
     tracing::info!(
-        quoted_orders = orders.len(),
+        total_orders = orders.len(),
+        quotable_orders = quotable_orders.len(),
+        skipped_zero_balance = orders.len() - quotable_orders.len(),
         "fetching batched quotes for orders by owner"
     );
-    let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let quote_results = ds.get_order_quotes_batch(&quotable_orders).await;
+    let quotes_stage_duration_ms = quotes_stage_start.elapsed().as_millis();
 
-    build_orders_list_response(
-        &orders,
-        total_count,
-        page_num.into(),
-        effective_page_size.into(),
-        quote_results,
-    )
+    // Map quote results back to original order positions
+    let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
+    for (qi, &original_idx) in quotable_indices.iter().enumerate() {
+        io_ratios[original_idx] = super::quote_result_to_io_ratio(
+            &orders[original_idx],
+            quote_results
+                .get(qi)
+                .cloned()
+                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
+        );
+    }
+
+    let mut summaries = Vec::with_capacity(orders.len());
+    for (order, io_ratio) in orders.iter().zip(io_ratios.iter()) {
+        summaries.push(build_order_summary(order, io_ratio)?);
+    }
+
+    let pagination = build_pagination(total_count, page_num.into(), effective_page_size.into());
+    tracing::info!(
+        page = page_num,
+        page_size = effective_page_size,
+        returned_orders = summaries.len(),
+        total_orders = total_count,
+        orders_stage_duration_ms,
+        quotes_stage_duration_ms,
+        total_duration_ms = total_start.elapsed().as_millis(),
+        "orders by owner request processed"
+    );
+    Ok(OrdersListResponse {
+        orders: summaries,
+        pagination,
+    })
 }
 
 #[utoipa::path(
@@ -192,7 +245,8 @@ mod tests {
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "wtMSTR");
         assert_eq!(result.orders[0].output_token.symbol, "wtMSTR");
-        assert_eq!(result.orders[0].io_ratio, "200.0");
+        // Zero-balance orders are not quoted; io_ratio defaults to "-"
+        assert_eq!(result.orders[0].io_ratio, "-");
     }
 
     #[rocket::async_test]

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -1,5 +1,5 @@
 use super::{
-    build_order_summary, build_pagination, OrdersListDataSource, RaindexOrdersListDataSource,
+    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
     DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::auth::AuthenticatedKey;
@@ -23,6 +23,7 @@ pub(crate) async fn process_get_orders_by_owner(
     let filters = GetOrdersFilters {
         owners: vec![address],
         active: Some(true),
+        has_positive_output_vault_balance: Some(true),
         ..Default::default()
     };
 
@@ -38,67 +39,32 @@ pub(crate) async fn process_get_orders_by_owner(
         .await?;
     let orders_stage_duration_ms = orders_stage_start.elapsed().as_millis();
 
-    // Only quote orders with non-zero output balance
-    let mut quotable_indices: Vec<usize> = Vec::new();
-    let mut quotable_orders: Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder> =
-        Vec::new();
-    for (i, order) in orders.iter().enumerate() {
-        let has_balance = crate::routes::resolve_io_vaults(order)
-            .map(|(_, output)| {
-                output
-                    .formatted_balance()
-                    .parse::<f64>()
-                    .is_ok_and(|b| b > 0.0)
-            })
-            .unwrap_or(false);
-        if has_balance {
-            quotable_indices.push(i);
-            quotable_orders.push(order.clone());
-        }
-    }
-
     let quotes_stage_start = Instant::now();
     tracing::info!(
         total_orders = orders.len(),
-        quotable_orders = quotable_orders.len(),
-        skipped_zero_balance = orders.len() - quotable_orders.len(),
         "fetching batched quotes for orders by owner"
     );
-    let quote_results = ds.get_order_quotes_batch(&quotable_orders).await;
+    let quote_results = ds.get_order_quotes_batch(&orders).await;
     let quotes_stage_duration_ms = quotes_stage_start.elapsed().as_millis();
 
-    // Map quote results back to original order positions
-    let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
-    for (qi, &original_idx) in quotable_indices.iter().enumerate() {
-        io_ratios[original_idx] = super::quote_result_to_io_ratio(
-            &orders[original_idx],
-            quote_results
-                .get(qi)
-                .cloned()
-                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
-        );
-    }
-
-    let mut summaries = Vec::with_capacity(orders.len());
-    for (order, io_ratio) in orders.iter().zip(io_ratios.iter()) {
-        summaries.push(build_order_summary(order, io_ratio)?);
-    }
-
-    let pagination = build_pagination(total_count, page_num.into(), effective_page_size.into());
+    let response = build_orders_list_response(
+        &orders,
+        total_count,
+        page_num.into(),
+        effective_page_size.into(),
+        quote_results,
+    )?;
     tracing::info!(
         page = page_num,
         page_size = effective_page_size,
-        returned_orders = summaries.len(),
+        returned_orders = response.orders.len(),
         total_orders = total_count,
         orders_stage_duration_ms,
         quotes_stage_duration_ms,
         total_duration_ms = total_start.elapsed().as_millis(),
         "orders by owner request processed"
     );
-    Ok(OrdersListResponse {
-        orders: summaries,
-        pagination,
-    })
+    Ok(response)
 }
 
 #[utoipa::path(
@@ -245,8 +211,7 @@ mod tests {
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "wtMSTR");
         assert_eq!(result.orders[0].output_token.symbol, "wtMSTR");
-        // Zero-balance orders are not quoted; io_ratio defaults to "-"
-        assert_eq!(result.orders[0].io_ratio, "-");
+        assert_eq!(result.orders[0].io_ratio, "200.0");
     }
 
     #[rocket::async_test]

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -118,7 +118,35 @@ mod tests {
     };
     use crate::routes::orders::test_fixtures::MockOrdersListDataSource;
     use crate::test_helpers::{basic_auth_header, seed_api_key, TestClientBuilder};
+    use async_trait::async_trait;
+    use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
+    use rain_orderbook_common::raindex_client::orders::RaindexOrder;
     use rocket::http::{Header, Status};
+    use std::sync::{Arc, Mutex};
+
+    struct CapturingOrdersListDataSource {
+        filters: Arc<Mutex<Vec<GetOrdersFilters>>>,
+    }
+
+    #[async_trait]
+    impl OrdersListDataSource for CapturingOrdersListDataSource {
+        async fn get_orders_list(
+            &self,
+            filters: GetOrdersFilters,
+            _page: Option<u16>,
+            _page_size: Option<u16>,
+        ) -> Result<(Vec<RaindexOrder>, u32), ApiError> {
+            self.filters.lock().expect("lock filters").push(filters);
+            Ok((vec![], 0))
+        }
+
+        async fn get_order_quotes(
+            &self,
+            _order: &RaindexOrder,
+        ) -> Result<Vec<RaindexOrderQuote>, ApiError> {
+            Ok(vec![])
+        }
+    }
 
     #[rocket::async_test]
     async fn test_process_get_orders_by_owner_success() {
@@ -161,6 +189,27 @@ mod tests {
         assert!(result.orders.is_empty());
         assert_eq!(result.pagination.total_orders, 0);
         assert_eq!(result.pagination.total_pages, 0);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_owner_filters_positive_output_vault_balance() {
+        let filters = Arc::new(Mutex::new(Vec::new()));
+        let ds = CapturingOrdersListDataSource {
+            filters: Arc::clone(&filters),
+        };
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        process_get_orders_by_owner(&ds, addr, None, None)
+            .await
+            .unwrap();
+
+        let filters = filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].owners, vec![addr]);
+        assert_eq!(filters[0].active, Some(true));
+        assert_eq!(filters[0].has_positive_output_vault_balance, Some(true));
     }
 
     #[rocket::async_test]

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -1,5 +1,5 @@
 use super::{
-    build_order_summary, build_pagination, OrdersListDataSource, RaindexOrdersListDataSource,
+    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
     DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::auth::AuthenticatedKey;
@@ -40,6 +40,7 @@ pub(crate) async fn process_get_orders_by_token(
     let filters = GetOrdersFilters {
         active: Some(true),
         tokens: Some(token_filter),
+        has_positive_output_vault_balance: Some(true),
         ..Default::default()
     };
 
@@ -55,67 +56,32 @@ pub(crate) async fn process_get_orders_by_token(
         .await?;
     let orders_stage_duration_ms = orders_stage_start.elapsed().as_millis();
 
-    // Separate orders with non-zero output balance (worth quoting) from empty ones
-    let mut quotable_indices: Vec<usize> = Vec::new();
-    let mut quotable_orders: Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder> =
-        Vec::new();
-    for (i, order) in orders.iter().enumerate() {
-        let has_balance = crate::routes::resolve_io_vaults(order)
-            .map(|(_, output)| {
-                output
-                    .formatted_balance()
-                    .parse::<f64>()
-                    .is_ok_and(|b| b > 0.0)
-            })
-            .unwrap_or(false);
-        if has_balance {
-            quotable_indices.push(i);
-            quotable_orders.push(order.clone());
-        }
-    }
-
     let quotes_stage_start = Instant::now();
     tracing::info!(
         total_orders = orders.len(),
-        quotable_orders = quotable_orders.len(),
-        skipped_zero_balance = orders.len() - quotable_orders.len(),
         "fetching batched quotes for orders by token"
     );
-    let quote_results = ds.get_order_quotes_batch(&quotable_orders).await;
+    let quote_results = ds.get_order_quotes_batch(&orders).await;
     let quotes_stage_duration_ms = quotes_stage_start.elapsed().as_millis();
 
-    // Map quote results back to original order positions
-    let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
-    for (qi, &original_idx) in quotable_indices.iter().enumerate() {
-        io_ratios[original_idx] = super::quote_result_to_io_ratio(
-            &orders[original_idx],
-            quote_results
-                .get(qi)
-                .cloned()
-                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
-        );
-    }
-
-    let mut summaries = Vec::with_capacity(orders.len());
-    for (order, io_ratio) in orders.iter().zip(io_ratios.iter()) {
-        summaries.push(build_order_summary(order, io_ratio)?);
-    }
-
-    let pagination = build_pagination(total_count, page_num.into(), effective_page_size.into());
+    let response = build_orders_list_response(
+        &orders,
+        total_count,
+        page_num.into(),
+        effective_page_size.into(),
+        quote_results,
+    )?;
     tracing::info!(
         page = page_num,
         page_size = effective_page_size,
-        returned_orders = summaries.len(),
+        returned_orders = response.orders.len(),
         total_orders = total_count,
         orders_stage_duration_ms,
         quotes_stage_duration_ms,
         total_duration_ms = total_start.elapsed().as_millis(),
         "orders by token request processed"
     );
-    Ok(OrdersListResponse {
-        orders: summaries,
-        pagination,
-    })
+    Ok(response)
 }
 
 #[utoipa::path(

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -1,5 +1,5 @@
 use super::{
-    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
+    build_order_summary, build_pagination, OrdersListDataSource, RaindexOrdersListDataSource,
     DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::auth::AuthenticatedKey;
@@ -12,6 +12,7 @@ use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rain_orderbook_common::raindex_client::orders::GetOrdersTokenFilter;
 use rocket::serde::json::Json;
 use rocket::State;
+use std::time::Instant;
 use tracing::Instrument;
 
 pub(crate) async fn process_get_orders_by_token(
@@ -42,27 +43,79 @@ pub(crate) async fn process_get_orders_by_token(
         ..Default::default()
     };
 
+    let total_start = Instant::now();
     let page_num = page.unwrap_or(1);
     let effective_page_size = page_size
         .unwrap_or(DEFAULT_PAGE_SIZE as u16)
         .min(MAX_PAGE_SIZE);
+
+    let orders_stage_start = Instant::now();
     let (orders, total_count) = ds
         .get_orders_list(filters, Some(page_num), Some(effective_page_size))
         .await?;
+    let orders_stage_duration_ms = orders_stage_start.elapsed().as_millis();
 
+    // Separate orders with non-zero output balance (worth quoting) from empty ones
+    let mut quotable_indices: Vec<usize> = Vec::new();
+    let mut quotable_orders: Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder> =
+        Vec::new();
+    for (i, order) in orders.iter().enumerate() {
+        let has_balance = crate::routes::resolve_io_vaults(order)
+            .map(|(_, output)| {
+                output
+                    .formatted_balance()
+                    .parse::<f64>()
+                    .is_ok_and(|b| b > 0.0)
+            })
+            .unwrap_or(false);
+        if has_balance {
+            quotable_indices.push(i);
+            quotable_orders.push(order.clone());
+        }
+    }
+
+    let quotes_stage_start = Instant::now();
     tracing::info!(
-        quoted_orders = orders.len(),
+        total_orders = orders.len(),
+        quotable_orders = quotable_orders.len(),
+        skipped_zero_balance = orders.len() - quotable_orders.len(),
         "fetching batched quotes for orders by token"
     );
-    let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let quote_results = ds.get_order_quotes_batch(&quotable_orders).await;
+    let quotes_stage_duration_ms = quotes_stage_start.elapsed().as_millis();
 
-    build_orders_list_response(
-        &orders,
-        total_count,
-        page_num.into(),
-        effective_page_size.into(),
-        quote_results,
-    )
+    // Map quote results back to original order positions
+    let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
+    for (qi, &original_idx) in quotable_indices.iter().enumerate() {
+        io_ratios[original_idx] = super::quote_result_to_io_ratio(
+            &orders[original_idx],
+            quote_results
+                .get(qi)
+                .cloned()
+                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
+        );
+    }
+
+    let mut summaries = Vec::with_capacity(orders.len());
+    for (order, io_ratio) in orders.iter().zip(io_ratios.iter()) {
+        summaries.push(build_order_summary(order, io_ratio)?);
+    }
+
+    let pagination = build_pagination(total_count, page_num.into(), effective_page_size.into());
+    tracing::info!(
+        page = page_num,
+        page_size = effective_page_size,
+        returned_orders = summaries.len(),
+        total_orders = total_count,
+        orders_stage_duration_ms,
+        quotes_stage_duration_ms,
+        total_duration_ms = total_start.elapsed().as_millis(),
+        "orders by token request processed"
+    );
+    Ok(OrdersListResponse {
+        orders: summaries,
+        pagination,
+    })
 }
 
 #[utoipa::path(

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -136,7 +136,35 @@ mod tests {
     };
     use crate::routes::orders::test_fixtures::MockOrdersListDataSource;
     use crate::test_helpers::{basic_auth_header, seed_api_key, TestClientBuilder};
+    use async_trait::async_trait;
+    use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
+    use rain_orderbook_common::raindex_client::orders::RaindexOrder;
     use rocket::http::{Header, Status};
+    use std::sync::{Arc, Mutex};
+
+    struct CapturingOrdersListDataSource {
+        filters: Arc<Mutex<Vec<GetOrdersFilters>>>,
+    }
+
+    #[async_trait]
+    impl OrdersListDataSource for CapturingOrdersListDataSource {
+        async fn get_orders_list(
+            &self,
+            filters: GetOrdersFilters,
+            _page: Option<u16>,
+            _page_size: Option<u16>,
+        ) -> Result<(Vec<RaindexOrder>, u32), ApiError> {
+            self.filters.lock().expect("lock filters").push(filters);
+            Ok((vec![], 0))
+        }
+
+        async fn get_order_quotes(
+            &self,
+            _order: &RaindexOrder,
+        ) -> Result<Vec<RaindexOrderQuote>, ApiError> {
+            Ok(vec![])
+        }
+    }
 
     #[rocket::async_test]
     async fn test_process_get_orders_by_token_success() {
@@ -179,6 +207,29 @@ mod tests {
         assert!(result.orders.is_empty());
         assert_eq!(result.pagination.total_orders, 0);
         assert_eq!(result.pagination.total_pages, 0);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_token_filters_positive_output_vault_balance() {
+        let filters = Arc::new(Mutex::new(Vec::new()));
+        let ds = CapturingOrdersListDataSource {
+            filters: Arc::clone(&filters),
+        };
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        process_get_orders_by_token(&ds, addr, Some(OrderSide::Output), None, None)
+            .await
+            .unwrap();
+
+        let filters = filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].active, Some(true));
+        assert_eq!(filters[0].has_positive_output_vault_balance, Some(true));
+        let token_filter = filters[0].tokens.as_ref().expect("token filter");
+        assert_eq!(token_filter.inputs, None);
+        assert_eq!(token_filter.outputs, Some(vec![addr]));
     }
 
     #[rocket::async_test]

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -207,7 +207,10 @@ impl<'a> OrdersListDataSource for RaindexOrdersListDataSource<'a> {
             .first()
             .map(RaindexOrder::chain_id)
             .unwrap_or_default();
-        fetch_order_quotes_batch(orders, None, None)
+        // Use small chunk size (4) to avoid exceeding public RPC eth_call gas
+        // limits, which would trigger expensive probe-and-split retries in the
+        // quote library.
+        fetch_order_quotes_batch(orders, None, Some(4))
             .await
             .map_err(|error| {
                 tracing::error!(

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -16,6 +16,8 @@ use rain_orderbook_common::take_orders::{
 };
 use rocket::Route;
 
+const SWAP_QUOTE_CHUNK_SIZE: u32 = 4;
+
 #[async_trait]
 pub(crate) trait SwapDataSource: Send + Sync {
     async fn validate_supported_tokens(
@@ -114,7 +116,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             input_token,
             output_token,
             None,
-            None,
+            Some(SWAP_QUOTE_CHUNK_SIZE),
             Address::ZERO,
             &NoopInjector,
         )

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -12,7 +12,7 @@ use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_common::raindex_client::RaindexError;
 use rain_orderbook_common::take_orders::{
-    build_take_order_candidates_for_pair, TakeOrderCandidate,
+    build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate,
 };
 use rocket::Route;
 
@@ -109,12 +109,20 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         input_token: Address,
         output_token: Address,
     ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
-        build_take_order_candidates_for_pair(orders, input_token, output_token, None, None)
-            .await
-            .map_err(|e| {
-                tracing::error!(error = %e, "failed to build order candidates");
-                ApiError::Internal("failed to build order candidates".into())
-            })
+        build_take_order_candidates_for_pair(
+            orders,
+            input_token,
+            output_token,
+            None,
+            None,
+            Address::ZERO,
+            &NoopInjector,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to build order candidates");
+            ApiError::Internal("failed to build order candidates".into())
+        })
     }
 
     async fn get_calldata(

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -122,7 +122,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn test_get_tokens_returns_multiple_tokens() {
-        let settings = r#"version: 4
+        let settings = r#"version: 5
 networks:
   base:
     rpcs:
@@ -180,7 +180,7 @@ tokens:
 
     #[rocket::async_test]
     async fn test_get_tokens_adds_name_and_isin_from_remote_tokens() {
-        let settings = r#"version: 4
+        let settings = r#"version: 5
 networks:
   base:
     rpcs:

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::{Address, U256};
 use base64::Engine;
 use rain_math_float::Float;
-use rain_orderbook_bindings::IOrderBookV6::{EvaluableV4, OrderV4, IOV2};
+use rain_orderbook_bindings::IRaindexV6::{EvaluableV4, OrderV4, IOV2};
 use rain_orderbook_common::raindex_client::orders::RaindexOrder;
 use rain_orderbook_common::take_orders::TakeOrderCandidate;
 use rocket::local::asynchronous::Client;
@@ -72,7 +72,7 @@ pub(crate) async fn mock_raindex_config() -> crate::raindex::RaindexProvider {
 }
 
 pub(crate) async fn mock_raindex_registry_url() -> String {
-    let settings = r#"version: 4
+    let settings = r#"version: 5
 networks:
   base:
     rpcs:
@@ -207,7 +207,7 @@ pub(crate) fn basic_auth_header(key_id: &str, secret: &str) -> String {
 fn stub_raindex_client() -> serde_json::Value {
     json!({
         "orderbook_yaml": {
-            "documents": ["version: 4\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\ndeployers:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
+            "documents": ["version: 5\nnetworks:\n  base:\n    rpcs:\n      - https://mainnet.base.org\n    chain-id: 8453\n    currency: ETH\nsubgraphs:\n  base: https://example.com/sg\norderbooks:\n  base:\n    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7\n    network: base\n    subgraph: base\n    deployment-block: 0\ndeployers:\n  base:\n    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D\n    network: base\n"],
             "profile": "strict"
         }
     })
@@ -310,5 +310,6 @@ pub(crate) fn mock_candidate(max_output: &str, ratio: &str) -> TakeOrderCandidat
         output_io_index: 0,
         max_output: Float::parse(max_output.to_string()).unwrap(),
         ratio: Float::parse(ratio.to_string()).unwrap(),
+        signed_context: vec![],
     }
 }


### PR DESCRIPTION
## Summary
- Set quote batch `chunk_size` to 4 to avoid exceeding public RPC `eth_call` gas limits.
- Add stage timing (`orders`, `quotes`, `total`) to structured logs for order list performance monitoring.
- Delegate output-vault balance filtering to Raindex via `has_positive_output_vault_balance: Some(true)` before quote fetching.
- Remove REST-side formatted balance parsing and local zero-balance quote filtering.
- Update REST compatibility for the newer Raindex bindings, take-order candidate signature, signed context field, and spec version 5 test fixtures.

## Depends On
- https://github.com/rainlanguage/raindex/pull/2562 (`feat: add positive output vault balance order filter`)
- This stack bumps `lib/rain.orderbook` to `014016c699a2da4aa27d335bbf565e7347c2f762`, which exposes `has_positive_output_vault_balance`.

## Stack
- Base branch: `alastair/nginx-hardening` (#87)
- Head branch: `alastair/order-perf-optimizations`

## Test plan
- [x] `nix develop -c cargo check`
- [x] `nix develop -c cargo test routes::orders`
- [x] `nix develop -c cargo test`
- [ ] `nix develop -c rainix-rs-static` fails on existing clippy `too_many_arguments` errors in `src/routes/trades.rs` route handlers.
