### PR TITLE
Enable SDK tracing logs in deploys

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -370,10 +370,10 @@ Server (NixOS on DigitalOcean)
 
 ## Environment variables
 
-Set `RUST_LOG` to control log verbosity (configured in `.env`):
+Set `RUST_LOG` to control log verbosity. The deployed systemd service sets this
+in `os.nix`:
 ```
-RUST_LOG=st0x_rest_api=info,rocket=warn,warn
+RUST_LOG=st0x_rest_api=info,raindex_common=info,raindex_quote=info,rocket=warn,warn
 ```
 
-This is read by the systemd service environment. To change it on the server,
-update `os.nix` and redeploy with `deploy-nixos`.
+To change it on the server, update `os.nix` and redeploy with `deploy-nixos`.

--- a/os.nix
+++ b/os.nix
@@ -30,6 +30,11 @@ let
         ConditionPathExists = "/run/st0x/${name}.ready";
       };
 
+      environment = {
+        RUST_LOG =
+          "st0x_rest_api=info,raindex_common=info,raindex_quote=info,rocket=warn,warn";
+      };
+
       serviceConfig = {
         User = "st0x-rest-api";
         Group = "st0x";


### PR DESCRIPTION
## Summary
- Update the rain.orderbook submodule to include SDK tracing for order/trade/take-order paths.
- Configure deployed systemd services to emit info-level st0x REST, raindex_common, and raindex_quote tracing while keeping Rocket and unrelated crates quiet.
- Update deploy docs to describe the service-level RUST_LOG setting.

## Verification
- nix develop -c cargo fmt
- nix develop -c rainix-rs-static
- Local route checks confirmed request-correlated SDK tracing for orders, trades, swap quotes, and take-order calldata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment docs with revised guidance for configuring runtime logging.
* **Chores**
  * Updated an internal dependency to a newer release.
  * Enhanced service startup logging defaults to include additional components and adjust log-levels for quieter framework output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->