### PR TITLE
Materialize private registry RPCs

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -50,5 +50,13 @@ jobs:
 
       - run: ./prep.sh
 
-      - name: Build and deploy
-        run: nix run .#deployAll
+      - name: Build and deploy system
+        run: nix run .#deployNixos
+
+      - name: Upload private RPC URLs
+        env:
+          PRIVATE_RPC_URLS: ${{ secrets.PRIVATE_RPC_URLS }}
+        run: nix run .#deployRpcSecrets
+
+      - name: Build and deploy REST API service
+        run: nix run .#deployService -- rest-api

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8966,6 +8966,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "strict-yaml-rust",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rocket = { version = "0.5.1", features = ["json"] }
 rocket_cors = "0.6"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+strict-yaml-rust = "0.1.2"
 thiserror = "2"
 utoipa = { version = "5", features = ["rocket_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["rocket"] }

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -222,6 +222,25 @@ systemctl cat rest-api
 nix develop -c deploy-service rest-api
 ```
 
+### Private registry RPCs
+The deploy workflow can prepend private RPC URLs to the public registry settings.
+Set the GitHub Actions secret `PRIVATE_RPC_URLS` to a comma-separated list:
+
+```text
+https://paid-rpc-1.example/key,https://paid-rpc-2.example/key
+```
+
+During deploy, the workflow writes this to:
+
+```text
+/mnt/data/st0x-rest-api/private-rpcs.txt
+```
+
+The service reads that file from `registry_rpc_urls_path`, prepends the URLs to
+the public registry's network for the configured chain, and serves the generated
+registry/settings only on loopback. If the file is missing, empty, or invalid,
+the service logs the issue and falls back to the public registry.
+
 ### SSH into the server
 ```bash
 nix develop -c remote

--- a/config/dev.toml
+++ b/config/dev.toml
@@ -1,6 +1,7 @@
 log_dir = "./logs"
 database_url = "sqlite:./data/st0x.db"
 registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+registry_rpc_urls_path = "./data/private-rpcs.txt"
 rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "./docs/book"

--- a/config/rest-api.toml
+++ b/config/rest-api.toml
@@ -1,6 +1,7 @@
 log_dir = "/mnt/data/st0x-rest-api/logs"
 database_url = "sqlite:///mnt/data/st0x-rest-api/st0x.db"
 registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+registry_rpc_urls_path = "/mnt/data/st0x-rest-api/private-rpcs.txt"
 rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "/var/lib/st0x-docs"

--- a/deploy.nix
+++ b/deploy.nix
@@ -50,11 +50,16 @@ in {
     let
       deployInputs = infraPkgs.buildInputs
         ++ [ deploy-rs.packages.${localSystem}.deploy-rs ];
+      sshInputs = infraPkgs.buildInputs ++ [ pkgs.openssh pkgs.coreutils ];
 
-      deployPreamble = ''
+      hostPreamble = ''
         ${infraPkgs.resolveIp}
         export DEPLOY_HOST="$host_ip"
         export NIX_SSHOPTS="-i $identity"
+      '';
+
+      deployPreamble = ''
+        ${hostPreamble}
         ssh_flag="--ssh-opts=-i $identity"
       '';
 
@@ -93,6 +98,33 @@ in {
           ${deployPreamble}
           deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} .#st0x-rest-api \
             -- --impure "$@"
+        '';
+      };
+
+      deployRpcSecrets = pkgs.writeShellApplication {
+        name = "deploy-rpc-secrets";
+        runtimeInputs = sshInputs;
+        text = ''
+          ${hostPreamble}
+          remote="root@$DEPLOY_HOST"
+          remote_path="/mnt/data/st0x-rest-api/private-rpcs.txt"
+
+          if [ -z "''${PRIVATE_RPC_URLS:-}" ]; then
+            echo "PRIVATE_RPC_URLS is not set; deployment will use the public registry RPCs"
+            ssh -i "$identity" "$remote" "rm -f $remote_path"
+            exit 0
+          fi
+
+          tmp_file="$(mktemp)"
+          trap 'rm -f "$tmp_file"' EXIT
+          printf '%s' "$PRIVATE_RPC_URLS" > "$tmp_file"
+
+          ssh -i "$identity" "$remote" \
+            'install -d -m 0775 -o root -g st0x /mnt/data/st0x-rest-api'
+          ssh -i "$identity" "$remote" \
+            "umask 0177 && cat > $remote_path.tmp" < "$tmp_file"
+          ssh -i "$identity" "$remote" \
+            "chown root:st0x $remote_path.tmp && chmod 0640 $remote_path.tmp && mv $remote_path.tmp $remote_path"
         '';
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,7 @@
               packages.prepSolArtifacts
               packages.remote
               packages.deployNixos
+              packages.deployRpcSecrets
               packages.deployService
               packages.deployAll
             ] ++ rainix.devShells.${system}.default.buildInputs;

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ pub struct Config {
     pub log_dir: String,
     pub database_url: String,
     pub registry_url: String,
+    #[serde(default)]
+    pub registry_rpc_urls_path: Option<String>,
     pub rate_limit_global_rpm: u64,
     pub rate_limit_per_key_rpm: u64,
     pub docs_dir: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,9 +238,15 @@ async fn main() {
                 }
             }
 
+            let registry_rpc_urls_path = cfg
+                .registry_rpc_urls_path
+                .as_deref()
+                .map(std::path::Path::new);
+
             let raindex_config = match raindex::RaindexProvider::load(
                 &registry_url,
                 Some(local_db_path),
+                registry_rpc_urls_path,
             )
             .await
             {

--- a/src/raindex/config.rs
+++ b/src/raindex/config.rs
@@ -1,22 +1,73 @@
 use crate::error::ApiError;
+use crate::raindex::materialized_registry::{MaterializedRegistry, MaterializedRegistryStats};
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_js_api::registry::DotrainRegistry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub(crate) struct RaindexProvider {
-    registry: DotrainRegistry,
     client: RaindexClient,
     db_path: Option<PathBuf>,
+    public_registry_url: String,
+    rpc_urls_path: Option<PathBuf>,
+    materialized_registry: Option<MaterializedRegistry>,
 }
 
 impl RaindexProvider {
     pub(crate) async fn load(
         registry_url: &str,
         db_path: Option<PathBuf>,
+        rpc_urls_path: Option<&Path>,
     ) -> Result<Self, RaindexProviderError> {
-        let url = registry_url.to_string();
+        let rpc_urls_path = rpc_urls_path.map(Path::to_path_buf);
+        let materialized_registry = match rpc_urls_path.as_deref() {
+            Some(path) => match MaterializedRegistry::start(registry_url, path).await {
+                Ok(materialized_registry) => materialized_registry,
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        path = %path.display(),
+                        "failed to materialize private registry; using public registry"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
+        if let Some(materialized_registry) = materialized_registry {
+            match Self::load_from_source(
+                RegistrySource::materialized(registry_url, materialized_registry),
+                db_path.clone(),
+                rpc_urls_path.clone(),
+            )
+            .await
+            {
+                Ok(provider) => return Ok(provider),
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "failed to load materialized registry; using public registry"
+                    );
+                }
+            }
+        }
+
+        Self::load_from_source(RegistrySource::public(registry_url), db_path, rpc_urls_path).await
+    }
+
+    async fn load_from_source(
+        source: RegistrySource,
+        db_path: Option<PathBuf>,
+        rpc_urls_path: Option<PathBuf>,
+    ) -> Result<Self, RaindexProviderError> {
         let db = db_path.clone();
+        let source_kind = source.kind();
+        let RegistrySource {
+            load_url,
+            public_registry_url,
+            materialized_registry,
+        } = source;
 
         let (tx, rx) = tokio::sync::oneshot::channel();
 
@@ -33,7 +84,7 @@ impl RaindexProvider {
             };
 
             let result = runtime.block_on(async {
-                let registry = DotrainRegistry::new(url)
+                let registry = DotrainRegistry::new(load_url)
                     .await
                     .map_err(|e| RaindexProviderError::RegistryLoad(e.to_string()))?;
 
@@ -43,16 +94,34 @@ impl RaindexProvider {
                     .map_err(|e| RaindexProviderError::ClientInit(e.to_string()))?;
 
                 Ok(RaindexProvider {
-                    registry,
                     client,
                     db_path: db,
+                    public_registry_url,
+                    rpc_urls_path,
+                    materialized_registry,
                 })
             });
 
             let _ = tx.send(result);
         });
 
-        rx.await.map_err(|_| RaindexProviderError::WorkerPanicked)?
+        let provider = rx
+            .await
+            .map_err(|_| RaindexProviderError::WorkerPanicked)??;
+        let maybe_stats = provider.private_registry_stats();
+        let stats = maybe_stats.unwrap_or_default();
+
+        tracing::info!(
+            registry_source = source_kind,
+            private_registry_active = maybe_stats.is_some(),
+            private_rpc_count = stats.private_rpc_count,
+            public_rpc_count = stats.public_rpc_count,
+            merged_rpc_count = stats.merged_rpc_count,
+            duplicate_rpc_count = stats.duplicate_rpc_count,
+            "raindex provider loaded"
+        );
+
+        Ok(provider)
     }
 
     pub(crate) fn client(&self) -> &RaindexClient {
@@ -60,11 +129,57 @@ impl RaindexProvider {
     }
 
     pub(crate) fn registry_url(&self) -> String {
-        self.registry.registry_url()
+        self.public_registry_url.clone()
     }
 
     pub(crate) fn db_path(&self) -> Option<PathBuf> {
         self.db_path.clone()
+    }
+
+    pub(crate) fn rpc_urls_path(&self) -> Option<PathBuf> {
+        self.rpc_urls_path.clone()
+    }
+
+    pub(crate) fn private_registry_stats(&self) -> Option<MaterializedRegistryStats> {
+        self.materialized_registry
+            .as_ref()
+            .map(MaterializedRegistry::stats)
+    }
+}
+
+#[derive(Debug)]
+struct RegistrySource {
+    load_url: String,
+    public_registry_url: String,
+    materialized_registry: Option<MaterializedRegistry>,
+}
+
+impl RegistrySource {
+    fn kind(&self) -> &'static str {
+        if self.materialized_registry.is_some() {
+            "materialized"
+        } else {
+            "public"
+        }
+    }
+
+    fn public(registry_url: &str) -> Self {
+        Self {
+            load_url: registry_url.to_string(),
+            public_registry_url: registry_url.to_string(),
+            materialized_registry: None,
+        }
+    }
+
+    fn materialized(
+        public_registry_url: &str,
+        materialized_registry: MaterializedRegistry,
+    ) -> Self {
+        Self {
+            load_url: materialized_registry.registry_url().to_string(),
+            public_registry_url: public_registry_url.to_string(),
+            materialized_registry: Some(materialized_registry),
+        }
     }
 }
 
@@ -101,7 +216,7 @@ mod tests {
 
     #[rocket::async_test]
     async fn test_load_fails_with_unreachable_url() {
-        let result = RaindexProvider::load("http://127.0.0.1:1/registry.txt", None).await;
+        let result = RaindexProvider::load("http://127.0.0.1:1/registry.txt", None, None).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -126,7 +241,8 @@ mod tests {
             let _ = tokio::io::AsyncWriteExt::write_all(&mut socket, response.as_bytes()).await;
         });
 
-        let result = RaindexProvider::load(&format!("http://{addr}/registry.txt"), None).await;
+        let result =
+            RaindexProvider::load(&format!("http://{addr}/registry.txt"), None, None).await;
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -138,6 +254,65 @@ mod tests {
     async fn test_load_succeeds_with_valid_registry() {
         let config = crate::test_helpers::mock_raindex_config().await;
         assert!(!config.registry_url().is_empty());
+    }
+
+    #[rocket::async_test]
+    async fn test_load_keeps_public_registry_url() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rpc_urls_path = dir.path().join("private-rpcs.txt");
+        tokio::fs::write(&rpc_urls_path, "https://private.example/rpc")
+            .await
+            .expect("write private rpcs");
+        let registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let config = RaindexProvider::load(&registry_url, None, Some(&rpc_urls_path))
+            .await
+            .expect("load private materialized registry");
+
+        assert_eq!(config.registry_url(), registry_url);
+        let materialized_registry = config
+            .materialized_registry
+            .as_ref()
+            .expect("materialized registry retained");
+        assert!(materialized_registry
+            .registry_url()
+            .starts_with("http://127.0.0.1:"));
+        assert_ne!(materialized_registry.registry_url(), registry_url);
+        assert_eq!(
+            config.rpc_urls_path().as_deref(),
+            Some(rpc_urls_path.as_path())
+        );
+        assert_eq!(
+            config.private_registry_stats(),
+            Some(MaterializedRegistryStats {
+                private_rpc_count: 1,
+                public_rpc_count: 1,
+                merged_rpc_count: 2,
+                duplicate_rpc_count: 0,
+            })
+        );
+    }
+
+    #[rocket::async_test]
+    async fn test_load_with_invalid_private_rpcs_falls_back_to_public_registry() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rpc_urls_path = dir.path().join("private-rpcs.txt");
+        tokio::fs::write(&rpc_urls_path, "not a url")
+            .await
+            .expect("write invalid private rpcs");
+        let registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let config = RaindexProvider::load(&registry_url, None, Some(&rpc_urls_path))
+            .await
+            .expect("fallback public registry loads");
+
+        assert_eq!(config.registry_url(), registry_url);
+        assert!(config.materialized_registry.is_none());
+        assert_eq!(
+            config.rpc_urls_path().as_deref(),
+            Some(rpc_urls_path.as_path())
+        );
+        assert_eq!(config.private_registry_stats(), None);
     }
 
     #[test]

--- a/src/raindex/materialized_registry.rs
+++ b/src/raindex/materialized_registry.rs
@@ -1,0 +1,623 @@
+use rain_orderbook_app_settings::yaml::{load_yaml, YamlError};
+use rain_orderbook_js_api::registry::DotrainRegistry;
+use std::collections::HashSet;
+use std::io;
+use std::path::{Path, PathBuf};
+use strict_yaml_rust::strict_yaml::Hash;
+use strict_yaml_rust::{StrictYaml, StrictYamlEmitter};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+const REGISTRY_PATH: &str = "/registry";
+const SETTINGS_PATH: &str = "/settings.yaml";
+const NETWORKS_KEY: &str = "networks";
+const CHAIN_ID_KEY: &str = "chain-id";
+const RPCS_KEY: &str = "rpcs";
+
+#[derive(Debug)]
+pub(crate) struct MaterializedRegistry {
+    registry_url: String,
+    stats: MaterializedRegistryStats,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl MaterializedRegistry {
+    pub(crate) async fn start(
+        public_registry_url: &str,
+        rpc_urls_path: &Path,
+    ) -> Result<Option<Self>, MaterializedRegistryError> {
+        let rpc_urls = match read_private_rpc_urls(rpc_urls_path).await {
+            Ok(urls) if urls.is_empty() => {
+                tracing::warn!(
+                    path = %rpc_urls_path.display(),
+                    "private registry RPC URL file is empty; using public registry"
+                );
+                return Ok(None);
+            }
+            Ok(urls) => urls,
+            Err(MaterializedRegistryError::RpcUrlsFileMissing(path)) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    "private registry RPC URL file is missing; using public registry"
+                );
+                return Ok(None);
+            }
+            Err(e) => return Err(e),
+        };
+
+        let snapshot = load_public_registry_snapshot(public_registry_url).await?;
+        let materialized_settings = materialize_settings(&snapshot.settings, &rpc_urls)?;
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .map_err(MaterializedRegistryError::Bind)?;
+        let addr = listener
+            .local_addr()
+            .map_err(MaterializedRegistryError::LocalAddr)?;
+        let settings_url = format!("http://{addr}{SETTINGS_PATH}");
+        let registry_url = format!("http://{addr}{REGISTRY_PATH}");
+        let registry = rewrite_registry_settings_url(&snapshot.registry, &settings_url)?;
+        let stats = materialized_settings.stats;
+
+        let handle = tokio::spawn(async move {
+            serve(listener, registry, materialized_settings.yaml).await;
+        });
+
+        tracing::info!(
+            path = %rpc_urls_path.display(),
+            chain_id = crate::CHAIN_ID,
+            private_rpc_count = stats.private_rpc_count,
+            public_rpc_count = stats.public_rpc_count,
+            merged_rpc_count = stats.merged_rpc_count,
+            duplicate_rpc_count = stats.duplicate_rpc_count,
+            "serving materialized registry on loopback"
+        );
+
+        Ok(Some(Self {
+            registry_url,
+            stats,
+            handle,
+        }))
+    }
+
+    pub(crate) fn registry_url(&self) -> &str {
+        &self.registry_url
+    }
+
+    pub(crate) fn stats(&self) -> MaterializedRegistryStats {
+        self.stats
+    }
+}
+
+impl Drop for MaterializedRegistry {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MaterializedRegistryStats {
+    pub(crate) private_rpc_count: usize,
+    pub(crate) public_rpc_count: usize,
+    pub(crate) merged_rpc_count: usize,
+    pub(crate) duplicate_rpc_count: usize,
+}
+
+#[derive(Debug)]
+struct MaterializedSettings {
+    yaml: String,
+    stats: MaterializedRegistryStats,
+}
+
+#[derive(Debug)]
+struct PublicRegistrySnapshot {
+    registry: String,
+    settings: String,
+}
+
+async fn load_public_registry_snapshot(
+    registry_url: &str,
+) -> Result<PublicRegistrySnapshot, MaterializedRegistryError> {
+    let url = registry_url.to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+
+    std::thread::spawn(move || {
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                let _ = tx.send(Err(MaterializedRegistryError::RegistryLoad(e.to_string())));
+                return;
+            }
+        };
+
+        let result = runtime.block_on(async {
+            let registry = DotrainRegistry::new(url)
+                .await
+                .map_err(|e| MaterializedRegistryError::RegistryLoad(e.to_string()))?;
+            Ok(PublicRegistrySnapshot {
+                registry: registry.registry(),
+                settings: registry.settings(),
+            })
+        });
+
+        let _ = tx.send(result);
+    });
+
+    rx.await
+        .map_err(|_| MaterializedRegistryError::WorkerPanicked)?
+}
+
+async fn read_private_rpc_urls(path: &Path) -> Result<Vec<String>, MaterializedRegistryError> {
+    let contents = match tokio::fs::read_to_string(path).await {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            return Err(MaterializedRegistryError::RpcUrlsFileMissing(
+                path.to_path_buf(),
+            ));
+        }
+        Err(e) => return Err(MaterializedRegistryError::ReadRpcUrls(e)),
+    };
+
+    parse_private_rpc_urls(&contents)
+}
+
+fn parse_private_rpc_urls(contents: &str) -> Result<Vec<String>, MaterializedRegistryError> {
+    let mut urls = Vec::new();
+
+    for (index, raw_url) in contents.split(',').enumerate() {
+        let url = raw_url.trim();
+        if url.is_empty() {
+            continue;
+        }
+
+        reqwest::Url::parse(url)
+            .map_err(|_| MaterializedRegistryError::InvalidRpcUrl { index: index + 1 })?;
+        urls.push(url.to_string());
+    }
+
+    Ok(urls)
+}
+
+fn materialize_settings(
+    settings: &str,
+    private_rpcs: &[String],
+) -> Result<MaterializedSettings, MaterializedRegistryError> {
+    let mut settings = load_yaml(settings).map_err(MaterializedRegistryError::ParseSettings)?;
+    let network = network_for_chain_id_mut(&mut settings, crate::CHAIN_ID)?;
+    let network = strict_hash_mut(network)
+        .ok_or_else(|| invalid_settings("matched network must be a mapping"))?;
+
+    let rpcs_key = yaml_key(RPCS_KEY);
+    let existing_rpcs = match network.get(&rpcs_key) {
+        Some(StrictYaml::Array(values)) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_string))
+            .collect::<Vec<_>>(),
+        Some(_) => {
+            return Err(invalid_settings("matched network rpcs must be a list"));
+        }
+        None => Vec::new(),
+    };
+
+    let mut seen = HashSet::new();
+    let mut merged = Vec::new();
+    for rpc in private_rpcs.iter().chain(existing_rpcs.iter()) {
+        if seen.insert(rpc.clone()) {
+            merged.push(StrictYaml::String(rpc.clone()));
+        }
+    }
+
+    let stats = MaterializedRegistryStats {
+        private_rpc_count: private_rpcs.len(),
+        public_rpc_count: existing_rpcs.len(),
+        merged_rpc_count: merged.len(),
+        duplicate_rpc_count: private_rpcs.len() + existing_rpcs.len() - merged.len(),
+    };
+
+    network.insert(rpcs_key, StrictYaml::Array(merged));
+    let yaml = emit_yaml(&settings).map_err(MaterializedRegistryError::SerializeSettings)?;
+
+    Ok(MaterializedSettings { yaml, stats })
+}
+
+fn network_for_chain_id_mut(
+    settings: &mut StrictYaml,
+    chain_id: u32,
+) -> Result<&mut StrictYaml, MaterializedRegistryError> {
+    let root = strict_hash_mut(settings)
+        .ok_or_else(|| invalid_settings("settings root must be a mapping"))?;
+    let networks = strict_hash_mut(mapping_get_mut(root, NETWORKS_KEY)?)
+        .ok_or_else(|| invalid_settings("networks must be a mapping"))?;
+
+    for (_, network) in networks.iter_mut() {
+        let Some(mapping) = network.as_hash() else {
+            continue;
+        };
+        let Some(value) = mapping_get(mapping, CHAIN_ID_KEY) else {
+            continue;
+        };
+        if yaml_chain_id(value) == Some(chain_id) {
+            return Ok(network);
+        }
+    }
+
+    Err(MaterializedRegistryError::ChainIdNotFound(chain_id))
+}
+
+fn mapping_get_mut<'a>(
+    mapping: &'a mut Hash,
+    key: &str,
+) -> Result<&'a mut StrictYaml, MaterializedRegistryError> {
+    mapping
+        .get_mut(&yaml_key(key))
+        .ok_or_else(|| invalid_settings(&format!("missing {key}")))
+}
+
+fn mapping_get<'a>(mapping: &'a Hash, key: &str) -> Option<&'a StrictYaml> {
+    mapping.get(&yaml_key(key))
+}
+
+fn yaml_key(key: &str) -> StrictYaml {
+    StrictYaml::String(key.to_string())
+}
+
+fn strict_hash_mut(value: &mut StrictYaml) -> Option<&mut Hash> {
+    match value {
+        StrictYaml::Hash(hash) => Some(hash),
+        _ => None,
+    }
+}
+
+fn yaml_chain_id(value: &StrictYaml) -> Option<u32> {
+    value.as_str()?.parse().ok()
+}
+
+fn emit_yaml(document: &StrictYaml) -> Result<String, YamlError> {
+    let mut out = String::new();
+    let mut emitter = StrictYamlEmitter::new(&mut out);
+    emitter.dump(document)?;
+
+    if out.starts_with("---") {
+        Ok(out.trim_start_matches("---").trim_start().to_string())
+    } else {
+        Ok(out)
+    }
+}
+
+fn invalid_settings(message: &str) -> MaterializedRegistryError {
+    MaterializedRegistryError::InvalidSettings(message.to_string())
+}
+
+fn rewrite_registry_settings_url(
+    registry: &str,
+    settings_url: &str,
+) -> Result<String, MaterializedRegistryError> {
+    let mut lines = registry
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    lines
+        .next()
+        .ok_or(MaterializedRegistryError::EmptyRegistry)?;
+
+    let mut rewritten = settings_url.to_string();
+    for line in lines {
+        rewritten.push('\n');
+        rewritten.push_str(line);
+    }
+    rewritten.push('\n');
+
+    Ok(rewritten)
+}
+
+async fn serve(listener: TcpListener, registry: String, settings: String) {
+    loop {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            break;
+        };
+        let registry = registry.clone();
+        let settings = settings.clone();
+
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            let n = socket.read(&mut buf).await.unwrap_or(0);
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let path = request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1));
+
+            let (status, content_type, body) = match path {
+                Some(REGISTRY_PATH) => ("200 OK", "text/plain; charset=utf-8", registry),
+                Some(SETTINGS_PATH) => ("200 OK", "application/yaml; charset=utf-8", settings),
+                _ => (
+                    "404 Not Found",
+                    "text/plain; charset=utf-8",
+                    "not found".to_string(),
+                ),
+            };
+
+            let response = format!(
+                "HTTP/1.1 {status}\r\nConnection: close\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            let _ = socket.write_all(response.as_bytes()).await;
+        });
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MaterializedRegistryError {
+    #[error("private RPC URL file is missing: {0}")]
+    RpcUrlsFileMissing(PathBuf),
+    #[error("failed to read private RPC URL file: {0}")]
+    ReadRpcUrls(io::Error),
+    #[error("invalid private RPC URL at comma-separated position {index}")]
+    InvalidRpcUrl { index: usize },
+    #[error("failed to load public registry: {0}")]
+    RegistryLoad(String),
+    #[error("registry worker thread panicked")]
+    WorkerPanicked,
+    #[error("failed to parse settings YAML: {0}")]
+    ParseSettings(YamlError),
+    #[error("invalid settings YAML: {0}")]
+    InvalidSettings(String),
+    #[error("settings YAML does not define chain id {0}")]
+    ChainIdNotFound(u32),
+    #[error("failed to serialize settings YAML: {0}")]
+    SerializeSettings(YamlError),
+    #[error("registry file is empty")]
+    EmptyRegistry,
+    #[error("failed to bind private registry listener: {0}")]
+    Bind(io::Error),
+    #[error("failed to read private registry listener address: {0}")]
+    LocalAddr(io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SETTINGS: &str = r#"version: 5
+networks:
+  base:
+    rpcs:
+      - https://mainnet.base.org
+      - https://public.example/rpc
+    chain-id: 8453
+    currency: ETH
+"#;
+
+    #[test]
+    fn parse_private_rpc_urls_trims_and_skips_empty_entries() {
+        let urls = parse_private_rpc_urls(
+            " https://private-a.example/rpc ,, https://private-b.example/rpc ",
+        )
+        .expect("valid urls");
+
+        assert_eq!(
+            urls,
+            vec![
+                "https://private-a.example/rpc".to_string(),
+                "https://private-b.example/rpc".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_private_rpc_urls_rejects_invalid_urls() {
+        let err = parse_private_rpc_urls("https://private.example/rpc,not a url")
+            .expect_err("invalid url");
+
+        assert!(matches!(
+            err,
+            MaterializedRegistryError::InvalidRpcUrl { index: 2 }
+        ));
+    }
+
+    #[test]
+    fn prepend_private_rpcs_errors_when_chain_id_is_missing() {
+        let settings = r#"version: 5
+networks:
+  arbitrum:
+    rpcs:
+      - https://arb.example/rpc
+    chain-id: 42161
+    currency: ETH
+"#;
+
+        let err = materialize_settings(settings, &["https://private.example/rpc".to_string()])
+            .expect_err("missing configured chain id");
+
+        assert!(matches!(
+            err,
+            MaterializedRegistryError::ChainIdNotFound(crate::CHAIN_ID)
+        ));
+    }
+
+    #[test]
+    fn prepend_private_rpcs_errors_when_rpcs_is_not_a_list() {
+        let settings = r#"version: 5
+networks:
+  base:
+    rpcs: https://mainnet.base.org
+    chain-id: 8453
+    currency: ETH
+"#;
+
+        let err = materialize_settings(settings, &["https://private.example/rpc".to_string()])
+            .expect_err("invalid rpcs shape");
+
+        assert!(matches!(
+            err,
+            MaterializedRegistryError::InvalidSettings(message) if message == "matched network rpcs must be a list"
+        ));
+    }
+
+    #[test]
+    fn prepend_private_rpcs_preserves_private_first_and_dedupes() {
+        let materialized = materialize_settings(
+            SETTINGS,
+            &[
+                "https://private-a.example/rpc".to_string(),
+                "https://private-b.example/rpc".to_string(),
+                "https://mainnet.base.org".to_string(),
+            ],
+        )
+        .expect("merge settings");
+
+        assert_eq!(
+            materialized.stats,
+            MaterializedRegistryStats {
+                private_rpc_count: 3,
+                public_rpc_count: 2,
+                merged_rpc_count: 4,
+                duplicate_rpc_count: 1,
+            }
+        );
+
+        let parsed = load_yaml(&materialized.yaml).expect("parse merged settings");
+        let rpcs = parsed["networks"]["base"]["rpcs"]
+            .as_vec()
+            .expect("rpcs list")
+            .iter()
+            .map(|value| value.as_str().expect("rpc string"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rpcs,
+            vec![
+                "https://private-a.example/rpc",
+                "https://private-b.example/rpc",
+                "https://mainnet.base.org",
+                "https://public.example/rpc"
+            ]
+        );
+    }
+
+    #[test]
+    fn rewrite_registry_settings_url_replaces_first_non_empty_line() {
+        let registry = rewrite_registry_settings_url(
+            "\nhttps://public.example/settings.yaml\norder https://example.com/order.rain\n",
+            &format!("http://127.0.0.1:1{SETTINGS_PATH}"),
+        )
+        .expect("rewrite registry");
+
+        assert_eq!(
+            registry,
+            format!("http://127.0.0.1:1{SETTINGS_PATH}\norder https://example.com/order.rain\n")
+        );
+    }
+
+    #[rocket::async_test]
+    async fn start_returns_none_when_private_rpc_file_is_missing() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let missing_path = dir.path().join("missing-private-rpcs.txt");
+        let public_registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let materialized = MaterializedRegistry::start(&public_registry_url, &missing_path)
+            .await
+            .expect("missing private RPC file should fall back");
+
+        assert!(materialized.is_none());
+    }
+
+    #[rocket::async_test]
+    async fn start_returns_none_when_private_rpc_file_is_empty() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rpc_urls_path = dir.path().join("private-rpcs.txt");
+        tokio::fs::write(&rpc_urls_path, " , ")
+            .await
+            .expect("write empty private rpcs");
+        let public_registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let materialized = MaterializedRegistry::start(&public_registry_url, &rpc_urls_path)
+            .await
+            .expect("empty private RPC file should fall back");
+
+        assert!(materialized.is_none());
+    }
+
+    #[rocket::async_test]
+    async fn start_errors_when_private_rpc_file_has_invalid_url() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rpc_urls_path = dir.path().join("private-rpcs.txt");
+        tokio::fs::write(&rpc_urls_path, "not a url")
+            .await
+            .expect("write invalid private rpcs");
+        let public_registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let err = MaterializedRegistry::start(&public_registry_url, &rpc_urls_path)
+            .await
+            .expect_err("invalid private RPC file should error");
+
+        assert!(matches!(
+            err,
+            MaterializedRegistryError::InvalidRpcUrl { index: 1 }
+        ));
+    }
+
+    #[rocket::async_test]
+    async fn start_serves_materialized_registry_on_loopback() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let rpc_urls_path = dir.path().join("private-rpcs.txt");
+        tokio::fs::write(
+            &rpc_urls_path,
+            "https://private-a.example/rpc,https://private-b.example/rpc",
+        )
+        .await
+        .expect("write private rpcs");
+        let public_registry_url = crate::test_helpers::mock_raindex_registry_url().await;
+
+        let materialized = MaterializedRegistry::start(&public_registry_url, &rpc_urls_path)
+            .await
+            .expect("start materialized registry")
+            .expect("materialized registry");
+
+        assert!(materialized.registry_url().starts_with("http://127.0.0.1:"));
+        assert_eq!(
+            materialized.stats(),
+            MaterializedRegistryStats {
+                private_rpc_count: 2,
+                public_rpc_count: 1,
+                merged_rpc_count: 3,
+                duplicate_rpc_count: 0,
+            }
+        );
+
+        let registry = reqwest::get(materialized.registry_url())
+            .await
+            .expect("fetch materialized registry")
+            .text()
+            .await
+            .expect("registry body");
+        let settings_url = registry.lines().next().expect("settings url");
+        assert!(settings_url.starts_with("http://127.0.0.1:"));
+        assert_ne!(settings_url, public_registry_url);
+
+        let settings = reqwest::get(settings_url)
+            .await
+            .expect("fetch materialized settings")
+            .text()
+            .await
+            .expect("settings body");
+        let parsed = load_yaml(&settings).expect("parse settings");
+        let rpcs = parsed["networks"]["base"]["rpcs"]
+            .as_vec()
+            .expect("rpcs list")
+            .iter()
+            .map(|value| value.as_str().expect("rpc string"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            rpcs,
+            vec![
+                "https://private-a.example/rpc",
+                "https://private-b.example/rpc",
+                "https://mainnet.base.org"
+            ]
+        );
+    }
+}

--- a/src/raindex/mod.rs
+++ b/src/raindex/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config;
+pub(crate) mod materialized_registry;
 
 pub(crate) use config::RaindexProvider;
 pub(crate) type SharedRaindexProvider = tokio::sync::RwLock<RaindexProvider>;

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -52,9 +52,9 @@ pub async fn put_registry(
             ));
         }
 
