### PR TITLE
ci: simplify staging deploy workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -37,6 +37,7 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             sandbox = false
 
       - uses: DeterminateSystems/magic-nix-cache-action@main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       CARGO_TARGET_DIR: target/${{ matrix.cache_target }}
       COMMIT_SHA: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Cache submodules
         id: cache-sub
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             lib/
@@ -81,12 +81,13 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Cache Solidity artifacts
         id: cache-sol
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             lib/**/cache/
@@ -99,7 +100,7 @@ jobs:
         run: nix run .#prepSolArtifacts
 
       - name: Cache cargo artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/git/db/
@@ -128,13 +129,14 @@ jobs:
   docs:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -2,24 +2,6 @@ name: Deploy Preview
 
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Branch to deploy to preview"
-        required: true
-        default: "main"
-      deploy_scope:
-        description: "Deploy scope"
-        required: true
-        type: choice
-        default: "service"
-        options:
-          - service
-          - all
-      recreate_host:
-        description: "Recreate the preview droplet before deploy"
-        required: true
-        type: boolean
-        default: false
 
 concurrency:
   group: deploy-preview
@@ -36,22 +18,16 @@ jobs:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
           fetch-depth: 0
 
-      - name: Verify deploy branch
+      - name: Resolve deploy branch
         run: |
-          deploy_branch="${{ inputs.ref }}"
-          deploy_branch="${deploy_branch#refs/heads/}"
-          if [ -z "$deploy_branch" ] || [[ "$deploy_branch" == refs/* ]]; then
-            echo "Deploy Preview requires a branch ref, got '${{ inputs.ref }}'" >&2
-            exit 1
-          fi
+          deploy_branch="${GITHUB_REF_NAME}"
           if ! git ls-remote --exit-code --heads origin "$deploy_branch" >/dev/null; then
-            echo "Deploy Preview requires an existing remote branch, got '${{ inputs.ref }}'" >&2
+            echo "Deploy Preview requires an existing remote branch, got '${GITHUB_REF_NAME}'" >&2
             exit 1
           fi
           git fetch origin "refs/heads/$deploy_branch:refs/remotes/origin/$deploy_branch"
@@ -68,6 +44,7 @@ jobs:
           extra-conf: |
             accept-flake-config = true
             fallback = true
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             sandbox = false
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
@@ -86,7 +63,7 @@ jobs:
             echo "DO_TOKEN secret is required for preview infrastructure deploys" >&2
             exit 1
           fi
-          RECREATE_PREVIEW_HOST="${{ inputs.recreate_host }}" nix run .#tfPreviewProvision
+          nix run .#tfPreviewProvision
 
       - name: Commit encrypted Terraform state
         run: |
@@ -126,12 +103,6 @@ jobs:
       # Prepare local build artifacts used by deploy-rs.
       - run: ./prep.sh
 
-      - name: Deploy preview service
-        if: (inputs.deploy_scope || 'all') == 'service'
-        timeout-minutes: 30
-        run: nix run .#deployPreviewService
-
       - name: Deploy preview system and service
-        if: (inputs.deploy_scope || 'all') == 'all'
         timeout-minutes: 60
         run: nix run .#deployPreviewAll


### PR DESCRIPTION
## Stack

1. This PR: simplify staging deploy workflow.
2. Next: #122 keeps staging state across deploys.
3. Then: #123 adds registry fallback from config.

## Motivation

The preview deploy workflow had two branch selectors and a deploy scope selector, which made routine staging deploys harder to reason about.

## Solution

- Use GitHub's native workflow branch selector as the deploy branch.
- Remove the custom `ref`, `deploy_scope`, and recreate-host inputs.
- Always run the full preview system and service deploy.

## Checks

- `nix develop -c cargo test`
- `nix develop -c rainix-rs-static`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions for improved compatibility and reliability.
  * Enhanced authentication configuration across CI/CD pipelines with token access.
  * Simplified preview deployment workflow for faster iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->