### PR TITLE
Improve order endpoint trade lookup

### DIFF
--- a/src/routes/order/mod.rs
+++ b/src/routes/order/mod.rs
@@ -8,7 +8,10 @@ use alloy::primitives::{Bytes, B256};
 use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
 use rain_orderbook_common::raindex_client::orders::{GetOrdersFilters, RaindexOrder};
-use rain_orderbook_common::raindex_client::trades::RaindexTrade;
+use rain_orderbook_common::raindex_client::trades::{
+    GetTradesByOrderHashesFilters, OrderHashes, RaindexTrade,
+};
+use rain_orderbook_common::raindex_client::types::TimeFilter;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rocket::Route;
 
@@ -55,14 +58,27 @@ impl<'a> OrderDataSource for RaindexOrderDataSource<'a> {
     }
 
     async fn get_order_trades(&self, order: &RaindexOrder) -> Result<Vec<RaindexTrade>, ApiError> {
-        order
-            .get_trades_list(None, None, None)
+        let order_hash = order.order_hash();
+        let filters = GetTradesByOrderHashesFilters {
+            time_filter: Some(TimeFilter::default()),
+            ..Default::default()
+        };
+
+        let result = self
+            .client
+            .get_trades_by_order_hashes(None, OrderHashes(vec![order_hash]), Some(filters))
             .await
-            .map(|r| r.trades().to_vec())
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to query order trades");
                 ApiError::Internal("failed to query order trades".into())
-            })
+            })?;
+
+        Ok(result
+            .trades_by_order_hash()
+            .iter()
+            .find(|entry| entry.order_hash() == order_hash)
+            .map(|entry| entry.trades().to_vec())
+            .unwrap_or_default())
     }
 
     async fn get_remove_calldata(&self, order: &RaindexOrder) -> Result<Bytes, ApiError> {


### PR DESCRIPTION
## Dependent PR

Stacked on #108, `feature/rai-581-preview-api-infrastructure`.

## Linear

Part of RAI-580.

## Motivation

`GET /v1/order/{order_hash}` was the biggest confirmed endpoint latency issue in the benchmark pass. The production path was observed around 30-40s for a real order hash, which made the endpoint unsuitable for normal interactive use.

## Solution

- Replace the order endpoint's trade lookup from `order.get_trades_list(...)` to `client.get_trades_by_order_hashes(...)`.
- Keep the response shape unchanged by selecting the requested order hash's grouped trades from the batch result.
- Leave broader SDK and SQL changes out of this PR; this is the safe checkpoint for the confirmed endpoint win.

## Benchmark Notes

Order hash used:

`0x55c8f34ab380147ee98450e145f32c5dda080a4c6c9ad45206267048a3b475bf`

Observed before this change:

- Production API: roughly 30-40s for the order endpoint.
- Old `order.get_trades_list(...)` path against a ready local DB: roughly 10-11s.

Observed with this change against the current production registry bootstrap DB:

- Warm local runs mostly landed around 1.5-2.0s.
- Earlier local runs were around 1.6-1.8s after the DB was ready.
- The same response returned 72 trades.

Follow-up investigation showed direct SQLite trade SQL itself is fast, so remaining latency is likely SDK enrichment work rather than missing indexes:

- `order.get_quotes(...)`
- dotrain/metaboard source hydration during order lookup
- object hydration, formatting, and response serialization

## Checks

- `nix develop -c cargo fmt`
- `nix develop -c rainix-rs-static`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved backend trade data retrieval mechanism for orders, enhancing system reliability and query performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.rest.api/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
