### PR TITLE
fix(ci): cargo fmt + allow clippy too_many_arguments on trades routes

### DIFF
--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -80,7 +80,13 @@ pub(crate) async fn process_get_orders_by_owner(
     // Map quote results back to original order positions
     let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
     for (qi, &original_idx) in quotable_indices.iter().enumerate() {
-        io_ratios[original_idx] = super::quote_result_to_io_ratio(&orders[original_idx], quote_results.get(qi).cloned().unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))));
+        io_ratios[original_idx] = super::quote_result_to_io_ratio(
+            &orders[original_idx],
+            quote_results
+                .get(qi)
+                .cloned()
+                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
+        );
     }
 
     let mut summaries = Vec::with_capacity(orders.len());

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -98,7 +98,13 @@ pub(crate) async fn process_get_orders_by_token(
     // Map quote results back to original order positions
     let mut io_ratios: Vec<String> = vec!["-".into(); orders.len()];
     for (qi, &original_idx) in quotable_indices.iter().enumerate() {
-        io_ratios[original_idx] = super::quote_result_to_io_ratio(&orders[original_idx], quote_results.get(qi).cloned().unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))));
+        io_ratios[original_idx] = super::quote_result_to_io_ratio(
+            &orders[original_idx],
+            quote_results
+                .get(qi)
+                .cloned()
+                .unwrap_or_else(|| Err(ApiError::Internal("missing quote".into()))),
+        );
     }
 
     let mut summaries = Vec::with_capacity(orders.len());

--- a/src/routes/trades.rs
+++ b/src/routes/trades.rs
@@ -873,6 +873,7 @@ pub async fn get_trades_by_tx(
     )
 )]
 #[get("/<address>?<params..>", rank = 2)]
+#[allow(clippy::too_many_arguments)] // Rocket route handlers naturally accumulate &State<...> params.
 pub async fn get_trades_by_address(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
@@ -921,6 +922,7 @@ pub async fn get_trades_by_address(
     )
 )]
 #[get("/taker/<address>?<params..>")]
+#[allow(clippy::too_many_arguments)] // Rocket route handlers naturally accumulate &State<...> params.
 pub async fn get_taker_trades(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,


### PR DESCRIPTION
## Motivation

Main is red and has been for the last several runs. Two latent issues:

1. \`cargo fmt --check\` fails on \`src/routes/orders/get_by_owner.rs:80\` and \`get_by_token.rs:98\` — long single-line \`super::quote_result_to_io_ratio\` calls were merged un-formatted.
2. Once fmt is fixed, \`clippy::too_many_arguments\` fires on \`get_trades_by_address\` (8/7) and \`get_taker_trades\` (9/7) in \`src/routes/trades.rs\`. CI currently never reaches this step because fmt fails first, but it surfaces immediately on any branch that fixes fmt.

This PR unblocks the whole stack — it sits at the bottom so #78 (and any other in-flight branches) inherit a green base instead of having to carry the bandage themselves.

## Solution

- Reformatted the two \`get_by_*\` files with \`cargo fmt --all\`.
- Added \`#[allow(clippy::too_many_arguments)]\` (with a one-line justification) to the two Rocket route handlers. Their arity is dictated by the \`&State<…>\` they need to read; this is structural and not refactorable without splitting the handler.

No behaviour change.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic (n/a — no logic change)
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a change to a front-end/dashboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code restructuring for improved readability and maintainability. Linting improvements applied to enhance code quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->