-        let (previous_url, db_path) = {
+        let (previous_url, db_path, rpc_urls_path) = {
             let guard = shared_raindex.read().await;
-            (guard.registry_url(), guard.db_path())
+            (guard.registry_url(), guard.db_path(), guard.rpc_urls_path())
         };
 
         if previous_url == req.registry_url {
@@ -68,12 +68,13 @@ pub async fn put_registry(
             }));
         }
 
-        let new_provider = RaindexProvider::load(&req.registry_url, db_path)
-            .await
-            .map_err(|e| {
-                tracing::warn!(error = %e, "failed to load new registry");
-                ApiError::BadRequest(format!("failed to load registry: {e}"))
-            })?;
+        let new_provider =
+            RaindexProvider::load(&req.registry_url, db_path, rpc_urls_path.as_deref())
+                .await
+                .map_err(|e| {
+                    tracing::warn!(error = %e, "failed to load new registry");
+                    ApiError::BadRequest(format!("failed to load registry: {e}"))
+                })?;
 
         let mut guard = shared_raindex.write().await;
         let previous_url = guard.registry_url();

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -157,7 +157,7 @@ tokens:
 "#;
         let registry_url =
             crate::test_helpers::mock_raindex_registry_url_with_settings(settings).await;
-        let config = crate::raindex::RaindexProvider::load(&registry_url, None)
+        let config = crate::raindex::RaindexProvider::load(&registry_url, None, None)
             .await
             .expect("load raindex config");
         let client = TestClientBuilder::new()
