### PR TITLE
Fix tokens API documentation

### DIFF
--- a/docs/src/tokens.md
+++ b/docs/src/tokens.md
@@ -20,34 +20,62 @@ curl https://api.st0x.io/v1/tokens \
 ### Response
 
 ```json
-{
-  "tokens": [
-    {
-      "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-      "symbol": "USDC",
-      "name": "USD Coin",
-      "ISIN": "US0000000001",
-      "decimals": 6
+[
+  {
+    "key": "usdc",
+    "network": {
+      "key": "base",
+      "rpcs": [],
+      "chainId": 8453,
+      "label": "Base",
+      "networkId": null,
+      "currency": "ETH"
     },
-    {
-      "address": "0x4200000000000000000000000000000000000006",
-      "symbol": "WETH",
-      "name": "Wrapped Ether",
-      "decimals": 18
-    }
-  ]
-}
+    "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "decimals": 6,
+    "label": "USD Coin",
+    "symbol": "USDC",
+    "logo-uri": null,
+    "extensions": {
+      "isin": "US0000000001"
+    },
+    "name": "USD Coin",
+    "isin": "US0000000001"
+  },
+  {
+    "key": "weth",
+    "network": {
+      "key": "base",
+      "rpcs": [],
+      "chainId": 8453,
+      "label": "Base",
+      "networkId": null,
+      "currency": "ETH"
+    },
+    "address": "0x4200000000000000000000000000000000000006",
+    "decimals": 18,
+    "label": "Wrapped Ether",
+    "symbol": "WETH",
+    "logo-uri": null,
+    "extensions": null,
+    "name": "Wrapped Ether",
+    "isin": null
+  }
+]
 ```
 
 ### Fields
 
-| Field      | Type              | Description                                  |
-| ---------- | ----------------- | -------------------------------------------- |
-| `address`  | string            | Token contract address on Base               |
-| `symbol`   | string            | Token ticker symbol                          |
-| `name`     | string            | Full token name                              |
-| `ISIN`     | string (optional) | ISIN identifier, omitted when not applicable |
-| `decimals` | number            | Token decimal places                         |
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Token key from the registry settings |
+| `address` | string | Token contract address on Base |
+| `symbol` | string | Token ticker symbol |
+| `name` | string | Full token name |
+| `isin` | string or null | ISIN identifier, when available |
+| `decimals` | number | Token decimal places |
+| `network` | object | Token network metadata with RPC URLs removed |
+| `extensions` | object or null | Additional token metadata, when available |
 
 Use the `address` field when specifying tokens in swap and order requests.
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -124,7 +124,7 @@ API_KEY="$SAVED_KEY"; API_SECRET="$SAVED_SECRET"
 
 # 3. Authenticated endpoints — only run if creds are set
 if [[ -n "$API_KEY" && -n "$API_SECRET" ]]; then
-    probe "GET /v1/tokens"                       GET "/v1/tokens" 200 '.tokens | type == "array"'
+    probe "GET /v1/tokens"                       GET "/v1/tokens" 200 'type == "array"'
     probe "GET /v1/orders/token/{usdc}"          GET "/v1/orders/token/$USDC_BASE" 200 '.orders | type == "array" and .pagination'
     probe "GET /v1/orders/owner/{owner}"         GET "/v1/orders/owner/$SAMPLE_OWNER" 200 '.orders | type == "array"'
     probe "GET /v1/trades/token/{usdc}"          GET "/v1/trades/token/$USDC_BASE?pageSize=10" 200 '.trades | type == "array"'

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use tracing::Instrument;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 const SFT_PAGE_SIZE: usize = 1000;
 const DEFAULT_ACTIVITY_LIMIT: u32 = 5;
@@ -246,6 +246,51 @@ pub struct TokenProofReceipt {
 pub enum TokenProofReceiptType {
     Deposit,
     Withdraw,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+struct TokenNetworkResponseSchema {
+    /// Network identifier from the registry settings.
+    key: String,
+    /// RPC URLs are intentionally stripped from public token responses.
+    rpcs: Vec<String>,
+    /// EVM chain ID.
+    chain_id: u32,
+    /// Human-readable network label, when configured.
+    label: Option<String>,
+    /// Optional network ID from the registry settings.
+    network_id: Option<u32>,
+    /// Native currency symbol.
+    currency: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "kebab-case")]
+struct TokenResponseSchema {
+    /// Token key from the registry settings.
+    key: String,
+    /// Sanitized network metadata for the token.
+    network: TokenNetworkResponseSchema,
+    /// Token contract address.
+    address: String,
+    /// Token decimals, when known.
+    decimals: Option<u8>,
+    /// Human-readable token label.
+    label: Option<String>,
+    /// Token symbol.
+    symbol: Option<String>,
+    /// Token logo URI, when available.
+    logo_uri: Option<String>,
+    /// Token list metadata extensions, when available.
+    #[schema(value_type = Object)]
+    extensions: Option<Value>,
+    /// Convenience display name derived from the token label.
+    name: Option<String>,
+    /// ISIN identifier from token extensions, when available.
+    isin: Option<String>,
 }
 
 impl From<TokenCfg> for TokenResponse {
@@ -1291,7 +1336,34 @@ fn activity_limit(params: &TokenDetailsQueryParams) -> u32 {
     tag = "Tokens",
     security(("basicAuth" = [])),
     responses(
-        (status = 200, description = "List of supported tokens", body = Vec<serde_json::Value>),
+        (
+            status = 200,
+            description = "List of supported tokens",
+            body = Vec<TokenResponseSchema>,
+            example = json!([
+                {
+                    "key": "usdc",
+                    "network": {
+                        "key": "base",
+                        "rpcs": [],
+                        "chainId": 8453,
+                        "label": "Base",
+                        "networkId": null,
+                        "currency": "ETH"
+                    },
+                    "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+                    "decimals": 6,
+                    "label": "USD Coin",
+                    "symbol": "USDC",
+                    "logo-uri": null,
+                    "extensions": {
+                        "isin": "US0000000001"
+                    },
+                    "name": "USD Coin",
+                    "isin": "US0000000001"
+                }
+            ])
+        ),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),


### PR DESCRIPTION
## Summary

- document `GET /v1/tokens` as a raw array of token objects in OpenAPI instead of `["string"]`
- update the tokens mdBook page to match the existing response contract, including lowercase `isin` and sanitized `network` metadata
- fix the smoke check to validate the root response is an array

## Context

`GET /v1/tokens` already returns a raw JSON array for customers. This keeps that runtime contract intact and only cleans up the generated/API-facing documentation around it.

Closes RAI-479

## Validation

- Not run locally per request; CI should cover compile/static validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the token list API docs with a new response example and revised field descriptions.
  * Added clearer metadata for token entries, including network details and optional extension fields.
* **Bug Fixes**
  * Aligned the smoke test with the current token response shape by checking for a top-level array response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->