### PR TITLE
feat(trades): add batch order-hash query endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,7 @@ enum StartupError {
         routes::orders::get_orders_by_token,
         routes::admin::put_registry,
         routes::trades::get_by_tx::get_trades_by_tx,
+        routes::trades::get_by_order_hashes::get_trades_by_order_hashes,
         routes::trades::get_by_token::get_trades_by_token,
         routes::trades::get_by_taker::get_trades_by_taker,
         routes::trades::get_by_address::get_trades_by_address,

--- a/src/routes/trades/get_by_address.rs
+++ b/src/routes/trades/get_by_address.rs
@@ -127,6 +127,17 @@ mod tests {
         ) -> Result<RaindexTradesListResult, ApiError> {
             unimplemented!()
         }
+
+        async fn get_trades_by_order_hashes(
+            &self,
+            _order_hashes: Vec<B256>,
+            _time_filter: TimeFilter,
+        ) -> Result<
+            rain_orderbook_common::raindex_client::trades::RaindexTradesByOrderHashResult,
+            ApiError,
+        > {
+            unimplemented!()
+        }
     }
 
     #[rocket::async_test]

--- a/src/routes/trades/get_by_order_hashes.rs
+++ b/src/routes/trades/get_by_order_hashes.rs
@@ -1,0 +1,341 @@
+use super::{map_trade_for_list, RaindexTradesDataSource, TradesDataSource};
+use crate::auth::AuthenticatedKey;
+use crate::error::{ApiError, ApiErrorResponse};
+use crate::fairings::{GlobalRateLimit, TracingSpan};
+use crate::types::trades::{
+    TradesByOrderHashEntry, TradesByOrderHashesRequest, TradesByOrderHashesResponse,
+};
+use alloy::primitives::B256;
+use rain_orderbook_common::raindex_client::trades::RaindexTradesByOrderHashResult;
+use rain_orderbook_common::raindex_client::types::TimeFilter;
+use rocket::serde::json::Json;
+use rocket::State;
+use std::str::FromStr;
+use tracing::Instrument;
+
+#[utoipa::path(
+    post,
+    path = "/v1/trades/query",
+    tag = "Trades",
+    security(("basicAuth" = [])),
+    request_body = TradesByOrderHashesRequest,
+    responses(
+        (status = 200, description = "Trades grouped by requested order hash", body = TradesByOrderHashesResponse),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[post("/query", data = "<request>")]
+pub async fn get_trades_by_order_hashes(
+    _global: GlobalRateLimit,
+    _key: AuthenticatedKey,
+    shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    span: TracingSpan,
+    request: Json<TradesByOrderHashesRequest>,
+) -> Result<Json<TradesByOrderHashesResponse>, ApiError> {
+    async move {
+        let request = request.into_inner();
+        tracing::info!(
+            order_hashes_count = request.order_hashes.len(),
+            start_time = request.start_time,
+            end_time = request.end_time,
+            "request received"
+        );
+        let client = {
+            let raindex = shared_raindex.read().await;
+            raindex.client().clone()
+        };
+        let ds = RaindexTradesDataSource { client: &client };
+        process_get_trades_by_order_hashes(&ds, request).await
+    }
+    .instrument(span.0)
+    .await
+}
+
+pub(super) async fn process_get_trades_by_order_hashes(
+    ds: &dyn TradesDataSource,
+    request: TradesByOrderHashesRequest,
+) -> Result<Json<TradesByOrderHashesResponse>, ApiError> {
+    let order_hashes = parse_order_hashes(&request.order_hashes)?;
+    let time_filter = TimeFilter {
+        start: request.start_time,
+        end: request.end_time,
+    };
+
+    tracing::info!(
+        order_hashes_count = order_hashes.len(),
+        "querying trades by order hashes"
+    );
+    let result = ds
+        .get_trades_by_order_hashes(order_hashes, time_filter)
+        .await?;
+
+    build_trades_by_order_hashes_response(result)
+}
+
+fn parse_order_hashes(order_hashes: &[String]) -> Result<Vec<B256>, ApiError> {
+    order_hashes
+        .iter()
+        .map(|hash| {
+            B256::from_str(hash).map_err(|e| {
+                tracing::warn!(input = %hash, error = %e, "invalid order hash");
+                ApiError::BadRequest("invalid order hash".into())
+            })
+        })
+        .collect()
+}
+
+fn build_trades_by_order_hashes_response(
+    result: RaindexTradesByOrderHashResult,
+) -> Result<Json<TradesByOrderHashesResponse>, ApiError> {
+    let trades_by_order_hash = result
+        .trades_by_order_hash()
+        .iter()
+        .map(|entry| {
+            let trades = entry
+                .trades()
+                .iter()
+                .map(map_trade_for_list)
+                .collect::<Result<Vec<_>, ApiError>>()?;
+            Ok(TradesByOrderHashEntry {
+                order_hash: entry.order_hash(),
+                trades,
+            })
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+
+    Ok(Json(TradesByOrderHashesResponse {
+        trades_by_order_hash,
+        total_count: result.total_count(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::routes::order::test_fixtures::trade_json;
+    use crate::test_helpers::{basic_auth_header, seed_api_key, TestClientBuilder};
+    use alloy::primitives::{b256, Address};
+    use async_trait::async_trait;
+    use rain_orderbook_common::raindex_client::trades::RaindexTradesListResult;
+    use rain_orderbook_common::raindex_client::types::{PaginationParams, TimeFilter};
+    use rocket::http::{ContentType, Header, Status};
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug, Clone)]
+    struct CapturedOrderHashesQuery {
+        order_hashes: Vec<B256>,
+        time_filter: TimeFilter,
+    }
+
+    struct MockTradesDataSource {
+        result: Result<RaindexTradesByOrderHashResult, ApiError>,
+        captured: Arc<Mutex<Option<CapturedOrderHashesQuery>>>,
+    }
+
+    #[async_trait]
+    impl TradesDataSource for MockTradesDataSource {
+        async fn get_trades_by_tx(
+            &self,
+            _tx_hash: B256,
+        ) -> Result<RaindexTradesListResult, ApiError> {
+            unimplemented!()
+        }
+
+        async fn get_trades_for_owner(
+            &self,
+            _owner: Address,
+            _pagination: PaginationParams,
+            _time_filter: TimeFilter,
+        ) -> Result<RaindexTradesListResult, ApiError> {
+            unimplemented!()
+        }
+
+        async fn get_trades_for_token(
+            &self,
+            _token: Address,
+            _page: u16,
+            _page_size: u16,
+            _time_filter: TimeFilter,
+        ) -> Result<RaindexTradesListResult, ApiError> {
+            unimplemented!()
+        }
+
+        async fn get_trades_for_taker(
+            &self,
+            _taker: Address,
+            _page: u16,
+            _page_size: u16,
+            _time_filter: TimeFilter,
+        ) -> Result<RaindexTradesListResult, ApiError> {
+            unimplemented!()
+        }
+
+        async fn get_trades_by_order_hashes(
+            &self,
+            order_hashes: Vec<B256>,
+            time_filter: TimeFilter,
+        ) -> Result<RaindexTradesByOrderHashResult, ApiError> {
+            *self.captured.lock().unwrap() = Some(CapturedOrderHashesQuery {
+                order_hashes,
+                time_filter,
+            });
+            match &self.result {
+                Ok(r) => Ok(r.clone()),
+                Err(e) => Err(e.clone()),
+            }
+        }
+    }
+
+    fn hash_a() -> B256 {
+        b256!("0x000000000000000000000000000000000000000000000000000000000000abcd")
+    }
+
+    fn hash_b() -> B256 {
+        b256!("0x000000000000000000000000000000000000000000000000000000000000beef")
+    }
+
+    fn mock_grouped_result() -> RaindexTradesByOrderHashResult {
+        serde_json::from_value(serde_json::json!({
+            "tradesByOrderHash": [
+                {
+                    "orderHash": hash_a(),
+                    "trades": [trade_json()]
+                },
+                {
+                    "orderHash": hash_b(),
+                    "trades": []
+                }
+            ],
+            "totalCount": 1
+        }))
+        .unwrap()
+    }
+
+    #[rocket::async_test]
+    async fn test_process_success_groups_results_and_preserves_empty_hashes() {
+        let captured = Arc::new(Mutex::new(None));
+        let ds = MockTradesDataSource {
+            result: Ok(mock_grouped_result()),
+            captured: Arc::clone(&captured),
+        };
+        let request = TradesByOrderHashesRequest {
+            order_hashes: vec![hash_a().to_string(), hash_b().to_string()],
+            start_time: Some(1700000000),
+            end_time: Some(1700002000),
+        };
+        let result = process_get_trades_by_order_hashes(&ds, request)
+            .await
+            .unwrap();
+
+        let response = result.into_inner();
+        assert_eq!(response.total_count, 1);
+        assert_eq!(response.trades_by_order_hash.len(), 2);
+        assert_eq!(response.trades_by_order_hash[0].order_hash, hash_a());
+        assert_eq!(response.trades_by_order_hash[0].trades.len(), 1);
+        assert_eq!(response.trades_by_order_hash[1].order_hash, hash_b());
+        assert!(response.trades_by_order_hash[1].trades.is_empty());
+
+        let captured = captured.lock().unwrap().clone().unwrap();
+        assert_eq!(captured.order_hashes, vec![hash_a(), hash_b()]);
+        assert_eq!(captured.time_filter.start, Some(1700000000));
+        assert_eq!(captured.time_filter.end, Some(1700002000));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_empty_requested_hashes_returns_empty_response() {
+        let captured = Arc::new(Mutex::new(None));
+        let ds = MockTradesDataSource {
+            result: Ok(serde_json::from_value(serde_json::json!({
+                "tradesByOrderHash": [],
+                "totalCount": 0
+            }))
+            .unwrap()),
+            captured: Arc::clone(&captured),
+        };
+        let request = TradesByOrderHashesRequest {
+            order_hashes: vec![],
+            start_time: None,
+            end_time: None,
+        };
+        let result = process_get_trades_by_order_hashes(&ds, request)
+            .await
+            .unwrap();
+
+        let response = result.into_inner();
+        assert!(response.trades_by_order_hash.is_empty());
+        assert_eq!(response.total_count, 0);
+        assert!(captured
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap()
+            .order_hashes
+            .is_empty());
+    }
+
+    #[rocket::async_test]
+    async fn test_process_rejects_invalid_hash() {
+        let ds = MockTradesDataSource {
+            result: Ok(mock_grouped_result()),
+            captured: Arc::new(Mutex::new(None)),
+        };
+        let request = TradesByOrderHashesRequest {
+            order_hashes: vec!["not-a-hash".to_string()],
+            start_time: None,
+            end_time: None,
+        };
+        let result = process_get_trades_by_order_hashes(&ds, request).await;
+        assert!(matches!(result, Err(ApiError::BadRequest(_))));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_query_failure() {
+        let ds = MockTradesDataSource {
+            result: Err(ApiError::Internal("sdk error".into())),
+            captured: Arc::new(Mutex::new(None)),
+        };
+        let request = TradesByOrderHashesRequest {
+            order_hashes: vec![hash_a().to_string()],
+            start_time: None,
+            end_time: None,
+        };
+        let result = process_get_trades_by_order_hashes(&ds, request).await;
+        assert!(matches!(result, Err(ApiError::Internal(_))));
+    }
+
+    #[rocket::async_test]
+    async fn test_401_without_auth() {
+        let client = TestClientBuilder::new().build().await;
+        let response = client
+            .post("/v1/trades/query")
+            .header(ContentType::JSON)
+            .body(r#"{"orderHashes":[]}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[rocket::async_test]
+    async fn test_invalid_hash_returns_400() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v1/trades/query")
+            .header(Header::new("Authorization", header))
+            .header(ContentType::JSON)
+            .body(r#"{"orderHashes":["not-a-hash"]}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::BadRequest);
+    }
+
+    #[test]
+    fn test_route_is_registered() {
+        let routes = crate::routes::trades::routes();
+        assert!(routes.iter().any(|route| route.uri.path() == "/query"));
+    }
+}

--- a/src/routes/trades/get_by_taker.rs
+++ b/src/routes/trades/get_by_taker.rs
@@ -140,6 +140,17 @@ mod tests {
                 Err(e) => Err(e.clone()),
             }
         }
+
+        async fn get_trades_by_order_hashes(
+            &self,
+            _order_hashes: Vec<B256>,
+            _time_filter: TimeFilter,
+        ) -> Result<
+            rain_orderbook_common::raindex_client::trades::RaindexTradesByOrderHashResult,
+            ApiError,
+        > {
+            unimplemented!()
+        }
     }
 
     #[rocket::async_test]

--- a/src/routes/trades/get_by_token.rs
+++ b/src/routes/trades/get_by_token.rs
@@ -123,6 +123,17 @@ mod tests {
         ) -> Result<RaindexTradesListResult, ApiError> {
             unimplemented!()
         }
+
+        async fn get_trades_by_order_hashes(
+            &self,
+            _order_hashes: Vec<B256>,
+            _time_filter: TimeFilter,
+        ) -> Result<
+            rain_orderbook_common::raindex_client::trades::RaindexTradesByOrderHashResult,
+            ApiError,
+        > {
+            unimplemented!()
+        }
     }
 
     #[rocket::async_test]

--- a/src/routes/trades/get_by_tx.rs
+++ b/src/routes/trades/get_by_tx.rs
@@ -173,6 +173,17 @@ mod tests {
         ) -> Result<RaindexTradesListResult, ApiError> {
             unimplemented!()
         }
+
+        async fn get_trades_by_order_hashes(
+            &self,
+            _order_hashes: Vec<B256>,
+            _time_filter: TimeFilter,
+        ) -> Result<
+            rain_orderbook_common::raindex_client::trades::RaindexTradesByOrderHashResult,
+            ApiError,
+        > {
+            unimplemented!()
+        }
     }
 
     #[rocket::async_test]

--- a/src/routes/trades/mod.rs
+++ b/src/routes/trades/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod get_by_address;
+pub(crate) mod get_by_order_hashes;
 pub(crate) mod get_by_taker;
 pub(crate) mod get_by_token;
 pub(crate) mod get_by_tx;
@@ -11,7 +12,8 @@ use crate::types::trades::{
 use alloy::primitives::{Address, B256};
 use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::trades::{
-    GetTradesFilters, GetTradesTokenFilter, RaindexTrade, RaindexTradesListResult,
+    GetTradesByOrderHashesFilters, GetTradesFilters, GetTradesTokenFilter, OrderHashes,
+    RaindexTrade, RaindexTradesByOrderHashResult, RaindexTradesListResult,
 };
 use rain_orderbook_common::raindex_client::types::{PaginationParams, TimeFilter};
 use rain_orderbook_common::raindex_client::{RaindexClient, RaindexError};
@@ -44,6 +46,12 @@ pub(crate) trait TradesDataSource: Send + Sync {
         page_size: u16,
         time_filter: TimeFilter,
     ) -> Result<RaindexTradesListResult, ApiError>;
+
+    async fn get_trades_by_order_hashes(
+        &self,
+        order_hashes: Vec<B256>,
+        time_filter: TimeFilter,
+    ) -> Result<RaindexTradesByOrderHashResult, ApiError>;
 }
 
 pub(crate) struct RaindexTradesDataSource<'a> {
@@ -127,6 +135,25 @@ impl TradesDataSource for RaindexTradesDataSource<'_> {
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to query trades for taker");
+                ApiError::Internal("failed to query trades".into())
+            })
+    }
+
+    async fn get_trades_by_order_hashes(
+        &self,
+        order_hashes: Vec<B256>,
+        time_filter: TimeFilter,
+    ) -> Result<RaindexTradesByOrderHashResult, ApiError> {
+        let filters = GetTradesByOrderHashesFilters {
+            time_filter: Some(time_filter),
+            ..Default::default()
+        };
+
+        self.client
+            .get_trades_by_order_hashes(None, OrderHashes(order_hashes), Some(filters))
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to query trades by order hashes");
                 ApiError::Internal("failed to query trades".into())
             })
     }