@@ -227,7 +227,7 @@ using-tokens-from:
 }"#;
         let registry_url =
             mock_raindex_registry_url_with_settings_and_tokens(settings, remote_tokens).await;
-        let config = crate::raindex::RaindexProvider::load(&registry_url, None)
+        let config = crate::raindex::RaindexProvider::load(&registry_url, None, None)
             .await
             .expect("load raindex config");
         let client = TestClientBuilder::new()

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -49,7 +49,7 @@ impl TestClientBuilder {
                     Some(url) => url,
                     None => mock_raindex_registry_url().await,
                 };
-                crate::raindex::RaindexProvider::load(&registry_url, None)
+                crate::raindex::RaindexProvider::load(&registry_url, None, None)
                     .await
                     .expect("mock raindex config from registry url")
             }
@@ -66,7 +66,7 @@ impl TestClientBuilder {
 
 pub(crate) async fn mock_raindex_config() -> crate::raindex::RaindexProvider {
     let registry_url = mock_raindex_registry_url().await;
-    crate::raindex::RaindexProvider::load(&registry_url, None)
+    crate::raindex::RaindexProvider::load(&registry_url, None, None)
         .await
         .expect("mock raindex config")
 }


### PR DESCRIPTION
## Motivation
The server currently loads the public registry directly. That means paid RPC URLs with API keys cannot be added to registry settings, because the public registry cannot contain those secrets.

## Solution
- Add PRIVATE_RPC_URLS as a GitHub Actions secret input during deploy.
- The deploy writes the comma-separated RPC URLs to /mnt/data/st0x-rest-api/private-rpcs.txt on the server.
- At startup and when the admin registry endpoint changes the registry, the API pulls the public registry through DotrainRegistry, reads its settings YAML, prepends the private RPC URLs for the configured chain, and serves the rebuilt registry/settings from a loopback-only listener.
- Raindex loads from that internal materialized registry, while public API responses and registry history keep using the public registry URL.
- If the private RPC file is missing, empty, or invalid, the server logs non-secret status and falls back to the public registry.
- Add non-secret observability for private/public/merged/duplicate RPC counts.

## Checks
- nix develop -c cargo fmt
- nix develop -c cargo test
- nix develop -c rainix-rs-static

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for private RPC URLs that are automatically merged into the registry and served on localhost for secure, private access.
  * Automatic fallback to public registry if private URLs are unavailable or invalid.

* **Documentation**
  * Added deployment guide for configuring private RPC URLs via GitHub Actions secrets.

* **Chores**
  * Enhanced deployment workflow with granular steps for improved modularity.
  * Updated configuration paths and dependencies to support private RPC handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->