### PR TITLE
ci: move validation to Blacksmith

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,5 @@
 name: CI
+
 on:
   push:
     branches:
@@ -9,51 +10,136 @@ concurrency:
   group: ${{ github.ref }}-ci
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  rust-checks:
+  rust-validation:
+    name: rust ${{ matrix.name }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     strategy:
-      matrix:
-        os: [ubuntu-latest]
-        task: [rs-test, rainix-rs-static]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+      matrix:
+        include:
+          - name: check
+            cache_target: check
+            command: nix develop -c cargo check --workspace
+          - name: test 1 of 4
+            cache_target: test
+            command: nix develop -c cargo nextest run --workspace --partition hash:1/4
+          - name: test 2 of 4
+            cache_target: test
+            command: nix develop -c cargo nextest run --workspace --partition hash:2/4
+          - name: test 3 of 4
+            cache_target: test
+            command: nix develop -c cargo nextest run --workspace --partition hash:3/4
+          - name: test 4 of 4
+            cache_target: test
+            command: nix develop -c cargo nextest run --workspace --partition hash:4/4
+          - name: static
+            cache_target: static
+            command: nix develop -c rainix-rs-static
     env:
+      CARGO_INCREMENTAL: "0"
+      CARGO_TARGET_DIR: target/${{ matrix.cache_target }}
       COMMIT_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+      - name: Compute submodule cache key
+        id: sub-key
+        run: echo "hash=$(git submodule status | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      - name: Cache submodules
+        id: cache-sub
+        uses: actions/cache@v4
         with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
+          path: |
+            lib/
+            .git/modules/
+          key: submodules-${{ steps.sub-key.outputs.hash }}
+          restore-keys: submodules-
 
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+      - name: Checkout submodules
+        run: |
+          if [ "${{ steps.cache-sub.outputs.cache-hit }}" = "true" ]; then
+            echo "Cache hit - trying no-fetch checkout"
+            git submodule update --init --recursive --no-fetch || {
+              echo "no-fetch failed - falling back to full fetch"
+              git submodule update --init --recursive
+            }
+          else
+            echo "Cache miss - full submodule fetch"
+            git submodule update --init --recursive
+          fi
+
+      - uses: DeterminateSystems/nix-installer-action@main
         with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          gc-max-store-size-linux: 10G
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
 
-      - run: ./prep.sh
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: Run ${{ matrix.task }}
-        run: nix develop -c ${{ matrix.task }}
+      - name: Cache Solidity artifacts
+        id: cache-sol
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/**/cache/
+            lib/**/out/
+          key: sol-artifacts-${{ hashFiles('.gitmodules', 'flake.lock', 'lib/**/*.sol', 'lib/**/foundry.toml', 'lib/**/remappings.txt') }}
+          restore-keys: sol-artifacts-
 
-  docs:
+      - name: Build Solidity artifacts
+        if: steps.cache-sol.outputs.cache-hit != 'true'
+        run: nix run .#prepSolArtifacts
+
+      - name: Prepare orderbook dependencies
+        run: cd lib/rain.orderbook && ./prep-base.sh
+
+      - name: Cache cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/git/db/
+            ~/.cargo/registry/cache/
+            ~/.cargo/registry/index/
+            target/${{ matrix.cache_target }}/
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'flake.lock', 'flake.nix', 'rust.nix') }}
+          restore-keys: cargo-${{ runner.os }}-${{ runner.arch }}-${{ matrix.cache_target }}-
+
+      - name: ${{ matrix.name }}
+        run: ${{ matrix.command }}
+
+  rust-checks:
+    name: rust-checks
+    needs: rust-validation
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
+      - name: Check rust validation
+        run: |
+          if [ "${{ needs.rust-validation.result }}" != "success" ]; then
+            echo "rust validation failed"
+            exit 1
+          fi
 
-      - uses: nixbuild/nix-quick-install-action@v30
+  docs:
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Build docs
         run: nix build .#st0x-docs

--- a/flake.nix
+++ b/flake.nix
@@ -172,6 +172,7 @@
           '';
           buildInputs = with pkgs;
             [
+              cargo-nextest
               sqlx-cli
               terraform
               mdbook


### PR DESCRIPTION
## Motivation

The REST API CI was still running the Rust checks as two broad legs on `ubuntu-latest`, and each leg performed a full recursive checkout plus `./prep.sh`. That duplicated expensive setup work and left test execution unsplit, while `st0x.liquidity` already has a faster Blacksmith-based pattern for the same Nix/Rust/submodule shape.

## Solution

- Move Rust validation and docs builds onto `blacksmith-8vcpu-ubuntu-2404`.
- Split Rust validation into separate matrix legs for `cargo check`, four hash-partitioned `cargo nextest` test shards, and `rainix-rs-static`.
- Preserve `rust-checks` as a stable aggregate status check for branch protection while the detailed jobs fan out underneath it.
- Cache submodule checkouts, Solidity build artifacts, Cargo registry/git DB data, and per-purpose Cargo target directories.
- Build Solidity artifacts via `nix run .#prepSolArtifacts` only when the Solidity artifact cache misses instead of running the full local prep script in every CI leg.
- Add `cargo-nextest` to the Nix dev shell so the new CI command is available through `nix develop`.
- Keep docs as a separate job, but run it through the same Determinate Nix installer and Magic Nix Cache setup.

## Notes

I intentionally did not copy the `SQLX_OFFLINE=true`/conditional database setup from the liquidity follow-up because this repo does not use SQLx compile-time query macros. The current checks do not require a CI database setup step for `cargo check`, `nextest --no-run`, or `rainix-rs-static`.

## Checks

- [x] `nix develop -c cargo fmt`
- [x] `nix develop -c rainix-rs-static`
- [x] `nix develop -c cargo nextest run --workspace --no-run`
- [x] `git diff --check`

`rainix-rs-static` and `nextest --no-run` both emitted existing warnings from `lib/rain.orderbook`, but exited successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI for faster, more reliable validation with a dedicated multi-task validation job and improved caching.
  * CI now sequences checks so validation gates downstream workflows.
  * Development environment updated to include additional testing tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->