### PR TITLE
Order endpoint caching (depends on #54)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,12 @@ impl<'r> Responder<'r, 'static> for ApiError {
     }
 }
 
+impl From<std::sync::Arc<ApiError>> for ApiError {
+    fn from(arc: std::sync::Arc<ApiError>) -> Self {
+        (*arc).clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,10 +125,15 @@ pub(crate) fn rocket(
 
     let options = Options::Index | Options::NormalizeDirs;
 
+    let orders_by_token_cache = routes::orders::orders_by_token_cache();
+    let orders_by_owner_cache = routes::orders::orders_by_owner_cache();
+
     Ok(rocket::custom(figment)
         .manage(pool)
         .manage(rate_limiter)
         .manage(raindex_config)
+        .manage(orders_by_token_cache)
+        .manage(orders_by_owner_cache)
         .mount("/", routes::health::routes())
         .mount("/v1/tokens", routes::tokens::routes())
         .mount("/v1/swap", routes::swap::routes())

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -13,6 +13,18 @@ use rocket::serde::json::Json;
 use rocket::State;
 use tracing::Instrument;
 
+use crate::cache::AppCache;
+use std::time::Duration;
+
+const ORDERS_BY_OWNER_CACHE_TTL: Duration = Duration::from_secs(15);
+const ORDERS_BY_OWNER_CACHE_CAPACITY: u64 = 1_000;
+
+pub(crate) type OrdersByOwnerCache = AppCache<(Address, u16, u16), OrdersListResponse>;
+
+pub(crate) fn orders_by_owner_cache() -> OrdersByOwnerCache {
+    AppCache::new(ORDERS_BY_OWNER_CACHE_CAPACITY, ORDERS_BY_OWNER_CACHE_TTL)
+}
+
 pub(crate) async fn process_get_orders_by_owner(
     ds: &dyn OrdersListDataSource,
     address: Address,
@@ -71,6 +83,7 @@ pub async fn get_orders_by_address(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    orders_cache: &State<OrdersByOwnerCache>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: OrdersPaginationParams,
@@ -78,13 +91,24 @@ pub async fn get_orders_by_address(
     async move {
         tracing::info!(address = ?address, params = ?params, "request received");
         let addr = address.0;
-        let page = params.page;
-        let page_size = params.page_size;
-        let raindex = shared_raindex.read().await;
-        let ds = RaindexOrdersListDataSource {
-            client: raindex.client(),
-        };
-        let response = process_get_orders_by_owner(&ds, addr, page, page_size).await?;
+        let page = params.page.unwrap_or(1);
+        let page_size = params
+            .page_size
+            .unwrap_or(DEFAULT_PAGE_SIZE as u16)
+            .min(MAX_PAGE_SIZE);
+        let cache_key = (addr, page, page_size);
+
+        let response = orders_cache
+            .get_or_try_insert(cache_key, || async {
+                let raindex = shared_raindex.read().await;
+                let ds = RaindexOrdersListDataSource {
+                    client: raindex.client(),
+                };
+                process_get_orders_by_owner(&ds, addr, Some(page), Some(page_size)).await
+            })
+            .await
+            .map_err(ApiError::from)?;
+
         Ok(Json(response))
     }
     .instrument(span.0)

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -14,6 +14,19 @@ use rocket::serde::json::Json;
 use rocket::State;
 use tracing::Instrument;
 
+use crate::cache::AppCache;
+use std::time::Duration;
+
+const ORDERS_CACHE_TTL: Duration = Duration::from_secs(15);
+const ORDERS_CACHE_CAPACITY: u64 = 1_000;
+
+pub(crate) type OrdersByTokenCache =
+    AppCache<(Address, Option<OrderSide>, u16, u16), OrdersListResponse>;
+
+pub(crate) fn orders_by_token_cache() -> OrdersByTokenCache {
+    AppCache::new(ORDERS_CACHE_CAPACITY, ORDERS_CACHE_TTL)
+}
+
 pub(crate) async fn process_get_orders_by_token(
     ds: &dyn OrdersListDataSource,
     address: Address,
@@ -88,6 +101,7 @@ pub async fn get_orders_by_token(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    orders_cache: &State<OrdersByTokenCache>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: OrdersByTokenParams,
@@ -96,13 +110,24 @@ pub async fn get_orders_by_token(
         tracing::info!(address = ?address, params = ?params, "request received");
         let addr = address.0;
         let side = params.side;
-        let page = params.page;
-        let page_size = params.page_size;
-        let raindex = shared_raindex.read().await;
-        let ds = RaindexOrdersListDataSource {
-            client: raindex.client(),
-        };
-        let response = process_get_orders_by_token(&ds, addr, side, page, page_size).await?;
+        let page = params.page.unwrap_or(1);
+        let page_size = params
+            .page_size
+            .unwrap_or(DEFAULT_PAGE_SIZE as u16)
+            .min(MAX_PAGE_SIZE);
+        let cache_key = (addr, side, page, page_size);
+
+        let response = orders_cache
+            .get_or_try_insert(cache_key, || async {
+                let raindex = shared_raindex.read().await;
+                let ds = RaindexOrdersListDataSource {
+                    client: raindex.client(),
+                };
+                process_get_orders_by_token(&ds, addr, side, Some(page), Some(page_size)).await
+            })
+            .await
+            .map_err(ApiError::from)?;
+
         Ok(Json(response))
     }
     .instrument(span.0)

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -319,6 +319,9 @@ pub use get_by_owner::*;
 pub use get_by_token::*;
 pub use get_by_tx::*;
 
+pub(crate) use get_by_owner::{orders_by_owner_cache, OrdersByOwnerCache};
+pub(crate) use get_by_token::{orders_by_token_cache, OrdersByTokenCache};
+
 pub fn routes() -> Vec<Route> {
     rocket::routes![
         get_by_tx::get_orders_by_tx,

--- a/src/types/orders.rs
+++ b/src/types/orders.rs
@@ -16,7 +16,9 @@ pub struct OrdersPaginationParams {
     pub page_size: Option<u16>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromFormField, ToSchema)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, FromFormField, ToSchema,
+)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderSide {
     Input,


### PR DESCRIPTION
## Summary
- Wraps `get_orders_by_address` and `get_orders_by_token` handlers with `AppCache` lookups (15s TTL, 1000 capacity)
- Adds `OrdersByOwnerCache` and `OrdersByTokenCache` types with constructors
- Adds `Copy, PartialEq, Eq, Hash` derives to `OrderSide` for use as cache key
- Adds `From<Arc<ApiError>>` impl for cache error conversion
- Registers caches as Rocket managed state

## Dependencies
- **Blocked on PR #54** which provides `AppCache`, `CacheGroup`, and `moka` dependency

## Test plan
- [ ] Second request to same endpoint within 15s returns in <100ms
- [ ] Different page/page_size params get separate cache entries
- [ ] Cache expires after 15s TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)