### PR TITLE
deploy: keep staging state across deploys

### DIFF
--- a/deploy.nix
+++ b/deploy.nix
@@ -61,10 +61,7 @@ in {
 
       profiles = {
         system.path = activate.nixos self.nixosConfigurations.st0x-rest-api-preview;
-      } // mkProfiles {
-        resetState = true;
-        dataDir = "/mnt/data/st0x-rest-api-preview";
-      };
+      } // mkProfiles { };
     };
   };
 


### PR DESCRIPTION
## Stack

1. Depends on #121.
2. This PR: keep staging state across deploys.
3. Next: #123 adds registry fallback from config.

## Motivation

Normal staging deploys should exercise production-like update and migration behavior instead of wiping service databases every time.

## Solution

- Remove the preview service profile reset from normal deploys.
- Keep preview deploys stateful while preserving the existing persistent data volume.

## Checks

- `nix develop -c cargo test`
- `nix develop -c rainix-rs-static`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview deployment configuration to preserve database state across deployments instead of forcing resets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.rest.api/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->