### PR TITLE
fix: use ST0x registry fallback in prod

### DIFF
--- a/config/prod.toml
+++ b/config/prod.toml
@@ -1,6 +1,6 @@
 log_dir = "/mnt/data/st0x-rest-api/logs"
 database_url = "sqlite:///mnt/data/st0x-rest-api/st0x.db"
-registry_url = "https://raw.githubusercontent.com/rainlanguage/rain.strategies/5d0a11ad4a3e89531c922317b09216200ea7bdc0/registry"
+registry_url = "https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/e1fa474d45f126d70cdf2d3acd893e15c836ef03/registry"
 private_registry_path = "/mnt/data/st0x-rest-api/private-registry.data"
 rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60


### PR DESCRIPTION
## Motivation

Prod currently needs a fallback registry that can initialize the deployed raindex client when no private registry artifact is available. The previous fallback points at the public rain.strategies registry, which failed to initialize during recovery.

## Solution

Update the prod fallback registry URL to the ST0x registry commit that was verified during recovery:

https://raw.githubusercontent.com/ST0x-Technology/st0x.registry/e1fa474d45f126d70cdf2d3acd893e15c836ef03/registry

## Checks

- nix develop -c cargo fmt
- nix develop -c rainix-rs-static

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782424556&installation_id=125569124&pr_number=119&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F119&signature=f23852e203aafd08db59cf6e7e326665157d85de95bf36083cd6a2b167a49d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry configuration to reference a new endpoint with pinned commit hash for improved version control and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.rest.api/pull/119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->