@@ -223,6 +250,7 @@ pub(super) fn trades_pagination_params(
 pub fn routes() -> Vec<Route> {
     rocket::routes![
         get_by_tx::get_trades_by_tx,
+        get_by_order_hashes::get_trades_by_order_hashes,
         get_by_token::get_trades_by_token,
         get_by_taker::get_trades_by_taker,
         get_by_address::get_trades_by_address

--- a/src/types/trades.rs
+++ b/src/types/trades.rs
@@ -1,5 +1,5 @@
 use crate::types::common::TokenRef;
-use alloy::primitives::{Address, FixedBytes};
+use alloy::primitives::{Address, FixedBytes, B256};
 use rocket::form::FromForm;
 use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, ToSchema};
@@ -61,6 +61,36 @@ pub struct TradesPagination {
 pub struct TradesByAddressResponse {
     pub trades: Vec<TradeByAddress>,
     pub pagination: TradesPagination,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TradesByOrderHashesRequest {
+    #[schema(
+        value_type = Vec<String>,
+        example = json!(["0x000000000000000000000000000000000000000000000000000000000000abcd"])
+    )]
+    pub order_hashes: Vec<String>,
+    #[schema(example = 1718452800)]
+    pub start_time: Option<u64>,
+    #[schema(example = 1718539200)]
+    pub end_time: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TradesByOrderHashEntry {
+    #[schema(value_type = String, example = "0x000000000000000000000000000000000000000000000000000000000000abcd")]
+    pub order_hash: B256,
+    pub trades: Vec<TradeByAddress>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TradesByOrderHashesResponse {
+    pub trades_by_order_hash: Vec<TradesByOrderHashEntry>,
+    #[schema(example = 3)]
+    pub total_count: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
## Chained PRs

- Stacked on [ST0x-Technology/st0x.rest.api#106](https://github.com/ST0x-Technology/st0x.rest.api/pull/106) for the taker trades endpoint.
- Also follows [ST0x-Technology/st0x.rest.api#105](https://github.com/ST0x-Technology/st0x.rest.api/pull/105) for the token trades endpoint.

## Dependent PRs

- Depends on [rainlanguage/raindex#2572](https://github.com/rainlanguage/raindex/pull/2572) ([Graphite](https://app.graphite.com/github/pr/rainlanguage/raindex/2572)) for SDK `getTradesByOrderHashes` support, local DB order-hash batching, and grouped results. This PR should not merge until that raindex PR lands and the submodule pointer is mergeable.

## Summary

- Adds `POST /v1/trades/query` for batch order-hash trade lookup.
- Defines request/response DTOs for `orderHashes` input and `tradesByOrderHash` grouped output.
- Includes every requested hash in the response through the SDK grouping behavior, including hashes with no trades.
- Validates order hashes with existing API error handling and returns `400` for invalid hash input.
- Wires the route through the existing trades module, auth, rate limiting, tracing span propagation, and OpenAPI registration.
- Uses the raindex SDK batch order-hash API directly; there is no API-side query workaround.
- Reuses the shared trade list mapper for each grouped trade entry.
- Bumps the `rain.orderbook` submodule to the SDK commit with batch order-hash trade lookup support.

Linear: RAI-528

## Behavior

The new endpoint accepts a JSON body:

```json
{
  "orderHashes": [
    "0x4a051ad4567935a5a0570b3e2e77714c44405bb58e5b83e3cc484de1cee0747e"
  ],
  "startTime": 1718452800,
  "endTime": 1718539200
}
```

It returns trades grouped by requested order hash:

```json
{
  "tradesByOrderHash": [
    {
      "orderHash": "0x4a051ad4567935a5a0570b3e2e77714c44405bb58e5b83e3cc484de1cee0747e",
      "trades": []
    }
  ],
  "totalCount": 0
}
```

## Local DB Smoke Test

After clearing the local raindex DB and waiting for the Base local source to become ready, the endpoint used local DB only:

```text
local_chain_ids_count=1
subgraph_chain_ids_count=0
```

Single-order smoke test:

- Request: one real order hash plus one zero hash.
- Result: real hash returned `50` trades; zero hash returned an empty `trades` array.
- HTTP total: `0.415652s`.
- SDK local fetch: `29ms`; SDK total: `161ms`.

Heavy response stress test using the highest-trade order hashes in the local DB:

- Top 10 order hashes: `3,790` trades, `2.12 MB` response, HTTP total `11.20s`.
- Top 20 order hashes: `4,596` trades, `2.57 MB` response, HTTP total `13.50s`.
- Top 20 SQL fetch was `930ms`; full SDK grouping/materialization was `13211ms`; full API request was `13495ms`.

The heavy case is dominated by materializing, grouping, mapping, and serializing thousands of full trade objects rather than by SQL lookup.

## Notes

- The `unimplemented!()` additions are test-only mock methods required by the expanded `TradesDataSource` trait; they are not production route code.
- Empty `orderHashes` currently returns an empty grouped result, matching the SDK behavior.

## Verification

- `nix develop -c cargo fmt`
- `nix develop -c cargo check`
- `nix develop -c cargo test routes::trades::get_by_order_hashes`
- `nix develop -c cargo test`
- `nix develop -c rainix-rs-static`

`rainix-rs-static` passes with pre-existing dead-code warnings in `src/cache.rs`.
