### PR TITLE
feat: add wrapped token ratio endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,6 +4937,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rain-erc"
+version = "0.1.2"
+source = "git+https://github.com/rainlanguage/rain.erc?rev=755b0bf5cad18a2cc43a57be52298b6dadd96751#755b0bf5cad18a2cc43a57be52298b6dadd96751"
+dependencies = [
+ "alloy",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "rain-error-decoding"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5045,7 +5057,7 @@ dependencies = [
  "inflate",
  "itertools 0.10.5",
  "once_cell",
- "rain-erc",
+ "rain-erc 0.1.1",
  "rain-metaboard-subgraph",
  "rain-metadata-bindings",
  "regex",
@@ -6976,6 +6988,7 @@ dependencies = [
  "clap",
  "futures",
  "moka",
+ "rain-erc 0.1.2",
  "rain-math-float",
  "raindex_app_settings",
  "raindex_bindings",
@@ -6997,6 +7010,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber 0.3.19",
  "tracing-test",
+ "url",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -8221,7 +8235,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,11 @@ thiserror = "2"
 utoipa = { version = "5", features = ["rocket_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["rocket"] }
 tokio = { version = "1", features = ["full"] }
-alloy = { version = "=1.8.3", default-features = false, features = ["std", "serde"] }
+alloy = { version = "=1.8.3", default-features = false, features = [
+  "std",
+  "serde",
+  "providers",
+] }
 async-trait = "0.1"
 futures = "0.3"
 tracing = "0.1"
@@ -32,8 +36,10 @@ rain_orderbook_js_api = { package = "raindex_js_api", path = "lib/rain.orderbook
 rain_orderbook_common = { package = "raindex_common", path = "lib/rain.orderbook/crates/common", default-features = false }
 rain_orderbook_app_settings = { package = "raindex_app_settings", path = "lib/rain.orderbook/crates/settings", default-features = false }
 rain_orderbook_bindings = { package = "raindex_bindings", path = "lib/rain.orderbook/crates/bindings", default-features = false }
+rain-erc = { git = "https://github.com/rainlanguage/rain.erc", rev = "755b0bf5cad18a2cc43a57be52298b6dadd96751" }
 rain-math-float = "0.1.7"
 wasm-bindgen = "=0.2.122"
+url = "2"
 
 [dev-dependencies]
 tracing-test = "0.2"

--- a/docs/src/tokens.md
+++ b/docs/src/tokens.md
@@ -41,12 +41,60 @@ curl https://api.st0x.io/v1/tokens \
 
 ### Fields
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `address` | string | Token contract address on Base |
-| `symbol` | string | Token ticker symbol |
-| `name` | string | Full token name |
-| `ISIN` | string (optional) | ISIN identifier, omitted when not applicable |
-| `decimals` | number | Token decimal places |
+| Field      | Type              | Description                                  |
+| ---------- | ----------------- | -------------------------------------------- |
+| `address`  | string            | Token contract address on Base               |
+| `symbol`   | string            | Token ticker symbol                          |
+| `name`     | string            | Full token name                              |
+| `ISIN`     | string (optional) | ISIN identifier, omitted when not applicable |
+| `decimals` | number            | Token decimal places                         |
 
 Use the `address` field when specifying tokens in swap and order requests.
+
+## Wrapped Token Ratios
+
+```
+GET /v1/tokens/wrap-ratio
+GET /v1/tokens/wrap-ratio/{address}
+```
+
+Returns ERC4626 wrapped-token ratios for registry tokens where
+`extensions.category` is `ST0x`. For the single-token endpoint, `{address}` must
+be the wrapped token / ERC4626 vault address. Symbol lookup is not supported.
+
+### Batch Response
+
+The batch endpoint returns successful ratios in `data` and per-token failures in
+`errors`. One failed token does not fail the whole response.
+
+```json
+{
+  "data": [
+    {
+      "shareAddress": "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2",
+      "assetAddress": "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe",
+      "assetsPerShare": "1.0",
+      "blockNumber": 123456789,
+      "blockTimestamp": 1717351200,
+      "capturedAt": "1717351201"
+    }
+  ],
+  "errors": [
+    {
+      "shareAddress": "0x1111111111111111111111111111111111111111",
+      "message": "failed to read ERC4626 ratio"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field            | Type           | Description                                                                                           |
+| ---------------- | -------------- | ----------------------------------------------------------------------------------------------------- |
+| `shareAddress`   | string         | Wrapped wtStock / ERC4626 vault token address                                                         |
+| `assetAddress`   | string         | Unwrapped tStock asset address from `extensions.unwrappedAddress`, verified against ERC4626 `asset()` |
+| `assetsPerShare` | string         | Assets returned by `convertToAssets(1 * 10^shareDecimals)`                                            |
+| `blockNumber`    | number         | Block number used for the ERC4626 batch read                                                          |
+| `blockTimestamp` | number or null | Block timestamp when available from the RPC                                                           |
+| `capturedAt`     | string         | Unix timestamp when the SDK captured the batch response                                               |

--- a/src/erc4626.rs
+++ b/src/erc4626.rs
@@ -1,0 +1,34 @@
+use alloy::primitives::Address;
+use alloy::providers::ProviderBuilder;
+use rain_erc::erc4626::{self, Erc4626BatchResponse, Erc4626BatchVault};
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Error)]
+pub(crate) enum Erc4626ReadError {
+    #[error("no RPC URLs configured")]
+    MissingRpc,
+    #[error("all configured RPC URLs failed: {0}")]
+    AllRpcsFailed(String),
+}
+
+pub(crate) async fn batch_share_ratios(
+    rpcs: &[Url],
+    vaults: Vec<Erc4626BatchVault>,
+    multicall3_address: Option<Address>,
+) -> Result<Erc4626BatchResponse, Erc4626ReadError> {
+    if rpcs.is_empty() {
+        return Err(Erc4626ReadError::MissingRpc);
+    }
+
+    let mut errors = Vec::new();
+    for rpc in rpcs {
+        let provider = ProviderBuilder::new().connect_http(rpc.clone());
+        match erc4626::batch_share_ratios(&provider, vaults.clone(), multicall3_address).await {
+            Ok(response) => return Ok(response),
+            Err(error) => errors.push(format!("{rpc}: {error}")),
+        }
+    }
+
+    Err(Erc4626ReadError::AllRpcsFailed(errors.join("; ")))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod catchers;
 mod cli;
 mod config;
 mod db;
+mod erc4626;
 mod error;
 mod fairings;
 mod raindex;
@@ -78,6 +79,8 @@ enum StartupRegistryError {
         routes::health::get_health,
         routes::health::get_health_detailed,
         routes::tokens::get_tokens,
+        routes::tokens::get_wrap_ratios,
+        routes::tokens::get_wrap_ratio_by_address,
         routes::swap::post_swap_quote,
         routes::swap::post_swap_calldata,
         routes::order::post_order_dca,

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -1,13 +1,18 @@
 use crate::auth::AuthenticatedKey;
+use crate::erc4626::batch_share_ratios;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::raindex::SharedRaindexProvider;
+use crate::types::common::ValidatedAddress;
+use alloy::primitives::Address;
+use rain_erc::erc4626::{Erc4626BatchItem, Erc4626BatchResponse, Erc4626BatchVault};
 use rain_orderbook_app_settings::token::TokenCfg;
 use rain_orderbook_common::raindex_client::RaindexError;
 use rocket::serde::json::Json;
 use rocket::{Route, State};
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::Instrument;
 
@@ -17,6 +22,55 @@ pub struct TokenResponse {
     token: TokenCfg,
     name: Option<String>,
     isin: Option<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapRatioResponse {
+    #[schema(value_type = String, example = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2")]
+    share_address: Address,
+    #[schema(value_type = String, example = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe")]
+    asset_address: Address,
+    #[schema(example = "1.0")]
+    assets_per_share: String,
+    #[schema(example = 123)]
+    block_number: u64,
+    #[schema(nullable = true, example = 456)]
+    block_timestamp: Option<u64>,
+    #[schema(example = "1717351200")]
+    captured_at: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapRatioErrorResponse {
+    #[schema(value_type = String, example = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2")]
+    share_address: Address,
+    #[schema(example = "failed to read ERC4626 ratio")]
+    message: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapRatioBatchResponse {
+    data: Vec<WrapRatioResponse>,
+    errors: Vec<WrapRatioErrorResponse>,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum WrapRatioLookupError {
+    #[error("missing registry extensions.unwrappedAddress")]
+    MissingUnwrappedAddress,
+    #[error("invalid registry extensions.unwrappedAddress: {0}")]
+    InvalidUnwrappedAddress(String),
+    #[error("registry unwrappedAddress does not match ERC4626 asset")]
+    AssetMismatch,
+    #[error("failed to read ERC4626 ratio: {0}")]
+    BatchItem(String),
+    #[error("ERC4626 batch response did not include requested token")]
+    MissingBatchItem,
+    #[error("ERC4626 batch response included duplicate requested token")]
+    DuplicateBatchItem,
 }
 
 impl From<TokenCfg> for TokenResponse {
@@ -39,6 +93,47 @@ impl From<TokenCfg> for TokenResponse {
     }
 }
 
+impl WrapRatioLookupError {
+    fn into_api_error(self) -> ApiError {
+        match self {
+            WrapRatioLookupError::MissingUnwrappedAddress => {
+                ApiError::Internal("token is missing unwrappedAddress".into())
+            }
+            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
+                ApiError::Internal("token has invalid unwrappedAddress".into())
+            }
+            WrapRatioLookupError::AssetMismatch => {
+                ApiError::Internal("token unwrappedAddress does not match ERC4626 asset".into())
+            }
+            WrapRatioLookupError::BatchItem(_) => {
+                ApiError::Internal("failed to read ERC4626 ratio".into())
+            }
+            WrapRatioLookupError::MissingBatchItem | WrapRatioLookupError::DuplicateBatchItem => {
+                ApiError::Internal("failed to read ERC4626 ratio".into())
+            }
+        }
+    }
+
+    fn batch_message(&self) -> String {
+        match self {
+            WrapRatioLookupError::MissingUnwrappedAddress => {
+                "missing registry unwrappedAddress".to_string()
+            }
+            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
+                "invalid registry unwrappedAddress".to_string()
+            }
+            WrapRatioLookupError::AssetMismatch => {
+                "registry unwrappedAddress does not match ERC4626 asset".to_string()
+            }
+            WrapRatioLookupError::BatchItem(_)
+            | WrapRatioLookupError::MissingBatchItem
+            | WrapRatioLookupError::DuplicateBatchItem => {
+                "failed to read ERC4626 ratio".to_string()
+            }
+        }
+    }
+}
+
 fn sanitize_network(
     network: &rain_orderbook_app_settings::network::NetworkCfg,
 ) -> rain_orderbook_app_settings::network::NetworkCfg {
@@ -56,6 +151,196 @@ fn extract_extension_string(
         Some(Value::Null) | None => None,
         Some(value) => Some(value.to_string()),
     }
+}
+
+fn is_st0x_token(token: &TokenCfg) -> bool {
+    token
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get("category"))
+        .and_then(Value::as_str)
+        == Some("ST0x")
+}
+
+fn unwrapped_address(token: &TokenCfg) -> Result<Address, WrapRatioLookupError> {
+    let value = token
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get("unwrappedAddress"))
+        .ok_or(WrapRatioLookupError::MissingUnwrappedAddress)?;
+
+    let Some(address) = value.as_str() else {
+        return Err(WrapRatioLookupError::InvalidUnwrappedAddress(
+            value.to_string(),
+        ));
+    };
+
+    address
+        .parse()
+        .map_err(|_| WrapRatioLookupError::InvalidUnwrappedAddress(address.to_string()))
+}
+
+fn assets_per_share_display(assets_display: String) -> String {
+    if assets_display == "1" {
+        "1.0".to_string()
+    } else {
+        assets_display
+    }
+}
+
+struct WrapRatioBatchInput<'a> {
+    token: &'a TokenCfg,
+    expected_asset_address: Address,
+}
+
+struct WrapRatioMetadata {
+    block_number: u64,
+    block_timestamp: Option<u64>,
+    captured_at: String,
+}
+
+impl WrapRatioMetadata {
+    fn from_batch_response(response: &Erc4626BatchResponse) -> Self {
+        Self {
+            block_number: response.block_number,
+            block_timestamp: Some(response.block_timestamp),
+            captured_at: response.captured_at.to_string(),
+        }
+    }
+}
+
+struct WrapRatioBatchGroupResponse {
+    input_indices: Vec<usize>,
+    response: Erc4626BatchResponse,
+}
+
+fn find_wrap_ratio_item(
+    items: &[Erc4626BatchItem],
+    share_address: Address,
+) -> Result<&Erc4626BatchItem, WrapRatioLookupError> {
+    let mut matches = items
+        .iter()
+        .filter(|item| item.vault_address == share_address);
+    let Some(item) = matches.next() else {
+        tracing::error!(
+            share_address = %share_address,
+            "ERC4626 batch response did not include requested token"
+        );
+        return Err(WrapRatioLookupError::MissingBatchItem);
+    };
+
+    if matches.next().is_some() {
+        tracing::error!(
+            share_address = %share_address,
+            "ERC4626 batch response included duplicate requested token"
+        );
+        return Err(WrapRatioLookupError::DuplicateBatchItem);
+    }
+
+    Ok(item)
+}
+
+fn build_wrap_ratio_response(
+    item: &Erc4626BatchItem,
+    expected_asset_address: Address,
+    metadata: &WrapRatioMetadata,
+) -> Result<WrapRatioResponse, WrapRatioLookupError> {
+    if !item.success {
+        return Err(WrapRatioLookupError::BatchItem(
+            item.error
+                .clone()
+                .unwrap_or_else(|| "failed to read ERC4626 ratio".to_string()),
+        ));
+    }
+
+    let Some(ratio) = item.data.as_ref() else {
+        return Err(WrapRatioLookupError::BatchItem(
+            "missing ERC4626 batch item data".to_string(),
+        ));
+    };
+
+    if ratio.asset_address != expected_asset_address {
+        tracing::error!(
+            share_address = %item.vault_address,
+            expected_asset_address = %expected_asset_address,
+            erc4626_asset_address = %ratio.asset_address,
+            "registry unwrappedAddress does not match ERC4626 asset"
+        );
+        return Err(WrapRatioLookupError::AssetMismatch);
+    }
+
+    Ok(WrapRatioResponse {
+        share_address: item.vault_address,
+        asset_address: expected_asset_address,
+        assets_per_share: assets_per_share_display(ratio.assets_display.clone()),
+        block_number: metadata.block_number,
+        block_timestamp: metadata.block_timestamp,
+        captured_at: metadata.captured_at.clone(),
+    })
+}
+
+async fn read_wrap_ratios_batch(
+    inputs: &[WrapRatioBatchInput<'_>],
+) -> Result<Vec<WrapRatioBatchGroupResponse>, ApiError> {
+    let mut inputs_by_chain: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+    for (index, input) in inputs.iter().enumerate() {
+        inputs_by_chain
+            .entry(input.token.network.chain_id)
+            .or_default()
+            .push(index);
+    }
+
+    let mut responses = Vec::with_capacity(inputs_by_chain.len());
+    for (chain_id, input_indices) in inputs_by_chain {
+        let Some(first_input_index) = input_indices.first() else {
+            continue;
+        };
+        let Some(first_input) = inputs.get(*first_input_index) else {
+            continue;
+        };
+
+        let vaults = input_indices
+            .iter()
+            .filter_map(|index| inputs.get(*index))
+            .map(|input| Erc4626BatchVault::new(input.token.address))
+            .collect();
+
+        let response = batch_share_ratios(&first_input.token.network.rpcs, vaults, None)
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    chain_id,
+                    error = %error,
+                    "failed to read ERC4626 batch ratios"
+                );
+                ApiError::Internal("failed to read ERC4626 ratios".into())
+            })?;
+
+        responses.push(WrapRatioBatchGroupResponse {
+            input_indices,
+            response,
+        });
+    }
+
+    Ok(responses)
+}
+
+fn token_lookup_error(error: RaindexError) -> ApiError {
+    tracing::error!(error = %error, "failed to get tokens from raindex");
+    ApiError::Internal("failed to retrieve token list".into())
+}
+
+async fn registry_tokens(
+    shared_raindex: &State<SharedRaindexProvider>,
+) -> Result<Vec<TokenCfg>, ApiError> {
+    let raindex = shared_raindex.read().await;
+    let tokens = raindex
+        .client()
+        .get_all_tokens()
+        .map_err(token_lookup_error)?
+        .into_values()
+        .collect();
+    Ok(tokens)
 }
 
 #[utoipa::path(
@@ -97,17 +382,572 @@ pub async fn get_tokens(
     .await
 }
 
+#[utoipa::path(
+    get,
+    path = "/v1/tokens/wrap-ratio",
+    tag = "Tokens",
+    security(("basicAuth" = [])),
+    responses(
+        (status = 200, description = "Wrapped ST0x token ratios", body = WrapRatioBatchResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[get("/wrap-ratio")]
+pub async fn get_wrap_ratios(
+    _global: GlobalRateLimit,
+    _key: AuthenticatedKey,
+    span: TracingSpan,
+    shared_raindex: &State<SharedRaindexProvider>,
+) -> Result<Json<WrapRatioBatchResponse>, ApiError> {
+    async move {
+        tracing::info!("request received");
+
+        let tokens = registry_tokens(shared_raindex).await?;
+        let st0x_tokens: Vec<&TokenCfg> =
+            tokens.iter().filter(|token| is_st0x_token(token)).collect();
+        tracing::info!(count = st0x_tokens.len(), "reading wrapped token ratios");
+
+        let mut data = Vec::new();
+        let mut errors = Vec::new();
+        let mut inputs = Vec::new();
+
+        for token in st0x_tokens {
+            match unwrapped_address(token) {
+                Ok(expected_asset_address) => inputs.push(WrapRatioBatchInput {
+                    token,
+                    expected_asset_address,
+                }),
+                Err(error) => {
+                    tracing::error!(
+                        share_address = %token.address,
+                        error = %error,
+                        "failed to read wrapped token ratio"
+                    );
+                    errors.push(WrapRatioErrorResponse {
+                        share_address: token.address,
+                        message: error.batch_message(),
+                    });
+                }
+            }
+        }
+
+        for group in read_wrap_ratios_batch(&inputs).await? {
+            let metadata = WrapRatioMetadata::from_batch_response(&group.response);
+
+            if group.response.items.len() != group.input_indices.len() {
+                tracing::error!(
+                    expected = group.input_indices.len(),
+                    actual = group.response.items.len(),
+                    "ERC4626 batch response item count mismatch"
+                );
+            }
+
+            for index in group.input_indices {
+                let Some(input) = inputs.get(index) else {
+                    continue;
+                };
+
+                let row = find_wrap_ratio_item(&group.response.items, input.token.address)
+                    .and_then(|item| {
+                        build_wrap_ratio_response(item, input.expected_asset_address, &metadata)
+                    });
+
+                match row {
+                    Ok(row) => data.push(row),
+                    Err(error) => {
+                        tracing::error!(
+                            share_address = %input.token.address,
+                            error = %error,
+                            "failed to read wrapped token ratio"
+                        );
+                        errors.push(WrapRatioErrorResponse {
+                            share_address: input.token.address,
+                            message: error.batch_message(),
+                        });
+                    }
+                }
+            }
+        }
+
+        tracing::info!(
+            data_count = data.len(),
+            error_count = errors.len(),
+            "returning wrapped token ratios"
+        );
+        Ok(Json(WrapRatioBatchResponse { data, errors }))
+    }
+    .instrument(span.0)
+    .await
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/tokens/wrap-ratio/{address}",
+    tag = "Tokens",
+    security(("basicAuth" = [])),
+    params(
+        ("address" = String, Path, description = "Wrapped token / ERC4626 vault address")
+    ),
+    responses(
+        (status = 200, description = "Wrapped token ratio", body = WrapRatioResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 404, description = "Wrapped ST0x token not found", body = ApiErrorResponse),
+        (status = 422, description = "Invalid wrapped token address", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[get("/wrap-ratio/<address>")]
+pub async fn get_wrap_ratio_by_address(
+    _global: GlobalRateLimit,
+    _key: AuthenticatedKey,
+    span: TracingSpan,
+    shared_raindex: &State<SharedRaindexProvider>,
+    address: ValidatedAddress,
+) -> Result<Json<WrapRatioResponse>, ApiError> {
+    async move {
+        tracing::info!(share_address = %address.0, "request received");
+
+        let tokens = registry_tokens(shared_raindex).await?;
+        let Some(token) = tokens
+            .iter()
+            .find(|token| token.address == address.0 && is_st0x_token(token))
+        else {
+            tracing::warn!(share_address = %address.0, "wrapped ST0x token not found");
+            return Err(ApiError::NotFound("wrapped ST0x token not found".into()));
+        };
+
+        let expected_asset_address = unwrapped_address(token).map_err(|error| {
+            tracing::error!(
+                share_address = %token.address,
+                error = %error,
+                "failed to read wrapped token ratio"
+            );
+            error.into_api_error()
+        })?;
+
+        let inputs = vec![WrapRatioBatchInput {
+            token,
+            expected_asset_address,
+        }];
+        let mut groups = read_wrap_ratios_batch(&inputs).await?;
+        let group = groups.pop().ok_or_else(|| {
+            tracing::error!(
+                share_address = %token.address,
+                "ERC4626 batch response did not include requested token"
+            );
+            ApiError::Internal("failed to read ERC4626 ratio".into())
+        })?;
+
+        if group.response.items.len() != 1 {
+            tracing::error!(
+                expected = 1,
+                actual = group.response.items.len(),
+                "ERC4626 batch response item count mismatch"
+            );
+            return Err(ApiError::Internal("failed to read ERC4626 ratio".into()));
+        }
+
+        let metadata = WrapRatioMetadata::from_batch_response(&group.response);
+        let item = find_wrap_ratio_item(&group.response.items, token.address).map_err(|error| {
+            tracing::error!(
+                share_address = %token.address,
+                error = %error,
+                "failed to read wrapped token ratio"
+            );
+            error.into_api_error()
+        })?;
+
+        let response = build_wrap_ratio_response(item, expected_asset_address, &metadata).map_err(
+            |error| {
+                tracing::error!(
+                    share_address = %token.address,
+                    error = %error,
+                    "failed to read wrapped token ratio"
+                );
+                error.into_api_error()
+            },
+        )?;
+
+        tracing::info!(share_address = %token.address, "returning wrapped token ratio");
+        Ok(Json(response))
+    }
+    .instrument(span.0)
+    .await
+}
+
 pub fn routes() -> Vec<Route> {
-    rocket::routes![get_tokens]
+    rocket::routes![get_tokens, get_wrap_ratios, get_wrap_ratio_by_address]
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{find_wrap_ratio_item, WrapRatioLookupError};
     use crate::test_helpers::{
         basic_auth_header, mock_raindex_registry_url_with_settings_and_tokens, seed_api_key,
         TestClientBuilder,
     };
+    use alloy::primitives::{address, Address, U256};
+    use alloy::providers::bindings::IMulticall3::{
+        aggregate3Call, aggregateCall, aggregateReturn, getCurrentBlockTimestampCall,
+        Result as Multicall3Result,
+    };
+    use alloy::{hex::encode_prefixed, sol_types::SolCall};
+    use rain_erc::erc4626::{
+        Erc4626BatchItem,
+        IERC20Metadata::decimalsCall as erc20DecimalsCall,
+        IERC4626::{assetCall, convertToAssetsCall, decimalsCall as erc4626DecimalsCall},
+    };
     use rocket::http::{Header, Status};
+    use serde_json::json;
+
+    const WT_MSTR: Address = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
+    const T_MSTR: Address = address!("013b782f402d61aa1004cca95b9f5bb402c9d5fe");
+    const WT_SECOND: Address = address!("3333333333333333333333333333333333333333");
+    const T_SECOND: Address = address!("4444444444444444444444444444444444444444");
+    const WT_BAD: Address = address!("1111111111111111111111111111111111111111");
+    const T_BAD: Address = address!("2222222222222222222222222222222222222222");
+
+    fn batch_item(vault_address: Address) -> Erc4626BatchItem {
+        Erc4626BatchItem {
+            vault_address,
+            success: false,
+            data: None,
+            error: Some("failed".to_string()),
+        }
+    }
+
+    fn success_result<C: SolCall>(value: &C::Return) -> Multicall3Result {
+        Multicall3Result {
+            success: true,
+            returnData: C::abi_encode_returns(value).into(),
+        }
+    }
+
+    fn failed_result() -> Multicall3Result {
+        Multicall3Result {
+            success: false,
+            returnData: Vec::<u8>::new().into(),
+        }
+    }
+
+    fn timestamp_success(block_number: u64, timestamp: u64) -> String {
+        let ret = aggregateReturn {
+            blockNumber: U256::from(block_number),
+            returnData: vec![
+                getCurrentBlockTimestampCall::abi_encode_returns(&U256::from(timestamp)).into(),
+            ],
+        };
+        encode_prefixed(aggregateCall::abi_encode_returns(&ret))
+    }
+
+    async fn mock_erc4626_batch_rpc(
+        vault: Address,
+        asset: Address,
+        share_decimals: u8,
+        asset_decimals: u8,
+        converted_assets: U256,
+    ) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock rpc");
+        let addr = listener.local_addr().expect("mock rpc address");
+
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4096];
+                    let n = tokio::io::AsyncReadExt::read(&mut socket, &mut buf)
+                        .await
+                        .unwrap_or(0);
+                    let request = String::from_utf8_lossy(&buf[..n]);
+
+                    let request_lower = request.to_ascii_lowercase();
+                    let result = if request.contains("eth_blockNumber") {
+                        json!("0x7b")
+                    } else if request.contains(
+                        encode_prefixed(getCurrentBlockTimestampCall::SELECTOR)
+                            .trim_start_matches("0x"),
+                    ) {
+                        json!(timestamp_success(123, 456))
+                    } else if request.contains(
+                        encode_prefixed(erc4626DecimalsCall::SELECTOR).trim_start_matches("0x"),
+                    ) && (request_lower.contains(
+                        format!("{vault:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase()
+                            .as_str(),
+                    ) || request_lower.contains(
+                        format!("{WT_BAD:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase()
+                            .as_str(),
+                    )) {
+                        let vault_hex = format!("{vault:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase();
+                        let bad_hex = format!("{WT_BAD:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase();
+                        let mut targets = Vec::new();
+                        if let Some(index) = request_lower.find(&vault_hex) {
+                            targets.push(index);
+                        }
+                        if let Some(index) = request_lower.find(&bad_hex) {
+                            targets.push(index);
+                        }
+                        targets.sort();
+
+                        let results = targets
+                            .into_iter()
+                            .map(|_| success_result::<erc4626DecimalsCall>(&share_decimals))
+                            .collect::<Vec<_>>();
+
+                        json!(encode_prefixed(aggregate3Call::abi_encode_returns(
+                            &results
+                        )))
+                    } else if request
+                        .contains(encode_prefixed(assetCall::SELECTOR).trim_start_matches("0x"))
+                    {
+                        let vault_hex = format!("{vault:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase();
+                        let bad_hex = format!("{WT_BAD:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase();
+                        let mut targets = Vec::new();
+                        if let Some(index) = request_lower.find(&vault_hex) {
+                            targets.push((index, false));
+                        }
+                        if let Some(index) = request_lower.find(&bad_hex) {
+                            targets.push((index, true));
+                        }
+                        targets.sort_by_key(|(index, _)| *index);
+
+                        let mut results = Vec::with_capacity(targets.len());
+                        for (_, is_bad) in targets {
+                            if is_bad {
+                                results.push(failed_result());
+                            } else {
+                                results.push(success_result::<assetCall>(&asset));
+                            }
+                        }
+
+                        json!(encode_prefixed(aggregate3Call::abi_encode_returns(
+                            &results
+                        )))
+                    } else if request.contains(
+                        encode_prefixed(erc20DecimalsCall::SELECTOR).trim_start_matches("0x"),
+                    ) && request_lower.contains(
+                        format!("{asset:#x}")
+                            .trim_start_matches("0x")
+                            .to_ascii_lowercase()
+                            .as_str(),
+                    ) {
+                        let results = vec![success_result::<erc20DecimalsCall>(&asset_decimals)];
+                        json!(encode_prefixed(aggregate3Call::abi_encode_returns(
+                            &results
+                        )))
+                    } else if request.contains(
+                        encode_prefixed(convertToAssetsCall::SELECTOR).trim_start_matches("0x"),
+                    ) {
+                        let results =
+                            vec![success_result::<convertToAssetsCall>(&converted_assets)];
+                        json!(encode_prefixed(aggregate3Call::abi_encode_returns(
+                            &results
+                        )))
+                    } else {
+                        json!("0x")
+                    };
+
+                    let body = json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": result,
+                    })
+                    .to_string();
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ =
+                        tokio::io::AsyncWriteExt::write_all(&mut socket, response.as_bytes()).await;
+                });
+            }
+        });
+
+        format!("http://{addr}/rpc")
+    }
+
+    async fn wrap_ratio_client(rpc_url: &str) -> rocket::local::asynchronous::Client {
+        let settings = format!(
+            r#"version: 6
+networks:
+  base:
+    rpcs:
+      - {rpc_url}
+    chain-id: 8453
+    currency: ETH
+subgraphs:
+  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn
+raindexes:
+  base:
+    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7
+    network: base
+    subgraph: base
+    deployment-block: 0
+deployers:
+  base:
+    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
+    network: base
+using-tokens-from:
+  - __TOKENS_URL__
+"#
+        );
+        let remote_tokens = format!(
+            r#"{{
+  "name": "ST0x Base Token List",
+  "timestamp": "2026-06-02T00:00:00.000Z",
+  "version": {{
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  }},
+  "tokens": [
+    {{
+      "chainId": 8453,
+      "address": "{WT_MSTR:#x}",
+      "decimals": 18,
+      "name": "Wrapped MicroStrategy ST0x",
+      "symbol": "wtMSTR",
+      "extensions": {{
+        "category": "ST0x",
+        "unwrappedAddress": "{T_MSTR:#x}"
+      }}
+    }},
+    {{
+      "chainId": 8453,
+      "address": "{T_MSTR:#x}",
+      "decimals": 18,
+      "name": "MicroStrategy ST0x",
+      "symbol": "tMSTR"
+    }},
+    {{
+      "chainId": 8453,
+      "address": "{WT_BAD:#x}",
+      "decimals": 18,
+      "name": "Bad Wrapped ST0x",
+      "symbol": "wtBAD",
+      "extensions": {{
+        "category": "ST0x",
+        "unwrappedAddress": "{T_BAD:#x}"
+      }}
+    }},
+    {{
+      "chainId": 8453,
+      "address": "0x4200000000000000000000000000000000000006",
+      "decimals": 18,
+      "name": "Wrapped Ether",
+      "symbol": "WETH"
+    }}
+  ]
+}}"#
+        );
+        let registry_url =
+            mock_raindex_registry_url_with_settings_and_tokens(&settings, &remote_tokens).await;
+        let config = crate::raindex::RaindexProvider::load(&registry_url, None)
+            .await
+            .expect("load raindex config");
+        TestClientBuilder::new()
+            .raindex_config(config)
+            .build()
+            .await
+    }
+
+    async fn wrap_ratio_multi_network_client(
+        base_rpc_url: &str,
+        polygon_rpc_url: &str,
+    ) -> rocket::local::asynchronous::Client {
+        let settings = format!(
+            r#"version: 6
+networks:
+  base:
+    rpcs:
+      - {base_rpc_url}
+    chain-id: 8453
+    currency: ETH
+  polygon:
+    rpcs:
+      - {polygon_rpc_url}
+    chain-id: 137
+    currency: POL
+subgraphs:
+  base: https://api.goldsky.com/api/public/project_clv14x04y9kzi01saerx7bxpg/subgraphs/ob4-base/0.9/gn
+raindexes:
+  base:
+    address: 0xd2938e7c9fe3597f78832ce780feb61945c377d7
+    network: base
+    subgraph: base
+    deployment-block: 0
+deployers:
+  base:
+    address: 0xC1A14cE2fd58A3A2f99deCb8eDd866204eE07f8D
+    network: base
+using-tokens-from:
+  - __TOKENS_URL__
+"#
+        );
+        let remote_tokens = format!(
+            r#"{{
+  "name": "ST0x Multi Network Token List",
+  "timestamp": "2026-06-02T00:00:00.000Z",
+  "version": {{
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  }},
+  "tokens": [
+    {{
+      "chainId": 8453,
+      "address": "{WT_MSTR:#x}",
+      "decimals": 18,
+      "name": "Wrapped MicroStrategy ST0x",
+      "symbol": "wtMSTR",
+      "extensions": {{
+        "category": "ST0x",
+        "unwrappedAddress": "{T_MSTR:#x}"
+      }}
+    }},
+    {{
+      "chainId": 137,
+      "address": "{WT_SECOND:#x}",
+      "decimals": 18,
+      "name": "Wrapped Second ST0x",
+      "symbol": "wtSECOND",
+      "extensions": {{
+        "category": "ST0x",
+        "unwrappedAddress": "{T_SECOND:#x}"
+      }}
+    }}
+  ]
+}}"#
+        );
+        let registry_url =
+            mock_raindex_registry_url_with_settings_and_tokens(&settings, &remote_tokens).await;
+        let config = crate::raindex::RaindexProvider::load(&registry_url, None)
+            .await
+            .expect("load raindex config");
+        TestClientBuilder::new()
+            .raindex_config(config)
+            .build()
+            .await
+    }
 
     #[rocket::async_test]
     async fn test_get_tokens_returns_token_list() {
@@ -334,5 +1174,163 @@ using-tokens-from:
             first["isin"],
             serde_json::Value::String("US1725731079".to_string())
         );
+    }
+
+    #[rocket::async_test]
+    async fn test_get_wrap_ratios_returns_data_and_per_token_errors() {
+        let rpc_url =
+            mock_erc4626_batch_rpc(WT_MSTR, T_MSTR, 18, 18, U256::from(10).pow(U256::from(18)))
+                .await;
+        let client = wrap_ratio_client(&rpc_url).await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+
+        let response = client
+            .get("/v1/tokens/wrap-ratio")
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        let data = body["data"].as_array().expect("data is an array");
+        let errors = body["errors"].as_array().expect("errors is an array");
+        assert_eq!(data.len(), 1);
+        assert_eq!(errors.len(), 1);
+
+        assert_eq!(data[0]["shareAddress"], format!("{WT_MSTR:#x}"));
+        assert_eq!(data[0]["assetAddress"], format!("{T_MSTR:#x}"));
+        assert_eq!(data[0]["assetsPerShare"], "1.0");
+        assert_eq!(data[0]["blockNumber"], 123);
+        assert_eq!(data[0]["blockTimestamp"], 456);
+        assert!(data[0]["capturedAt"].as_str().is_some());
+
+        assert_eq!(errors[0]["shareAddress"], format!("{WT_BAD:#x}"));
+        assert_eq!(errors[0]["message"], "failed to read ERC4626 ratio");
+    }
+
+    #[test]
+    fn test_find_wrap_ratio_item_rejects_missing_and_duplicate_items() {
+        let items = vec![batch_item(WT_BAD)];
+        let missing = find_wrap_ratio_item(&items, WT_MSTR).expect_err("missing item");
+        assert!(matches!(missing, WrapRatioLookupError::MissingBatchItem));
+
+        let items = vec![batch_item(WT_MSTR), batch_item(WT_MSTR)];
+        let duplicate = find_wrap_ratio_item(&items, WT_MSTR).expect_err("duplicate item");
+        assert!(matches!(
+            duplicate,
+            WrapRatioLookupError::DuplicateBatchItem
+        ));
+    }
+
+    #[rocket::async_test]
+    async fn test_get_wrap_ratios_batches_tokens_by_network() {
+        let base_rpc_url =
+            mock_erc4626_batch_rpc(WT_MSTR, T_MSTR, 18, 18, U256::from(10).pow(U256::from(18)))
+                .await;
+        let polygon_rpc_url = mock_erc4626_batch_rpc(
+            WT_SECOND,
+            T_SECOND,
+            18,
+            18,
+            U256::from(3_000_000_000_000_000_000u128),
+        )
+        .await;
+        let client = wrap_ratio_multi_network_client(&base_rpc_url, &polygon_rpc_url).await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+
+        let response = client
+            .get("/v1/tokens/wrap-ratio")
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        let data = body["data"].as_array().expect("data is an array");
+        let errors = body["errors"].as_array().expect("errors is an array");
+        assert_eq!(data.len(), 2);
+        assert!(errors.is_empty());
+
+        assert!(data
+            .iter()
+            .any(|row| row["shareAddress"] == format!("{WT_MSTR:#x}")
+                && row["assetAddress"] == format!("{T_MSTR:#x}")
+                && row["assetsPerShare"] == "1.0"));
+        assert!(data
+            .iter()
+            .any(|row| row["shareAddress"] == format!("{WT_SECOND:#x}")
+                && row["assetAddress"] == format!("{T_SECOND:#x}")
+                && row["assetsPerShare"] == "3"));
+    }
+
+    #[rocket::async_test]
+    async fn test_get_wrap_ratio_by_address_returns_row() {
+        let rpc_url = mock_erc4626_batch_rpc(
+            WT_MSTR,
+            T_MSTR,
+            18,
+            18,
+            U256::from(2_000_000_000_000_000_000u128),
+        )
+        .await;
+        let client = wrap_ratio_client(&rpc_url).await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+
+        let response = client
+            .get(format!("/v1/tokens/wrap-ratio/{WT_MSTR:#x}"))
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value =
+            serde_json::from_str(&response.into_string().await.unwrap()).unwrap();
+        assert_eq!(body["shareAddress"], format!("{WT_MSTR:#x}"));
+        assert_eq!(body["assetAddress"], format!("{T_MSTR:#x}"));
+        assert_eq!(body["assetsPerShare"], "2");
+        assert_eq!(body["blockNumber"], 123);
+        assert_eq!(body["blockTimestamp"], 456);
+        assert!(body["capturedAt"].as_str().is_some());
+    }
+
+    #[rocket::async_test]
+    async fn test_get_wrap_ratio_by_address_rejects_symbol_lookup() {
+        let rpc_url =
+            mock_erc4626_batch_rpc(WT_MSTR, T_MSTR, 18, 18, U256::from(10).pow(U256::from(18)))
+                .await;
+        let client = wrap_ratio_client(&rpc_url).await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+
+        let response = client
+            .get("/v1/tokens/wrap-ratio/wtMSTR")
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    #[rocket::async_test]
+    async fn test_get_wrap_ratio_by_address_returns_not_found_for_non_st0x_token() {
+        let rpc_url =
+            mock_erc4626_batch_rpc(WT_MSTR, T_MSTR, 18, 18, U256::from(10).pow(U256::from(18)))
+                .await;
+        let client = wrap_ratio_client(&rpc_url).await;
+        let (key_id, secret) = seed_api_key(&client).await;
+        let header = basic_auth_header(&key_id, &secret);
+
+        let response = client
+            .get("/v1/tokens/wrap-ratio/0x4200000000000000000000000000000000000006")
+            .header(Header::new("Authorization", header))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::NotFound);
     }
 }


### PR DESCRIPTION
## Dependent PRs

- Depends on rainlanguage/rain.erc#32 for ERC4626 read support.
- Pinned dependency: `rain-erc` at `755b0bf5cad18a2cc43a57be52298b6dadd96751`.
- This replaces the old rainlanguage/raindex#2616 dependency; the REST API now calls `rain-erc` directly through a local adapter instead of using orderbook/raindex for ERC4626 reads.

## Motivation

ST0x clients need REST access to ERC4626 wrapped-token ratios for wrapped wtStock vault tokens, including consistent block metadata and partial failure reporting across all registry ST0x tokens.

## Solution

- Add `rain-erc` as a direct Git dependency pinned to the replacement PR head.
- Add a local ERC4626 adapter that builds Alloy providers from configured registry RPC URLs and tries configured RPCs in order.
- Add `GET /v1/tokens/wrap-ratio` and `GET /v1/tokens/wrap-ratio/{address}`.
- Use `rain_erc::erc4626::batch_share_ratios(...)` for batch and single-address reads.
- Return flat rows with `shareAddress`, `assetAddress`, `assetsPerShare`, `blockNumber`, `blockTimestamp`, and `capturedAt`.
- Filter batch reads to registry tokens with `extensions.category == "ST0x"` and validate `extensions.unwrappedAddress` against the returned ERC4626 asset address.
- Preserve per-token batch errors while returning an `ApiError` for whole batch failures and single-address failures.
- Add Utoipa/OpenAPI annotations and update the token API docs.

## Checks

- `nix develop -c cargo fmt`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test routes::tokens`
- `nix develop -c cargo test routes::swap`
- `nix develop -c cargo test routes::orders`
- `nix develop -c cargo test routes::trades`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /v1/tokens/wrap-ratio (batch) and /v1/tokens/wrap-ratio/{address} (single) endpoints for wrapped-token (ERC‑4626) ratio lookups.
  * Batch responses return successful items in a top-level data array and per-token failures in a top-level errors array without failing the whole request.
  * Single-address route validates wrapper tokens and returns 404/422 for invalid inputs.

* **Documentation**
  * Updated token docs with endpoint behavior, request/response fields, wrapped-token ratio rules, and symbol lookup limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->