### PR TITLE
Deploy prod service by default

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -2,6 +2,16 @@ name: Deploy
 
 on:
   workflow_dispatch:
+    inputs:
+      deploy_scope:
+        description: "Deploy scope"
+        required: true
+        type: choice
+        default: "service"
+        options:
+          - service
+          - system
+          - all
 
 concurrency:
   group: deploy
@@ -50,5 +60,14 @@ jobs:
 
       - run: ./prep.sh
 
-      - name: Build and deploy
+      - name: Deploy service
+        if: (inputs.deploy_scope || 'service') == 'service'
+        run: nix run .#deployService -- rest-api
+
+      - name: Deploy system
+        if: (inputs.deploy_scope || 'service') == 'system'
+        run: nix run .#deployNixos
+
+      - name: Deploy system and service
+        if: (inputs.deploy_scope || 'service') == 'all'
         run: nix run .#deployAll


### PR DESCRIPTION
## Motivation

The prod deploy workflow currently runs `nix run .#deployAll`, which activates the full NixOS system profile before the `rest-api` service profile. The latest deploy failed in system activation because NixOS refused to hot-switch a critical component change (`dbus-implementation : dbus -> broker`).

For normal API releases, we only need to roll the `rest-api` service profile. Preview deploys already support this service-only mode.

## Solution

- Add a `deploy_scope` workflow input to prod deploy.
- Default prod deploys to `service`.
- Run `nix run .#deployService -- rest-api` for service deploys.
- Keep explicit `system` and `all` options available for intentional host/system deploys.

## Checks

- `nix develop -c cargo fmt`
- `nix develop -c rainix-rs-static`

## Validation plan

After opening this PR, dispatch `Deploy` on this branch with `deploy_scope=service` to verify the service-only path avoids the NixOS switch inhibitor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment workflow now supports manual selection of deployment scope (service, system, or all) so you can trigger service-only, system-only, or full deployments.
  * Deployment process now runs the appropriate scoped deployment steps based on the selected option, improving control and reducing unnecessary work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->