### PR TITLE
Add branch-deployable preview API infrastructure

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,0 +1,128 @@
+name: Deploy Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch to deploy to preview"
+        required: true
+        default: "main"
+      deploy_scope:
+        description: "Deploy scope"
+        required: true
+        type: choice
+        default: "service"
+        options:
+          - service
+          - all
+
+concurrency:
+  group: deploy-preview
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Verify deploy branch
+        run: |
+          deploy_branch="${{ inputs.ref }}"
+          deploy_branch="${deploy_branch#refs/heads/}"
+          if [ -z "$deploy_branch" ] || [[ "$deploy_branch" == refs/* ]]; then
+            echo "Deploy Preview requires a branch ref, got '${{ inputs.ref }}'" >&2
+            exit 1
+          fi
+          if ! git ls-remote --exit-code --heads origin "$deploy_branch" >/dev/null; then
+            echo "Deploy Preview requires an existing remote branch, got '${{ inputs.ref }}'" >&2
+            exit 1
+          fi
+          git fetch origin "refs/heads/$deploy_branch:refs/remotes/origin/$deploy_branch"
+          git checkout -B "$deploy_branch" "origin/$deploy_branch"
+          echo "DEPLOY_BRANCH=$deploy_branch" >> "$GITHUB_ENV"
+
+      - name: Configure Git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - uses: DeterminateSystems/nix-installer-action@main
+        with:
+          extra-conf: |
+            accept-flake-config = true
+            fallback = true
+            sandbox = false
+
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Provision preview infrastructure
+        run: |
+          nix run .#tfPlan -- -var preview_enabled=true
+          nix run .#tfApply
+          nix run .#tfRekey
+
+      - name: Commit encrypted Terraform state
+        run: |
+          git add infra/terraform.tfstate.age infra/terraform.tfvars.age keys.nix
+          if git diff --cached --quiet; then
+            echo "No encrypted infra changes to commit"
+          else
+            git commit -m "chore: update preview terraform state"
+            git push origin "HEAD:$DEPLOY_BRANCH"
+          fi
+
+      - name: Resolve preview host IP
+        run: |
+          host_ip=$(nix run .#resolvePreviewIp)
+          if [[ ! "$host_ip" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]]; then
+            echo "Invalid preview host IP resolved: $host_ip" >&2
+            exit 1
+          fi
+          echo "::add-mask::$host_ip"
+          echo "HOST_IP=$host_ip" >> "$GITHUB_ENV"
+
+      - name: Bootstrap preview host
+        run: DEPLOY_ENV=preview nix run .#bootstrap
+
+      - name: Trust preview host key
+        env:
+          PREVIEW_SSH_HOST_KEY: ${{ secrets.PREVIEW_SSH_HOST_KEY }}
+        run: |
+          # Prefer PREVIEW_SSH_HOST_KEY. ssh-keyscan is a first-bootstrap fallback
+          # that trusts the presented host key before writing known_hosts.
+          if [ -n "$PREVIEW_SSH_HOST_KEY" ]; then
+            echo "$HOST_IP $PREVIEW_SSH_HOST_KEY" > ~/.ssh/known_hosts
+          else
+            ssh-keyscan -H "$HOST_IP" > ~/.ssh/known_hosts
+          fi
+
+      # Prepare local build artifacts used by deploy-rs.
+      - run: ./prep.sh
+
+      - name: Deploy preview service
+        if: (inputs.deploy_scope || 'all') == 'service'
+        timeout-minutes: 30
+        run: nix run .#deployPreviewService
+
+      - name: Deploy preview system and service
+        if: (inputs.deploy_scope || 'all') == 'all'
+        timeout-minutes: 60
+        run: nix run .#deployPreviewAll

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -222,9 +222,109 @@ systemctl cat rest-api
 nix develop -c deploy-service rest-api
 ```
 
+### Deploy a branch to preview
+
+Preview is a separate reusable machine and volume. It is intended for testing
+branch builds under production-like conditions without touching production data
+or services.
+
+Provision preview by setting `preview_enabled = true` in the encrypted Terraform
+vars, then plan/apply:
+
+```bash
+nix develop -c tf-edit-vars
+nix develop -c tf-plan
+nix develop -c tf-apply
+```
+
+Bootstrap preview after the host exists:
+
+```bash
+DEPLOY_ENV=preview nix develop -c bootstrap
+```
+
+Point `api.preview.st0x.io` at the preview reserved IP:
+
+```bash
+nix develop -c resolve-preview-ip
+```
+
+Deploy the checked-out branch to preview:
+
+```bash
+nix develop -c deploy-preview-all
+```
+
+For service-only branch deploys after the preview system is already configured:
+
+```bash
+nix develop -c deploy-preview-service
+```
+
+Preview service deploys intentionally reset local preview state before restart:
+
+- stop `rest-api`
+- remove `/mnt/data/st0x-rest-api-preview/st0x.db`
+- remove `/mnt/data/st0x-rest-api-preview/raindex.db`
+- preserve `/mnt/data/st0x-rest-api-preview/private-registry.data`
+- restart `rest-api` from the branch build
+
+After deploy, wait for `/health/detailed` to report a ready raindex state before
+running performance checks:
+
+```bash
+export API_URL=https://api.preview.st0x.io
+read -r -p "API_KEY: " API_KEY && export API_KEY
+read -r -s -p "API_SECRET: " API_SECRET && export API_SECRET
+printf "\n"
+./scripts/smoke.sh
+```
+
+Because the preview app DB is reset on preview service deploys, create a fresh
+preview API key after deploy when you need to run authenticated checks:
+
+```bash
+nix develop -c preview-create-api-key "preview-benchmark" "arda@st0x.io"
+```
+
+The command runs only against the preview host and prints the new key ID and
+secret in the terminal. Add `--admin` if the preview key needs admin access:
+
+```bash
+nix develop -c preview-create-api-key "preview-admin" "arda@st0x.io" --admin
+```
+
+### Deploy preview from GitHub
+
+The `Deploy Preview` GitHub Actions workflow exposes a manual
+`workflow_dispatch` button. It accepts:
+
+- `ref`: branch, tag, or SHA to deploy
+- `deploy_scope`: `service` for the API binary/profile only, or `all` for the
+  preview NixOS system plus service
+
+The workflow:
+
+- checks out the selected ref
+- resolves the preview reserved IP from Terraform state
+- deploys to the preview deploy-rs node
+- resets preview DB state as part of the preview service activation
+
+Required repository secrets:
+
+- `SSH_KEY`: private key allowed to SSH to the preview host
+- `PREVIEW_SSH_HOST_KEY`: optional but recommended SSH host public key for the
+  preview machine. If it is absent, the workflow falls back to `ssh-keyscan` for
+  the preview host.
+
 ### SSH into the server
 ```bash
 nix develop -c remote
+```
+
+### SSH into preview
+```bash
+nix develop -c remote-preview
 ```
 
 ### View service logs

--- a/config/preview.toml
+++ b/config/preview.toml
@@ -1,0 +1,8 @@
+log_dir = "/mnt/data/st0x-rest-api-preview/logs"
+database_url = "sqlite:///mnt/data/st0x-rest-api-preview/st0x.db"
+registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+private_registry_path = "/mnt/data/st0x-rest-api-preview/private-registry.data"
+rate_limit_global_rpm = 600
+rate_limit_per_key_rpm = 60
+docs_dir = "/var/lib/st0x-docs"
+local_db_path = "/mnt/data/st0x-rest-api-preview/raindex.db"

--- a/deploy.nix
+++ b/deploy.nix
@@ -12,21 +12,31 @@ let
     (builtins.filter (n: !services.${n}.enabled)
       (builtins.attrNames services)));
 
-  mkServiceProfile = name:
+  mkServiceProfile = { name, resetState ? false, dataDir ? null }:
     let
       markerFile = "/run/st0x/${name}.ready";
-    in activate.custom st0xPackage (builtins.concatStringsSep " && " [
+      resetCommands = if resetState then [
+        "rm -f ${dataDir}/st0x.db ${dataDir}/raindex.db"
+      ] else [ ];
+    in activate.custom st0xPackage (builtins.concatStringsSep " && " ([
       "systemctl stop ${name} || true"
       "rm -f ${markerFile}"
+    ] ++ resetCommands ++ [
       "mkdir -p /run/st0x"
       "touch ${markerFile}"
       "systemctl restart ${name}"
-    ]);
+    ]));
 
-  mkProfile = name: {
-    path = mkServiceProfile name;
+  mkProfile = { name, resetState ? false, dataDir ? null }: {
+    path = mkServiceProfile { inherit name resetState dataDir; };
     profilePath = "${profileBase}/${name}";
   };
+
+  mkProfiles = { resetState ? false, dataDir ? null }:
+    builtins.listToAttrs (map (name: {
+      inherit name;
+      value = mkProfile { inherit name resetState dataDir; };
+    }) enabledServices);
 
 in {
   config = {
@@ -38,11 +48,23 @@ in {
       profilesOrder = [ "system" ] ++ enabledServices;
 
       profiles = {
-        system.path = activate.nixos self.nixosConfigurations.st0x-rest-api;
-      } // builtins.listToAttrs (map (name: {
-        inherit name;
-        value = mkProfile name;
-      }) enabledServices);
+        system.path = activate.nixos self.nixosConfigurations.st0x-rest-api-prod;
+      } // mkProfiles { };
+    };
+
+    nodes.st0x-rest-api-preview = {
+      hostname = builtins.getEnv "DEPLOY_HOST";
+      sshUser = "root";
+      user = "root";
+
+      profilesOrder = [ "system" ] ++ enabledServices;
+
+      profiles = {
+        system.path = activate.nixos self.nixosConfigurations.st0x-rest-api-preview;
+      } // mkProfiles {
+        resetState = true;
+        dataDir = "/mnt/data/st0x-rest-api-preview";
+      };
     };
   };
 
@@ -56,6 +78,11 @@ in {
         export DEPLOY_HOST="$host_ip"
         export NIX_SSHOPTS="-i $identity"
         ssh_flag="--ssh-opts=-i $identity"
+      '';
+
+      previewDeployPreamble = ''
+        export DEPLOY_ENV=preview
+        ${deployPreamble}
       '';
 
       deployFlags = if localSystem == "x86_64-linux" then
@@ -92,6 +119,38 @@ in {
         text = ''
           ${deployPreamble}
           deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} .#st0x-rest-api \
+            -- --impure "$@"
+        '';
+      };
+
+      deployPreviewNixos = pkgs.writeShellApplication {
+        name = "deploy-preview-nixos";
+        runtimeInputs = deployInputs;
+        text = ''
+          ${previewDeployPreamble}
+          deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} .#st0x-rest-api-preview.system \
+            -- --impure "$@"
+        '';
+      };
+
+      deployPreviewService = pkgs.writeShellApplication {
+        name = "deploy-preview-service";
+        runtimeInputs = deployInputs;
+        text = ''
+          ${previewDeployPreamble}
+          profile="''${1:-rest-api}"
+          shift || true
+          deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} ".#st0x-rest-api-preview.$profile" \
+            -- --impure "$@"
+        '';
+      };
+
+      deployPreviewAll = pkgs.writeShellApplication {
+        name = "deploy-preview-all";
+        runtimeInputs = deployInputs;
+        text = ''
+          ${previewDeployPreamble}
+          deploy ${deployFlags} ''${ssh_flag:+"$ssh_flag"} .#st0x-rest-api-preview \
             -- --impure "$@"
         '';
       };

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -1,6 +1,6 @@
 # Operations cheat sheet
 
-Quick journalctl + curl recipes for the deployed `rest-api` service. SSH in with `nix develop -c remote` (or `ssh root@<host>` if your key is in `roles.ssh`).
+Quick journalctl + curl recipes for the deployed `rest-api` service. SSH into production with `nix develop -c remote` and into preview with `nix develop -c remote-preview` (or `ssh root@<host>` if your key is in `roles.ssh`).
 
 ## Service health
 
@@ -20,7 +20,7 @@ Key fields in `/health/detailed.cache_warmer`:
 
 ## Common journalctl queries
 
-All queries run via `ssh root@api.preview.st0x.io '...'` or after `nix develop -c remote`.
+All preview queries run via `ssh root@api.preview.st0x.io '...'` or after `nix develop -c remote-preview`.
 
 ### 429 rate
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,18 +18,39 @@
 
   outputs = { self, flake-utils, rainix, ragenix, deploy-rs, disko
     , nixos-anywhere, crane, ... }:
-    {
-      nixosConfigurations.st0x-rest-api =
+    let
+      mkNixosConfiguration = st0xEnv:
         rainix.inputs.nixpkgs.lib.nixosSystem {
           system = "x86_64-linux";
 
           specialArgs = {
+            inherit st0xEnv;
             docsRoot = self.packages.x86_64-linux.st0x-docs;
           };
 
           modules =
             [ disko.nixosModules.disko ragenix.nixosModules.default ./os.nix ];
         };
+    in
+    {
+      nixosConfigurations.st0x-rest-api-prod = mkNixosConfiguration {
+        name = "prod";
+        virtualHost = "api.st0x.io";
+        configFile = ./config/prod.toml;
+        dataDir = "/mnt/data/st0x-rest-api";
+        dataVolumeName = "st0x-rest-api-data";
+      };
+
+      nixosConfigurations.st0x-rest-api-preview = mkNixosConfiguration {
+        name = "preview";
+        virtualHost = "api.preview.st0x.io";
+        configFile = ./config/preview.toml;
+        dataDir = "/mnt/data/st0x-rest-api-preview";
+        dataVolumeName = "st0x-rest-api-preview-data";
+      };
+
+      nixosConfigurations.st0x-rest-api =
+        self.nixosConfigurations.st0x-rest-api-prod;
 
       deploy = (import ./deploy.nix { inherit deploy-rs self; }).config;
 
@@ -99,9 +120,18 @@
               ++ [ nixos-anywhere.packages.${system}.default ];
             body = ''
               ${infraPkgs.resolveIp}
+              deploy_env="''${DEPLOY_ENV:-prod}"
+              case "$deploy_env" in
+                prod) nixos_config="st0x-rest-api-prod" ;;
+                preview) nixos_config="st0x-rest-api-preview" ;;
+                *)
+                  echo "unsupported DEPLOY_ENV '$deploy_env' (expected prod or preview)" >&2
+                  exit 1
+                  ;;
+              esac
               ssh_opts="-o StrictHostKeyChecking=no -o ConnectTimeout=5 -i $identity"
 
-              nixos-anywhere --flake ".#st0x-rest-api" \
+              nixos-anywhere --flake ".#$nixos_config" \
                 --option pure-eval false \
                 --ssh-option "IdentityFile=$identity" \
                 --target-host "root@$host_ip" "$@"
@@ -129,11 +159,19 @@
                 exit 1
               fi
 
-              ${pkgs.gnused}/bin/sed -i \
-                '/host =/{n;s|"ssh-ed25519 [A-Za-z0-9+/=]*"|"'"$new_key"'"|;}' \
-                keys.nix
+              if [ "$deploy_env" = "prod" ]; then
+                ${pkgs.gnused}/bin/sed -i \
+                  '/host =/{n;s|"ssh-ed25519 [A-Za-z0-9+/=]*"|"'"$new_key"'"|;}' \
+                  keys.nix
 
-              echo "Updated host key in keys.nix"
+                echo "Updated host key in keys.nix"
+              else
+                echo "Preview SSH host key:"
+                echo "$new_key"
+                echo
+                echo "Optional GitHub secret PREVIEW_SSH_HOST_KEY value:"
+                echo "$new_key"
+              fi
             '';
           };
 
@@ -152,12 +190,78 @@
             '';
           };
 
+          resolvePreviewIp = pkgs.writeShellApplication {
+            name = "resolve-preview-ip";
+            runtimeInputs = infraPkgs.buildInputs;
+            text = ''
+              export DEPLOY_ENV=preview
+              ${infraPkgs.resolveIp}
+              echo "$host_ip"
+            '';
+          };
+
           remote = pkgs.writeShellApplication {
             name = "remote";
             runtimeInputs = infraPkgs.buildInputs ++ [ pkgs.openssh ];
             text = ''
               ${infraPkgs.resolveIp}
               exec ssh -i "$identity" "root@$host_ip" "$@"
+            '';
+          };
+
+          remotePreview = pkgs.writeShellApplication {
+            name = "remote-preview";
+            runtimeInputs = infraPkgs.buildInputs ++ [ pkgs.openssh ];
+            text = ''
+              export DEPLOY_ENV=preview
+              ${infraPkgs.resolveIp}
+              exec ssh -i "$identity" "root@$host_ip" "$@"
+            '';
+          };
+
+          previewCreateApiKey = pkgs.writeShellApplication {
+            name = "preview-create-api-key";
+            runtimeInputs = infraPkgs.buildInputs ++ [ pkgs.openssh ];
+            text = ''
+              usage() {
+                echo "usage: preview-create-api-key <label> <owner> [--admin]" >&2
+              }
+
+              label="''${1:-}"
+              owner="''${2:-}"
+              admin="''${3:-}"
+
+              if [ -z "$label" ] || [ -z "$owner" ]; then
+                usage
+                exit 1
+              fi
+
+              if [ -n "$admin" ] && [ "$admin" != "--admin" ]; then
+                usage
+                exit 1
+              fi
+
+              export DEPLOY_ENV=preview
+              ${infraPkgs.resolveIp}
+
+              remote_cmd=(
+                /nix/var/nix/profiles/per-service/rest-api/bin/st0x_rest_api
+                keys
+                --config
+                /etc/st0x-rest-api/config.toml
+                create
+                --label
+                "$label"
+                --owner
+                "$owner"
+              )
+
+              if [ "$admin" = "--admin" ]; then
+                remote_cmd+=(--admin)
+              fi
+
+              printf -v remote_cmd_escaped '%q ' "''${remote_cmd[@]}"
+              exec ssh -i "$identity" "root@$host_ip" "''${remote_cmd_escaped% }"
             '';
           };
 
@@ -179,10 +283,17 @@
               ragenix.packages.${system}.default
               packages.rs-test
               packages.prepSolArtifacts
+              packages.resolveIp
               packages.remote
+              packages.remotePreview
+              packages.previewCreateApiKey
+              packages.resolvePreviewIp
               packages.deployNixos
               packages.deployService
               packages.deployAll
+              packages.deployPreviewNixos
+              packages.deployPreviewService
+              packages.deployPreviewAll
             ] ++ rainix.devShells.${system}.default.buildInputs;
         };
       });

--- a/infra/default.nix
+++ b/infra/default.nix
@@ -57,7 +57,27 @@ let
     ${parseIdentity}
     trap 'rm -f ${tfState}' EXIT
     ${decryptState}
-    host_ip=$(jq -r '.outputs.droplet_ipv4.value' ${tfState})
+    deploy_env="''${DEPLOY_ENV:-prod}"
+    case "$deploy_env" in
+      prod)
+        host_ip=$(jq -r '.outputs.reserved_ip.value // empty' ${tfState})
+        if [ -z "$host_ip" ] || [ "$host_ip" = "null" ]; then
+          echo "prod infrastructure is not present in Terraform state" >&2
+          exit 1
+        fi
+        ;;
+      preview)
+        host_ip=$(jq -r '.outputs.preview_reserved_ip.value // empty' ${tfState})
+        if [ -z "$host_ip" ] || [ "$host_ip" = "null" ]; then
+          echo "preview infrastructure is not present in Terraform state" >&2
+          exit 1
+        fi
+        ;;
+      *)
+        echo "unsupported DEPLOY_ENV '$deploy_env' (expected prod or preview)" >&2
+        exit 1
+        ;;
+    esac
     rm -f ${tfState}
   '';
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -31,3 +31,43 @@ resource "digitalocean_reserved_ip_assignment" "nixos" {
   ip_address = digitalocean_reserved_ip.nixos.ip_address
   droplet_id = digitalocean_droplet.nixos.id
 }
+
+resource "digitalocean_volume" "preview_data" {
+  count = var.preview_enabled ? 1 : 0
+
+  region                  = var.region
+  name                    = "st0x-rest-api-preview-data"
+  size                    = var.preview_volume_size_gb
+  initial_filesystem_type = "ext4"
+  description             = "Persistent preview storage for SQLite database and logs"
+}
+
+resource "digitalocean_droplet" "preview_nixos" {
+  count = var.preview_enabled ? 1 : 0
+
+  image    = "ubuntu-24-04-x64"
+  name     = "st0x-rest-api-preview-nixos"
+  region   = var.region
+  size     = var.preview_droplet_size
+  ssh_keys = [data.digitalocean_ssh_key.deploy.id]
+}
+
+resource "digitalocean_volume_attachment" "preview_data" {
+  count = var.preview_enabled ? 1 : 0
+
+  droplet_id = digitalocean_droplet.preview_nixos[0].id
+  volume_id  = digitalocean_volume.preview_data[0].id
+}
+
+resource "digitalocean_reserved_ip" "preview_nixos" {
+  count = var.preview_enabled ? 1 : 0
+
+  region = var.region
+}
+
+resource "digitalocean_reserved_ip_assignment" "preview_nixos" {
+  count = var.preview_enabled ? 1 : 0
+
+  ip_address = digitalocean_reserved_ip.preview_nixos[0].ip_address
+  droplet_id = digitalocean_droplet.preview_nixos[0].id
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -17,3 +17,23 @@ output "volume_id" {
   description = "ID of the data volume"
   value       = digitalocean_volume.data.id
 }
+
+output "preview_droplet_id" {
+  description = "ID of the preview NixOS droplet"
+  value       = var.preview_enabled ? digitalocean_droplet.preview_nixos[0].id : null
+}
+
+output "preview_droplet_ipv4" {
+  description = "Public IPv4 address of the preview droplet"
+  value       = var.preview_enabled ? digitalocean_droplet.preview_nixos[0].ipv4_address : null
+}
+
+output "preview_reserved_ip" {
+  description = "Reserved IP address assigned to the preview droplet"
+  value       = var.preview_enabled ? digitalocean_reserved_ip.preview_nixos[0].ip_address : null
+}
+
+output "preview_volume_id" {
+  description = "ID of the preview data volume"
+  value       = var.preview_enabled ? digitalocean_volume.preview_data[0].id : null
+}

--- a/infra/terraform.tfvars.example
+++ b/infra/terraform.tfvars.example
@@ -2,3 +2,6 @@
 # NEVER commit terraform.tfvars — it contains secrets.
 
 do_token = ""
+
+# Set to true to provision the reusable preview API host and volume.
+preview_enabled = false

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -27,3 +27,21 @@ variable "volume_size_gb" {
   type        = number
   default     = 5
 }
+
+variable "preview_enabled" {
+  description = "Whether to provision the reusable preview droplet, volume, and reserved IP"
+  type        = bool
+  default     = false
+}
+
+variable "preview_droplet_size" {
+  description = "Droplet size slug for the preview environment"
+  type        = string
+  default     = "s-2vcpu-4gb"
+}
+
+variable "preview_volume_size_gb" {
+  description = "Block storage volume size in GB for the preview environment"
+  type        = number
+  default     = 5
+}

--- a/keys.nix
+++ b/keys.nix
@@ -14,7 +14,7 @@ rec {
   };
 
   roles = with keys; {
-    infra = [ st0x-op ci sid alastair ];
+    infra = [ st0x-op ci arda sid alastair ];
     ssh = [ st0x-op ci arda sid alastair ];
   };
 }

--- a/os.nix
+++ b/os.nix
@@ -1,7 +1,15 @@
-{ pkgs, lib, modulesPath, docsRoot, ... }:
+{ pkgs, lib, modulesPath, docsRoot, st0xEnv ? { }, ... }:
 
 let
   inherit (import ./keys.nix) roles;
+
+  env = {
+    name = "prod";
+    virtualHost = "api.st0x.io";
+    configFile = ./config/prod.toml;
+    dataDir = "/mnt/data/st0x-rest-api";
+    dataVolumeName = "st0x-rest-api-data";
+  } // st0xEnv;
 
   services = import ./services.nix;
   enabledServices = lib.filterAttrs (_: v: v.enabled) services;
@@ -9,9 +17,8 @@ let
   mkService = name: cfg:
     let
       path = "/nix/var/nix/profiles/per-service/${name}/bin/${cfg.bin}";
-      configFile = ./config/prod.toml;
     in {
-      description = "st0x ${cfg.bin} (${name})";
+      description = "st0x ${cfg.bin} (${env.name}/${name})";
 
       wantedBy = [ ];
 
@@ -26,7 +33,7 @@ let
       serviceConfig = {
         User = "st0x-rest-api";
         Group = "st0x";
-        ExecStart = "${path} serve --config ${configFile}";
+        ExecStart = "${path} serve --config /etc/st0x-rest-api/config.toml";
         Restart = "always";
         RestartSec = 5;
         ReadWritePaths = [ "/mnt/data" ];
@@ -107,7 +114,7 @@ in {
         limit_req_zone $binary_remote_addr zone=api:10m rate=10r/s;
       '';
 
-      virtualHosts."api.st0x.io" = {
+      virtualHosts.${env.virtualHost} = {
         enableACME = true;
         forceSSL = true;
 
@@ -157,7 +164,7 @@ in {
   };
 
   fileSystems."/mnt/data" = {
-    device = "/dev/disk/by-id/scsi-0DO_Volume_st0x-rest-api-data";
+    device = "/dev/disk/by-id/scsi-0DO_Volume_${env.dataVolumeName}";
     fsType = "ext4";
   };
 
@@ -182,9 +189,11 @@ in {
   };
   programs.bash.interactiveShellInit = "set -o vi";
 
+  environment.etc."st0x-rest-api/config.toml".source = env.configFile;
+
   services.logrotate = {
     enable = true;
-    settings."/mnt/data/st0x-rest-api/logs/*.log" = {
+    settings."${env.dataDir}/logs/*.log" = {
       su = "root st0x";
       rotate = 14;
       weekly = true;
@@ -195,8 +204,8 @@ in {
   };
 
   systemd.tmpfiles.rules = [
-    "d /mnt/data/st0x-rest-api 0775 root st0x -"
-    "d /mnt/data/st0x-rest-api/logs 0775 root st0x -"
+    "d ${env.dataDir} 0775 root st0x -"
+    "d ${env.dataDir}/logs 0775 root st0x -"
   ];
   systemd.services = lib.mapAttrs mkService enabledServices;
 


### PR DESCRIPTION
## Summary

- add a separate preview NixOS/deploy-rs target for `api.preview.st0x.io`
- add additive Terraform resources for a reusable preview droplet, volume, and reserved IP behind `preview_enabled`
- add `deploy-preview-*`, `remote-preview`, `resolve-preview-ip`, and `preview-create-api-key` wrappers
- add a manual GitHub Actions `Deploy Preview` workflow that deploys a selected branch/tag/SHA to preview
- reset preview app/indexer DB state during preview service activation while preserving the private registry artifact
- install the active service config at `/etc/st0x-rest-api/config.toml` so preview key management has a stable config path
- document the preview provisioning, deploy, key creation, and GitHub workflow steps

## How to Use

1. Enable preview infrastructure in encrypted Terraform vars:

```bash
nix develop -c tf-edit-vars
# set preview_enabled = true
nix develop -c tf-plan
nix develop -c tf-apply
```

2. Bootstrap the preview host:

```bash
DEPLOY_ENV=preview nix develop -c bootstrap
```

3. Point `api.preview.st0x.io` to:

```bash
nix develop -c resolve-preview-ip
```

4. Add/confirm GitHub secrets:

- `SSH_KEY`: already used by production deploy; must be valid for the preview host too.
- `PREVIEW_SSH_HOST_KEY`: optional but recommended. If absent, the workflow falls back to `ssh-keyscan`.

5. Use GitHub Actions > `Deploy Preview`:

- `ref`: branch, tag, or SHA to deploy
- `deploy_scope`: `service` for normal branch deploys, `all` when the preview NixOS config also changed

6. After a preview deploy, create a fresh preview key if authenticated checks are needed:

```bash
nix develop -c preview-create-api-key "preview-benchmark" "arda@st0x.io"
# or with admin access:
nix develop -c preview-create-api-key "preview-admin" "arda@st0x.io" --admin
```

## Validation

- `nix eval .#deploy.nodes.st0x-rest-api-preview.profiles.rest-api.profilePath`
- `nix eval .#nixosConfigurations.st0x-rest-api-preview.config.services.nginx.virtualHosts --apply builtins.attrNames`
- `nix eval .#nixosConfigurations.st0x-rest-api-prod.config.services.nginx.virtualHosts --apply builtins.attrNames`
- `nix eval .#nixosConfigurations.st0x-rest-api-preview.config.systemd.services.rest-api.serviceConfig.ExecStart`
- `nix eval .#nixosConfigurations.st0x-rest-api-preview.config.fileSystems."/mnt/data".device`
- `nix eval --impure --expr ... environment.etc."st0x-rest-api/config.toml".source`
- `nix build .#deployPreviewService --no-link`
- `nix build .#deployPreviewAll --no-link`
- `nix build .#remotePreview --no-link`
- `nix build .#previewCreateApiKey --no-link`
- `nix develop -c terraform -chdir=infra fmt`
- `nix develop -c terraform -chdir=infra validate`
- `nix develop -c rainix-rs-static`
- `git diff --check`

`rainix-rs-static` passed with the existing cache dead-code warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add preview environment: deployable from CI/Workflow Dispatch or tooling with service-only or full-system scope; provisions independent preview infra and reserved host IP.

* **Configuration**
  * New preview config with separate paths, DB behavior, and rate-limit settings; deployment profiles support optional DB reset for preview.

* **Documentation**
  * Full “Deploy a branch to preview” guide, updated SSH/operational instructions, and post-deploy smoke-test/runbook.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.rest.api/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->