### PR TITLE
Fix deploy prep for orderbook Soldeer

### DIFF
--- a/prep.sh
+++ b/prep.sh
@@ -7,8 +7,8 @@ export COMMIT_SHA=$(git rev-parse HEAD)
 echo "Initializing all submodules..."
 git submodule update --init --recursive
 
-echo "Running orderbook prep-base..."
-(cd lib/rain.orderbook && ./prep-base.sh)
+echo "Preparing orderbook Solidity artifacts..."
+nix run .#prepSolArtifacts
 
 echo "Building docs..."
 nix build .#st0x-docs


### PR DESCRIPTION
## Motivation

The deploy workflows run `./prep.sh` before `deploy-rs`. After the orderbook update, that script still called `lib/rain.orderbook/prep-base.sh`, but the new orderbook commit removed that script and now uses Soldeer-managed Solidity dependencies.

## Solution

- Replace the stale orderbook `prep-base.sh` call in `prep.sh` with `nix run .#prepSolArtifacts`.
- Reuse the same Soldeer artifact prep path that CI now uses.

## Checks

- `nix develop -c ./prep.sh`
- `nix develop -c cargo fmt`
- `nix develop -c rainix-rs-static`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build preparation step to invoke a new artifact preparation method for orderbook artifacts; surrounding commit export, submodule init, docs build, and completion output remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->