### PR TITLE
Add order_bytes to OrderSummary API response

### DIFF
--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -118,6 +118,7 @@ mod tests {
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "USDC");
         assert_eq!(result.orders[0].output_token.symbol, "WETH");
+        assert_eq!(result.orders[0].order_bytes.as_ref(), &[1]);
         assert_eq!(result.orders[0].io_ratio, "1.5");
         assert_eq!(result.pagination.total_orders, 1);
         assert_eq!(result.pagination.page, 1);

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -136,6 +136,7 @@ mod tests {
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "USDC");
         assert_eq!(result.orders[0].output_token.symbol, "WETH");
+        assert_eq!(result.orders[0].order_bytes.as_ref(), &[1]);
         assert_eq!(result.orders[0].io_ratio, "1.5");
         assert_eq!(result.pagination.total_orders, 1);
         assert_eq!(result.pagination.page, 1);

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -233,6 +233,7 @@ pub(crate) fn build_order_summary(
     Ok(OrderSummary {
         order_hash: order.order_hash(),
         owner: order.owner(),
+        order_bytes: order.order_bytes(),
         input_token: TokenRef {
             address: input_token_info.address(),
             symbol: input_token_info.symbol().unwrap_or_default(),

--- a/src/types/orders.rs
+++ b/src/types/orders.rs
@@ -1,5 +1,5 @@
 use crate::types::common::TokenRef;
-use alloy::primitives::{Address, FixedBytes};
+use alloy::primitives::{Address, Bytes, FixedBytes};
 use rocket::form::{FromForm, FromFormField};
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
@@ -44,6 +44,8 @@ pub struct OrderSummary {
     pub order_hash: FixedBytes<32>,
     #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
     pub owner: Address,
+    #[schema(value_type = String, example = "0x01")]
+    pub order_bytes: Bytes,
     pub input_token: TokenRef,
     pub output_token: TokenRef,
     #[schema(example = "500000")]


### PR DESCRIPTION
## Summary
- Return the ABI-encoded `order_bytes` in order list responses so the frontend can decode `OrderV4` directly without a separate Raindex hydration round-trip
- Matches albion.rest.api which already returns this field
- Eliminates the need for the frontend to call `client.getOrders()` per order hash before execution

## Changes
- `src/types/orders.rs`: Add `order_bytes: Bytes` field to `OrderSummary`
- `src/routes/orders/mod.rs`: Populate `order_bytes` from `order.order_bytes()` in `build_order_summary`

## Test plan
- [ ] Deploy to preview and verify `/v1/orders/token/{addr}` response includes `orderBytes` hex string
- [ ] Verify st0x frontend decodes orderBytes and skips hydration step
- [ ] Confirm market order execution works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order summaries now include raw order bytes in API responses.

* **Tests**
  * Updated tests to verify the presence and content of the order bytes in returned summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->