### PR TITLE
quote: support unwrapped denomination

### DIFF
--- a/docs/src/swap-flow.md
+++ b/docs/src/swap-flow.md
@@ -1,6 +1,7 @@
 # Swap Flow
 
-Swapping is a two-step process: get a **quote** to preview pricing, then get **calldata** to build the on-chain transaction.
+Swapping is a two-step process: get a **quote** to preview pricing, then get
+**calldata** to build the on-chain transaction.
 
 ## Step 1: Get a Quote
 
@@ -17,15 +18,17 @@ curl -X POST https://api.st0x.io/v1/swap/quote \
   -d '{
     "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "outputToken": "0x4200000000000000000000000000000000000006",
-    "outputAmount": "1.0"
+    "outputAmount": "1.0",
+    "denomination": "wrapped"
   }'
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `inputToken` | string | Address of the token you are selling |
-| `outputToken` | string | Address of the token you want to receive |
-| `outputAmount` | string | Desired output amount (human-readable, e.g. `"1.0"` for 1 WETH) |
+| Field          | Type   | Description                                                                                                                                                                   |
+| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inputToken`   | string | Address of the token you are selling                                                                                                                                          |
+| `outputToken`  | string | Address of the token you want to receive                                                                                                                                      |
+| `outputAmount` | string | Desired output amount (human-readable, e.g. `"1.0"` for 1 WETH)                                                                                                               |
+| `denomination` | string | Optional. `"wrapped"` (default) returns orderbook-denominated values. `"unwrapped"` returns normalized display values for wrapped ST0x/ERC4626 tokens after quote simulation. |
 
 ### Response
 
@@ -34,19 +37,37 @@ curl -X POST https://api.st0x.io/v1/swap/quote \
   "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "outputToken": "0x4200000000000000000000000000000000000006",
   "outputAmount": "1.0",
+  "denomination": "wrapped",
   "estimatedOutput": "1.0",
   "estimatedInput": "2500.0",
   "estimatedIoRatio": "2500.0"
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `estimatedOutput` | string | Expected output amount |
-| `estimatedInput` | string | Expected input amount required |
-| `estimatedIoRatio` | string | Input-to-output ratio |
+| Field              | Type   | Description                                                                       |
+| ------------------ | ------ | --------------------------------------------------------------------------------- |
+| `denomination`     | string | Denomination used for `estimatedOutput`, `estimatedInput`, and `estimatedIoRatio` |
+| `estimatedOutput`  | string | Expected output amount                                                            |
+| `estimatedInput`   | string | Expected input amount required                                                    |
+| `estimatedIoRatio` | string | Input-to-output ratio                                                             |
 
-The quote reflects current orderbook state. Prices may change between quoting and execution.
+The quote reflects current orderbook state. Prices may change between quoting
+and execution.
+
+When `denomination` is omitted or set to `"wrapped"`, quote values use the
+wrapped/orderbook token units required by the swap endpoints. When
+`denomination` is `"unwrapped"`, the API still simulates against the
+wrapped/orderbook `inputToken` and `outputToken` addresses, then normalizes only
+the displayed `estimatedInput`, `estimatedOutput`, and `estimatedIoRatio` for
+wrapped ST0x/ERC4626 tokens. `outputAmount` remains in `outputToken` units and
+is not pre-converted.
+
+Do not pass unwrapped-normalized quote values into other endpoints unless those
+endpoints explicitly support `denomination=unwrapped` and you call them that
+way. In particular, `/v1/swap/calldata` currently expects `outputAmount` and
+`maximumIoRatio` in wrapped/orderbook-denominated units, so using an
+unwrapped-normalized `estimatedIoRatio` as calldata slippage input will produce
+different calculations.
 
 ## Step 2: Get Calldata
 
@@ -69,21 +90,24 @@ curl -X POST https://api.st0x.io/v1/swap/calldata \
   }'
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `taker` | string | Your wallet address that will execute the transaction |
-| `inputToken` | string | Address of the token you are selling |
-| `outputToken` | string | Address of the token you want to receive |
-| `outputAmount` | string | Desired output amount (human-readable) |
-| `maximumIoRatio` | string | Maximum acceptable IO ratio (slippage protection) |
+| Field            | Type   | Description                                           |
+| ---------------- | ------ | ----------------------------------------------------- |
+| `taker`          | string | Your wallet address that will execute the transaction |
+| `inputToken`     | string | Address of the token you are selling                  |
+| `outputToken`    | string | Address of the token you want to receive              |
+| `outputAmount`   | string | Desired output amount (human-readable)                |
+| `maximumIoRatio` | string | Maximum acceptable IO ratio (slippage protection)     |
 
-Set `maximumIoRatio` slightly above the `estimatedIoRatio` from the quote to allow for price movement.
+Set `maximumIoRatio` slightly above the `estimatedIoRatio` from the quote to
+allow for price movement.
 
 ### Response
 
-The response always includes all fields, but the content depends on whether your `taker` address has sufficient token approvals.
+The response always includes all fields, but the content depends on whether your
+`taker` address has sufficient token approvals.
 
-**If approvals are needed**, `data` is empty and `approvals` contains the required transactions:
+**If approvals are needed**, `data` is empty and `approvals` contains the
+required transactions:
 
 ```json
 {
@@ -103,7 +127,8 @@ The response always includes all fields, but the content depends on whether your
 }
 ```
 
-**If approvals are already in place**, `approvals` is empty and `data` contains the swap calldata:
+**If approvals are already in place**, `approvals` is empty and `data` contains
+the swap calldata:
 
 ```json
 {
@@ -115,25 +140,28 @@ The response always includes all fields, but the content depends on whether your
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `to` | string | Contract address to send the transaction to |
-| `data` | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed |
-| `value` | string | Native token value to send (usually `"0x0"`) |
-| `estimatedInput` | string | Expected input amount |
-| `approvals` | array | Token approvals needed — if non-empty, approve first then call this endpoint again |
+| Field            | Type   | Description                                                                        |
+| ---------------- | ------ | ---------------------------------------------------------------------------------- |
+| `to`             | string | Contract address to send the transaction to                                        |
+| `data`           | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed            |
+| `value`          | string | Native token value to send (usually `"0x0"`)                                       |
+| `estimatedInput` | string | Expected input amount                                                              |
+| `approvals`      | array  | Token approvals needed — if non-empty, approve first then call this endpoint again |
 
 ## Step 3: Handle Approvals
 
 If the `approvals` array is **not empty**, send the approval transactions first:
 
-1. For each approval, send a transaction to the `token` address with `approvalData` as calldata
+1. For each approval, send a transaction to the `token` address with
+   `approvalData` as calldata
 2. Wait for confirmation
-3. **Call the calldata endpoint again** — with approvals in place, the response will now contain the swap calldata
+3. **Call the calldata endpoint again** — with approvals in place, the response
+   will now contain the swap calldata
 
 ## Step 4: Execute the Swap
 
-Once you receive a response with an empty `approvals` array, send the main transaction using `to`, `data`, and `value`.
+Once you receive a response with an empty `approvals` array, send the main
+transaction using `to`, `data`, and `value`.
 
 ## Complete Example
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod registry_artifact;
 mod routes;
 mod telemetry;
 mod types;
+mod wrap_ratio;
 
 pub(crate) const CHAIN_ID: u32 = 8453;
 

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -4,6 +4,7 @@ mod quote;
 use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
 use crate::types::swap::SwapCalldataResponse;
+use crate::wrap_ratio::{read_wrap_ratio_values_for_addresses, WrapRatioValue};
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::orders::{
@@ -16,6 +17,7 @@ use rain_orderbook_common::take_orders::{
     build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate,
 };
 use rocket::Route;
+use std::collections::HashMap;
 
 #[async_trait]
 pub(crate) trait SwapDataSource: Send + Sync {
@@ -42,6 +44,13 @@ pub(crate) trait SwapDataSource: Send + Sync {
         &self,
         request: TakeOrdersRequest,
     ) -> Result<SwapCalldataResponse, ApiError>;
+
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        _token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        Ok(HashMap::new())
+    }
 }
 
 pub(crate) struct RaindexSwapDataSource<'a> {
@@ -205,6 +214,23 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 "unexpected calldata result state".into(),
             ))
         }
+    }
+
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        let tokens: Vec<_> = self
+            .client
+            .get_all_tokens()
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to retrieve curated tokens");
+                ApiError::Internal("failed to retrieve curated tokens".into())
+            })?
+            .into_values()
+            .collect();
+
+        read_wrap_ratio_values_for_addresses(&tokens, token_addresses).await
     }
 }
 

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -3,12 +3,13 @@ use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::swap::{SwapQuoteRequest, SwapQuoteResponse};
+use crate::types::swap::{SwapQuoteDenomination, SwapQuoteRequest, SwapQuoteResponse};
+use alloy::primitives::Address;
 use rain_math_float::Float;
 use rain_orderbook_common::take_orders::simulate_buy_over_candidates;
 use rocket::serde::json::Json;
 use rocket::State;
-use std::ops::Div;
+use std::ops::{Div, Mul};
 use tracing::Instrument;
 
 #[utoipa::path(
@@ -22,6 +23,7 @@ use tracing::Instrument;
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 404, description = "No liquidity found", body = ApiErrorResponse),
+        (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
@@ -94,17 +96,27 @@ async fn process_swap_quote(
         return Err(ApiError::NotFound("no valid quotes available".into()));
     }
 
-    let blended_ratio = sim.total_input.div(sim.total_output).map_err(|e| {
+    let (estimated_input, estimated_output) = normalize_quote_amounts(
+        ds,
+        req.denomination,
+        req.input_token,
+        req.output_token,
+        sim.total_input,
+        sim.total_output,
+    )
+    .await?;
+
+    let blended_ratio = estimated_input.div(estimated_output).map_err(|e| {
         tracing::error!(error = %e, "failed to compute blended ratio");
         ApiError::Internal("failed to compute ratio".into())
     })?;
 
-    let formatted_output = sim.total_output.format().map_err(|e| {
+    let formatted_output = estimated_output.format().map_err(|e| {
         tracing::error!(error = %e, "failed to format estimated output");
         ApiError::Internal("failed to format estimated output".into())
     })?;
 
-    let formatted_input = sim.total_input.format().map_err(|e| {
+    let formatted_input = estimated_input.format().map_err(|e| {
         tracing::error!(error = %e, "failed to format estimated input");
         ApiError::Internal("failed to format estimated input".into())
     })?;
@@ -118,9 +130,67 @@ async fn process_swap_quote(
         input_token: req.input_token,
         output_token: req.output_token,
         output_amount: req.output_amount,
+        denomination: req.denomination,
         estimated_output: formatted_output,
         estimated_input: formatted_input,
         estimated_io_ratio: formatted_ratio,
+    })
+}
+
+async fn normalize_quote_amounts(
+    ds: &dyn SwapDataSource,
+    denomination: SwapQuoteDenomination,
+    input_token: Address,
+    output_token: Address,
+    estimated_input: Float,
+    estimated_output: Float,
+) -> Result<(Float, Float), ApiError> {
+    match denomination {
+        SwapQuoteDenomination::Wrapped => Ok((estimated_input, estimated_output)),
+        SwapQuoteDenomination::Unwrapped => {
+            tracing::info!("normalizing swap quote response to unwrapped denomination");
+            let ratios = ds
+                .get_wrap_ratios_for_tokens(&[input_token, output_token])
+                .await?;
+
+            let converted_input = match ratios.get(&input_token) {
+                Some(ratio) => {
+                    tracing::info!(
+                        share_address = %ratio.share_address,
+                        assets_per_share = %ratio.assets_per_share,
+                        "normalizing estimated input to unwrapped denomination"
+                    );
+                    convert_wrapped_amount(estimated_input, &ratio.assets_per_share)?
+                }
+                None => estimated_input,
+            };
+
+            let converted_output = match ratios.get(&output_token) {
+                Some(ratio) => {
+                    tracing::info!(
+                        share_address = %ratio.share_address,
+                        assets_per_share = %ratio.assets_per_share,
+                        "normalizing estimated output to unwrapped denomination"
+                    );
+                    convert_wrapped_amount(estimated_output, &ratio.assets_per_share)?
+                }
+                None => estimated_output,
+            };
+
+            Ok((converted_input, converted_output))
+        }
+    }
+}
+
+fn convert_wrapped_amount(amount: Float, assets_per_share: &str) -> Result<Float, ApiError> {
+    let ratio = Float::parse(assets_per_share.to_string()).map_err(|e| {
+        tracing::error!(error = %e, "failed to parse wrapped token ratio");
+        ApiError::Internal("failed to read wrapped token ratio".into())
+    })?;
+
+    amount.mul(ratio).map_err(|e| {
+        tracing::error!(error = %e, "failed to normalize wrapped token amount");
+        ApiError::Internal("failed to normalize wrapped token amount".into())
     })
 }
 
@@ -129,8 +199,11 @@ mod tests {
     use super::*;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
+    use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::address;
+    use async_trait::async_trait;
     use rocket::http::{ContentType, Status};
+    use std::collections::HashMap;
 
     const USDC: alloy::primitives::Address = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
     const WETH: alloy::primitives::Address = address!("4200000000000000000000000000000000000006");
@@ -140,6 +213,91 @@ mod tests {
             input_token: USDC,
             output_token: WETH,
             output_amount: output_amount.to_string(),
+            denomination: SwapQuoteDenomination::Wrapped,
+        }
+    }
+
+    fn unwrapped_quote_request(
+        input_token: alloy::primitives::Address,
+        output_token: alloy::primitives::Address,
+        output_amount: &str,
+    ) -> SwapQuoteRequest {
+        SwapQuoteRequest {
+            input_token,
+            output_token,
+            output_amount: output_amount.to_string(),
+            denomination: SwapQuoteDenomination::Unwrapped,
+        }
+    }
+
+    fn wrap_ratio(
+        share_address: alloy::primitives::Address,
+        assets_per_share: &str,
+    ) -> WrapRatioValue {
+        WrapRatioValue {
+            share_address,
+            assets_per_share: assets_per_share.to_string(),
+        }
+    }
+
+    struct MockQuoteDataSource {
+        base: MockSwapDataSource,
+        wrap_ratios: HashMap<alloy::primitives::Address, WrapRatioValue>,
+    }
+
+    #[async_trait]
+    impl SwapDataSource for MockQuoteDataSource {
+        async fn validate_supported_tokens(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<(), ApiError> {
+            self.base
+                .validate_supported_tokens(input_token, output_token)
+                .await
+        }
+
+        async fn get_orders_for_pair(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder>, ApiError>
+        {
+            self.base
+                .get_orders_for_pair(input_token, output_token)
+                .await
+        }
+
+        async fn build_candidates_for_pair(
+            &self,
+            orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+            self.base
+                .build_candidates_for_pair(orders, input_token, output_token)
+                .await
+        }
+
+        async fn get_calldata(
+            &self,
+            request: rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest,
+        ) -> Result<crate::types::swap::SwapCalldataResponse, ApiError> {
+            self.base.get_calldata(request).await
+        }
+
+        async fn get_wrap_ratios_for_tokens(
+            &self,
+            token_addresses: &[alloy::primitives::Address],
+        ) -> Result<HashMap<alloy::primitives::Address, WrapRatioValue>, ApiError> {
+            Ok(token_addresses
+                .iter()
+                .filter_map(|address| {
+                    self.wrap_ratios
+                        .get(address)
+                        .map(|ratio| (*address, ratio.clone()))
+                })
+                .collect())
         }
     }
 
@@ -156,6 +314,7 @@ mod tests {
         assert_eq!(result.input_token, USDC);
         assert_eq!(result.output_token, WETH);
         assert_eq!(result.output_amount, "100");
+        assert_eq!(result.denomination, SwapQuoteDenomination::Wrapped);
         assert_eq!(result.estimated_output, "100");
         assert_eq!(result.estimated_input, "150");
         assert_eq!(result.estimated_io_ratio, "1.5");
@@ -208,6 +367,105 @@ mod tests {
 
         assert_eq!(result.estimated_io_ratio, "1.5");
         assert_eq!(result.estimated_input, "15");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_unwrapped_converts_input_amount_and_ratio() {
+        let wt_mstr = address!("Ff05e1BD696900DC6A52cA35cA61bB1024eDA8e2");
+        let ds = MockQuoteDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates: vec![mock_candidate("1000", "1.5")],
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            wrap_ratios: HashMap::from([(wt_mstr, wrap_ratio(wt_mstr, "2"))]),
+        };
+
+        let result = process_swap_quote(&ds, unwrapped_quote_request(wt_mstr, WETH, "100"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.output_amount, "100");
+        assert_eq!(result.estimated_output, "100");
+        assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.estimated_io_ratio, "3");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_unwrapped_converts_output_amount_and_ratio() {
+        let wt_mstr = address!("Ff05e1BD696900DC6A52cA35cA61bB1024eDA8e2");
+        let ds = MockQuoteDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates: vec![mock_candidate("1000", "1.5")],
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            wrap_ratios: HashMap::from([(wt_mstr, wrap_ratio(wt_mstr, "2"))]),
+        };
+
+        let result = process_swap_quote(&ds, unwrapped_quote_request(USDC, wt_mstr, "100"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.output_amount, "100");
+        assert_eq!(result.estimated_output, "200");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.estimated_io_ratio, "0.75");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_unwrapped_converts_both_sides() {
+        let wt_mstr = address!("Ff05e1BD696900DC6A52cA35cA61bB1024eDA8e2");
+        let wt_coin = address!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+        let ds = MockQuoteDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates: vec![mock_candidate("1000", "1.5")],
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            wrap_ratios: HashMap::from([
+                (wt_mstr, wrap_ratio(wt_mstr, "2")),
+                (wt_coin, wrap_ratio(wt_coin, "3")),
+            ]),
+        };
+
+        let result = process_swap_quote(&ds, unwrapped_quote_request(wt_mstr, wt_coin, "100"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.output_amount, "100");
+        assert_eq!(result.estimated_output, "300");
+        assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.estimated_io_ratio, "1");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_unwrapped_noop_for_non_wrapped_tokens() {
+        let ds = MockQuoteDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates: vec![mock_candidate("1000", "1.5")],
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            wrap_ratios: HashMap::new(),
+        };
+
+        let result = process_swap_quote(&ds, unwrapped_quote_request(USDC, WETH, "100"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.output_amount, "100");
+        assert_eq!(result.estimated_output, "100");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.estimated_io_ratio, "1.5");
     }
 
     #[rocket::async_test]
@@ -299,5 +557,20 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::BadRequest);
+    }
+
+    #[rocket::async_test]
+    async fn test_swap_quote_422_for_invalid_denomination() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v1/swap/quote")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100","denomination":"invalid"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 }

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -1,18 +1,19 @@
 use crate::auth::AuthenticatedKey;
-use crate::erc4626::batch_share_ratios;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::raindex::SharedRaindexProvider;
 use crate::types::common::ValidatedAddress;
+use crate::wrap_ratio::{
+    build_wrap_ratio_response, find_wrap_ratio_item, is_st0x_token, read_wrap_ratios_batch,
+    unwrapped_address, WrapRatioBatchInput, WrapRatioMetadata, WrapRatioResponse,
+};
 use alloy::primitives::Address;
-use rain_erc::erc4626::{Erc4626BatchItem, Erc4626BatchResponse, Erc4626BatchVault};
 use rain_orderbook_app_settings::token::TokenCfg;
 use rain_orderbook_common::raindex_client::RaindexError;
 use rocket::serde::json::Json;
 use rocket::{Route, State};
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::Instrument;
 
@@ -22,23 +23,6 @@ pub struct TokenResponse {
     token: TokenCfg,
     name: Option<String>,
     isin: Option<String>,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct WrapRatioResponse {
-    #[schema(value_type = String, example = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2")]
-    share_address: Address,
-    #[schema(value_type = String, example = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe")]
-    asset_address: Address,
-    #[schema(example = "1.0")]
-    assets_per_share: String,
-    #[schema(example = 123)]
-    block_number: u64,
-    #[schema(nullable = true, example = 456)]
-    block_timestamp: Option<u64>,
-    #[schema(example = "1717351200")]
-    captured_at: String,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -55,22 +39,6 @@ pub struct WrapRatioErrorResponse {
 pub struct WrapRatioBatchResponse {
     data: Vec<WrapRatioResponse>,
     errors: Vec<WrapRatioErrorResponse>,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum WrapRatioLookupError {
-    #[error("missing registry extensions.unwrappedAddress")]
-    MissingUnwrappedAddress,
-    #[error("invalid registry extensions.unwrappedAddress: {0}")]
-    InvalidUnwrappedAddress(String),
-    #[error("registry unwrappedAddress does not match ERC4626 asset")]
-    AssetMismatch,
-    #[error("failed to read ERC4626 ratio: {0}")]
-    BatchItem(String),
-    #[error("ERC4626 batch response did not include requested token")]
-    MissingBatchItem,
-    #[error("ERC4626 batch response included duplicate requested token")]
-    DuplicateBatchItem,
 }
 
 impl From<TokenCfg> for TokenResponse {
@@ -93,47 +61,6 @@ impl From<TokenCfg> for TokenResponse {
     }
 }
 
-impl WrapRatioLookupError {
-    fn into_api_error(self) -> ApiError {
-        match self {
-            WrapRatioLookupError::MissingUnwrappedAddress => {
-                ApiError::Internal("token is missing unwrappedAddress".into())
-            }
-            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
-                ApiError::Internal("token has invalid unwrappedAddress".into())
-            }
-            WrapRatioLookupError::AssetMismatch => {
-                ApiError::Internal("token unwrappedAddress does not match ERC4626 asset".into())
-            }
-            WrapRatioLookupError::BatchItem(_) => {
-                ApiError::Internal("failed to read ERC4626 ratio".into())
-            }
-            WrapRatioLookupError::MissingBatchItem | WrapRatioLookupError::DuplicateBatchItem => {
-                ApiError::Internal("failed to read ERC4626 ratio".into())
-            }
-        }
-    }
-
-    fn batch_message(&self) -> String {
-        match self {
-            WrapRatioLookupError::MissingUnwrappedAddress => {
-                "missing registry unwrappedAddress".to_string()
-            }
-            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
-                "invalid registry unwrappedAddress".to_string()
-            }
-            WrapRatioLookupError::AssetMismatch => {
-                "registry unwrappedAddress does not match ERC4626 asset".to_string()
-            }
-            WrapRatioLookupError::BatchItem(_)
-            | WrapRatioLookupError::MissingBatchItem
-            | WrapRatioLookupError::DuplicateBatchItem => {
-                "failed to read ERC4626 ratio".to_string()
-            }
-        }
-    }
-}
-
 fn sanitize_network(
     network: &rain_orderbook_app_settings::network::NetworkCfg,
 ) -> rain_orderbook_app_settings::network::NetworkCfg {
@@ -151,178 +78,6 @@ fn extract_extension_string(
         Some(Value::Null) | None => None,
         Some(value) => Some(value.to_string()),
     }
-}
-
-fn is_st0x_token(token: &TokenCfg) -> bool {
-    token
-        .extensions
-        .as_ref()
-        .and_then(|extensions| extensions.get("category"))
-        .and_then(Value::as_str)
-        == Some("ST0x")
-}
-
-fn unwrapped_address(token: &TokenCfg) -> Result<Address, WrapRatioLookupError> {
-    let value = token
-        .extensions
-        .as_ref()
-        .and_then(|extensions| extensions.get("unwrappedAddress"))
-        .ok_or(WrapRatioLookupError::MissingUnwrappedAddress)?;
-
-    let Some(address) = value.as_str() else {
-        return Err(WrapRatioLookupError::InvalidUnwrappedAddress(
-            value.to_string(),
-        ));
-    };
-
-    address
-        .parse()
-        .map_err(|_| WrapRatioLookupError::InvalidUnwrappedAddress(address.to_string()))
-}
-
-fn assets_per_share_display(assets_display: String) -> String {
-    if assets_display == "1" {
-        "1.0".to_string()
-    } else {
-        assets_display
-    }
-}
-
-struct WrapRatioBatchInput<'a> {
-    token: &'a TokenCfg,
-    expected_asset_address: Address,
-}
-
-struct WrapRatioMetadata {
-    block_number: u64,
-    block_timestamp: Option<u64>,
-    captured_at: String,
-}
-
-impl WrapRatioMetadata {
-    fn from_batch_response(response: &Erc4626BatchResponse) -> Self {
-        Self {
-            block_number: response.block_number,
-            block_timestamp: Some(response.block_timestamp),
-            captured_at: response.captured_at.to_string(),
-        }
-    }
-}
-
-struct WrapRatioBatchGroupResponse {
-    input_indices: Vec<usize>,
-    response: Erc4626BatchResponse,
-}
-
-fn find_wrap_ratio_item(
-    items: &[Erc4626BatchItem],
-    share_address: Address,
-) -> Result<&Erc4626BatchItem, WrapRatioLookupError> {
-    let mut matches = items
-        .iter()
-        .filter(|item| item.vault_address == share_address);
-    let Some(item) = matches.next() else {
-        tracing::error!(
-            share_address = %share_address,
-            "ERC4626 batch response did not include requested token"
-        );
-        return Err(WrapRatioLookupError::MissingBatchItem);
-    };
-
-    if matches.next().is_some() {
-        tracing::error!(
-            share_address = %share_address,
-            "ERC4626 batch response included duplicate requested token"
-        );
-        return Err(WrapRatioLookupError::DuplicateBatchItem);
-    }
-
-    Ok(item)
-}
-
-fn build_wrap_ratio_response(
-    item: &Erc4626BatchItem,
-    expected_asset_address: Address,
-    metadata: &WrapRatioMetadata,
-) -> Result<WrapRatioResponse, WrapRatioLookupError> {
-    if !item.success {
-        return Err(WrapRatioLookupError::BatchItem(
-            item.error
-                .clone()
-                .unwrap_or_else(|| "failed to read ERC4626 ratio".to_string()),
-        ));
-    }
-
-    let Some(ratio) = item.data.as_ref() else {
-        return Err(WrapRatioLookupError::BatchItem(
-            "missing ERC4626 batch item data".to_string(),
-        ));
-    };
-
-    if ratio.asset_address != expected_asset_address {
-        tracing::error!(
-            share_address = %item.vault_address,
-            expected_asset_address = %expected_asset_address,
-            erc4626_asset_address = %ratio.asset_address,
-            "registry unwrappedAddress does not match ERC4626 asset"
-        );
-        return Err(WrapRatioLookupError::AssetMismatch);
-    }
-
-    Ok(WrapRatioResponse {
-        share_address: item.vault_address,
-        asset_address: expected_asset_address,
-        assets_per_share: assets_per_share_display(ratio.assets_display.clone()),
-        block_number: metadata.block_number,
-        block_timestamp: metadata.block_timestamp,
-        captured_at: metadata.captured_at.clone(),
-    })
-}
-
-async fn read_wrap_ratios_batch(
-    inputs: &[WrapRatioBatchInput<'_>],
-) -> Result<Vec<WrapRatioBatchGroupResponse>, ApiError> {
-    let mut inputs_by_chain: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
-    for (index, input) in inputs.iter().enumerate() {
-        inputs_by_chain
-            .entry(input.token.network.chain_id)
-            .or_default()
-            .push(index);
-    }
-
-    let mut responses = Vec::with_capacity(inputs_by_chain.len());
-    for (chain_id, input_indices) in inputs_by_chain {
-        let Some(first_input_index) = input_indices.first() else {
-            continue;
-        };
-        let Some(first_input) = inputs.get(*first_input_index) else {
-            continue;
-        };
-
-        let vaults = input_indices
-            .iter()
-            .filter_map(|index| inputs.get(*index))
-            .map(|input| Erc4626BatchVault::new(input.token.address))
-            .collect();
-
-        let response = batch_share_ratios(&first_input.token.network.rpcs, vaults, None)
-            .await
-            .map_err(|error| {
-                tracing::error!(
-                    chain_id,
-                    error = %error,
-                    "failed to read ERC4626 batch ratios"
-                );
-                ApiError::Internal("failed to read ERC4626 ratios".into())
-            })?;
-
-        responses.push(WrapRatioBatchGroupResponse {
-            input_indices,
-            response,
-        });
-    }
-
-    Ok(responses)
 }
 
 fn token_lookup_error(error: RaindexError) -> ApiError {
@@ -584,7 +339,6 @@ pub fn routes() -> Vec<Route> {
 
 #[cfg(test)]
 mod tests {
-    use super::{find_wrap_ratio_item, WrapRatioLookupError};
     use crate::test_helpers::{
         basic_auth_header, mock_raindex_registry_url_with_settings_and_tokens, seed_api_key,
         TestClientBuilder,
@@ -596,7 +350,6 @@ mod tests {
     };
     use alloy::{hex::encode_prefixed, sol_types::SolCall};
     use rain_erc::erc4626::{
-        Erc4626BatchItem,
         IERC20Metadata::decimalsCall as erc20DecimalsCall,
         IERC4626::{assetCall, convertToAssetsCall, decimalsCall as erc4626DecimalsCall},
     };
@@ -609,15 +362,6 @@ mod tests {
     const T_SECOND: Address = address!("4444444444444444444444444444444444444444");
     const WT_BAD: Address = address!("1111111111111111111111111111111111111111");
     const T_BAD: Address = address!("2222222222222222222222222222222222222222");
-
-    fn batch_item(vault_address: Address) -> Erc4626BatchItem {
-        Erc4626BatchItem {
-            vault_address,
-            success: false,
-            data: None,
-            error: Some("failed".to_string()),
-        }
-    }
 
     fn success_result<C: SolCall>(value: &C::Return) -> Multicall3Result {
         Multicall3Result {
@@ -1208,20 +952,6 @@ using-tokens-from:
 
         assert_eq!(errors[0]["shareAddress"], format!("{WT_BAD:#x}"));
         assert_eq!(errors[0]["message"], "failed to read ERC4626 ratio");
-    }
-
-    #[test]
-    fn test_find_wrap_ratio_item_rejects_missing_and_duplicate_items() {
-        let items = vec![batch_item(WT_BAD)];
-        let missing = find_wrap_ratio_item(&items, WT_MSTR).expect_err("missing item");
-        assert!(matches!(missing, WrapRatioLookupError::MissingBatchItem));
-
-        let items = vec![batch_item(WT_MSTR), batch_item(WT_MSTR)];
-        let duplicate = find_wrap_ratio_item(&items, WT_MSTR).expect_err("duplicate item");
-        assert!(matches!(
-            duplicate,
-            WrapRatioLookupError::DuplicateBatchItem
-        ));
     }
 
     #[rocket::async_test]

--- a/src/types/swap.rs
+++ b/src/types/swap.rs
@@ -3,6 +3,14 @@ use alloy::primitives::{Address, Bytes, U256};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum SwapQuoteDenomination {
+    #[default]
+    Wrapped,
+    Unwrapped,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapQuoteRequest {
@@ -12,6 +20,9 @@ pub struct SwapQuoteRequest {
     pub output_token: Address,
     #[schema(example = "0.5")]
     pub output_amount: String,
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapQuoteDenomination,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -23,6 +34,8 @@ pub struct SwapQuoteResponse {
     pub output_token: Address,
     #[schema(example = "0.5")]
     pub output_amount: String,
+    #[schema(example = "wrapped")]
+    pub denomination: SwapQuoteDenomination,
     #[schema(example = "0.5")]
     pub estimated_output: String,
     #[schema(example = "1250.75")]

--- a/src/wrap_ratio.rs
+++ b/src/wrap_ratio.rs
@@ -1,0 +1,498 @@
+use crate::erc4626::batch_share_ratios;
+use crate::error::ApiError;
+use alloy::primitives::Address;
+use rain_erc::erc4626::{Erc4626BatchItem, Erc4626BatchResponse, Erc4626BatchVault};
+use rain_orderbook_app_settings::token::TokenCfg;
+use serde::Serialize;
+use serde_json::Value;
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapRatioResponse {
+    #[schema(value_type = String, example = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2")]
+    pub(crate) share_address: Address,
+    #[schema(value_type = String, example = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe")]
+    asset_address: Address,
+    #[schema(example = "1.0")]
+    pub(crate) assets_per_share: String,
+    #[schema(example = 123)]
+    block_number: u64,
+    #[schema(nullable = true, example = 456)]
+    block_timestamp: Option<u64>,
+    #[schema(example = "1717351200")]
+    captured_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WrapRatioValue {
+    pub share_address: Address,
+    pub assets_per_share: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum WrapRatioLookupError {
+    #[error("missing registry extensions.unwrappedAddress")]
+    MissingUnwrappedAddress,
+    #[error("invalid registry extensions.unwrappedAddress: {0}")]
+    InvalidUnwrappedAddress(String),
+    #[error("registry unwrappedAddress does not match ERC4626 asset")]
+    AssetMismatch,
+    #[error("failed to read ERC4626 ratio: {0}")]
+    BatchItem(String),
+    #[error("ERC4626 batch response did not include requested token")]
+    MissingBatchItem,
+    #[error("ERC4626 batch response included duplicate requested token")]
+    DuplicateBatchItem,
+}
+
+impl WrapRatioLookupError {
+    pub(crate) fn into_api_error(self) -> ApiError {
+        match self {
+            WrapRatioLookupError::MissingUnwrappedAddress => {
+                ApiError::Internal("token is missing unwrappedAddress".into())
+            }
+            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
+                ApiError::Internal("token has invalid unwrappedAddress".into())
+            }
+            WrapRatioLookupError::AssetMismatch => {
+                ApiError::Internal("token unwrappedAddress does not match ERC4626 asset".into())
+            }
+            WrapRatioLookupError::BatchItem(_) => {
+                ApiError::Internal("failed to read ERC4626 ratio".into())
+            }
+            WrapRatioLookupError::MissingBatchItem | WrapRatioLookupError::DuplicateBatchItem => {
+                ApiError::Internal("failed to read ERC4626 ratio".into())
+            }
+        }
+    }
+
+    pub(crate) fn batch_message(&self) -> String {
+        match self {
+            WrapRatioLookupError::MissingUnwrappedAddress => {
+                "missing registry unwrappedAddress".to_string()
+            }
+            WrapRatioLookupError::InvalidUnwrappedAddress(_) => {
+                "invalid registry unwrappedAddress".to_string()
+            }
+            WrapRatioLookupError::AssetMismatch => {
+                "registry unwrappedAddress does not match ERC4626 asset".to_string()
+            }
+            WrapRatioLookupError::BatchItem(_)
+            | WrapRatioLookupError::MissingBatchItem
+            | WrapRatioLookupError::DuplicateBatchItem => {
+                "failed to read ERC4626 ratio".to_string()
+            }
+        }
+    }
+}
+
+pub(crate) fn is_st0x_token(token: &TokenCfg) -> bool {
+    token
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get("category"))
+        .and_then(Value::as_str)
+        == Some("ST0x")
+}
+
+pub(crate) fn unwrapped_address(token: &TokenCfg) -> Result<Address, WrapRatioLookupError> {
+    let value = token
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get("unwrappedAddress"))
+        .ok_or(WrapRatioLookupError::MissingUnwrappedAddress)?;
+
+    let Some(address) = value.as_str() else {
+        return Err(WrapRatioLookupError::InvalidUnwrappedAddress(
+            value.to_string(),
+        ));
+    };
+
+    address
+        .parse()
+        .map_err(|_| WrapRatioLookupError::InvalidUnwrappedAddress(address.to_string()))
+}
+
+fn assets_per_share_display(assets_display: String) -> String {
+    if assets_display == "1" {
+        "1.0".to_string()
+    } else {
+        assets_display
+    }
+}
+
+pub(crate) struct WrapRatioBatchInput<'a> {
+    pub token: &'a TokenCfg,
+    pub expected_asset_address: Address,
+}
+
+pub(crate) struct WrapRatioMetadata {
+    block_number: u64,
+    block_timestamp: Option<u64>,
+    captured_at: String,
+}
+
+impl WrapRatioMetadata {
+    pub(crate) fn from_batch_response(response: &Erc4626BatchResponse) -> Self {
+        Self {
+            block_number: response.block_number,
+            block_timestamp: Some(response.block_timestamp),
+            captured_at: response.captured_at.to_string(),
+        }
+    }
+}
+
+pub(crate) struct WrapRatioBatchGroupResponse {
+    pub input_indices: Vec<usize>,
+    pub response: Erc4626BatchResponse,
+}
+
+pub(crate) fn find_wrap_ratio_item(
+    items: &[Erc4626BatchItem],
+    share_address: Address,
+) -> Result<&Erc4626BatchItem, WrapRatioLookupError> {
+    let mut matches = items
+        .iter()
+        .filter(|item| item.vault_address == share_address);
+    let Some(item) = matches.next() else {
+        tracing::error!(
+            share_address = %share_address,
+            "ERC4626 batch response did not include requested token"
+        );
+        return Err(WrapRatioLookupError::MissingBatchItem);
+    };
+
+    if matches.next().is_some() {
+        tracing::error!(
+            share_address = %share_address,
+            "ERC4626 batch response included duplicate requested token"
+        );
+        return Err(WrapRatioLookupError::DuplicateBatchItem);
+    }
+
+    Ok(item)
+}
+
+pub(crate) fn build_wrap_ratio_response(
+    item: &Erc4626BatchItem,
+    expected_asset_address: Address,
+    metadata: &WrapRatioMetadata,
+) -> Result<WrapRatioResponse, WrapRatioLookupError> {
+    if !item.success {
+        return Err(WrapRatioLookupError::BatchItem(
+            item.error
+                .clone()
+                .unwrap_or_else(|| "failed to read ERC4626 ratio".to_string()),
+        ));
+    }
+
+    let Some(ratio) = item.data.as_ref() else {
+        return Err(WrapRatioLookupError::BatchItem(
+            "missing ERC4626 batch item data".to_string(),
+        ));
+    };
+
+    if ratio.asset_address != expected_asset_address {
+        tracing::error!(
+            share_address = %item.vault_address,
+            expected_asset_address = %expected_asset_address,
+            erc4626_asset_address = %ratio.asset_address,
+            "registry unwrappedAddress does not match ERC4626 asset"
+        );
+        return Err(WrapRatioLookupError::AssetMismatch);
+    }
+
+    Ok(WrapRatioResponse {
+        share_address: item.vault_address,
+        asset_address: expected_asset_address,
+        assets_per_share: assets_per_share_display(ratio.assets_display.clone()),
+        block_number: metadata.block_number,
+        block_timestamp: metadata.block_timestamp,
+        captured_at: metadata.captured_at.clone(),
+    })
+}
+
+pub(crate) async fn read_wrap_ratios_batch(
+    inputs: &[WrapRatioBatchInput<'_>],
+) -> Result<Vec<WrapRatioBatchGroupResponse>, ApiError> {
+    let mut inputs_by_chain: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+    for (index, input) in inputs.iter().enumerate() {
+        inputs_by_chain
+            .entry(input.token.network.chain_id)
+            .or_default()
+            .push(index);
+    }
+
+    let mut responses = Vec::with_capacity(inputs_by_chain.len());
+    for (chain_id, input_indices) in inputs_by_chain {
+        let Some(first_input_index) = input_indices.first() else {
+            continue;
+        };
+        let Some(first_input) = inputs.get(*first_input_index) else {
+            continue;
+        };
+
+        let vaults = input_indices
+            .iter()
+            .filter_map(|index| inputs.get(*index))
+            .map(|input| Erc4626BatchVault::new(input.token.address))
+            .collect();
+
+        let response = batch_share_ratios(&first_input.token.network.rpcs, vaults, None)
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    chain_id,
+                    error = %error,
+                    "failed to read ERC4626 batch ratios"
+                );
+                ApiError::Internal("failed to read ERC4626 ratios".into())
+            })?;
+
+        responses.push(WrapRatioBatchGroupResponse {
+            input_indices,
+            response,
+        });
+    }
+
+    Ok(responses)
+}
+
+pub(crate) async fn read_wrap_ratio_values_for_addresses(
+    tokens: &[TokenCfg],
+    share_addresses: &[Address],
+) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+    let requested: HashSet<Address> = share_addresses.iter().copied().collect();
+    let mut inputs = Vec::new();
+
+    for token in tokens
+        .iter()
+        .filter(|token| requested.contains(&token.address) && is_st0x_token(token))
+    {
+        let expected_asset_address = unwrapped_address(token).map_err(|error| {
+            tracing::error!(
+                share_address = %token.address,
+                error = %error,
+                "failed to read wrapped token ratio"
+            );
+            error.into_api_error()
+        })?;
+        inputs.push(WrapRatioBatchInput {
+            token,
+            expected_asset_address,
+        });
+    }
+
+    let mut ratios = HashMap::new();
+    for group in read_wrap_ratios_batch(&inputs).await? {
+        let metadata = WrapRatioMetadata::from_batch_response(&group.response);
+
+        if group.response.items.len() != group.input_indices.len() {
+            tracing::error!(
+                expected = group.input_indices.len(),
+                actual = group.response.items.len(),
+                "ERC4626 batch response item count mismatch"
+            );
+        }
+
+        for index in group.input_indices {
+            let Some(input) = inputs.get(index) else {
+                continue;
+            };
+
+            let row = find_wrap_ratio_item(&group.response.items, input.token.address)
+                .and_then(|item| {
+                    build_wrap_ratio_response(item, input.expected_asset_address, &metadata)
+                })
+                .map_err(|error| {
+                    tracing::error!(
+                        share_address = %input.token.address,
+                        error = %error,
+                        "failed to read wrapped token ratio"
+                    );
+                    error.into_api_error()
+                })?;
+
+            ratios.insert(
+                row.share_address,
+                WrapRatioValue {
+                    share_address: row.share_address,
+                    assets_per_share: row.assets_per_share,
+                },
+            );
+        }
+    }
+
+    Ok(ratios)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{address, Address, U256};
+    use rain_erc::erc4626::{Erc4626BatchItem, Erc4626ShareAssetConversion};
+    use rain_orderbook_app_settings::network::NetworkCfg;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    const WT_MSTR: Address = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
+    const T_MSTR: Address = address!("013b782f402d61aa1004cca95b9f5bb402c9d5fe");
+    const WT_BAD: Address = address!("1111111111111111111111111111111111111111");
+
+    fn token(address: Address, extensions: Option<serde_json::Value>) -> TokenCfg {
+        let extensions = extensions.map(|value| {
+            serde_json::from_value(value).expect("extensions fixture should be an object")
+        });
+        let mut network = NetworkCfg::dummy();
+        network.key = "base".to_string();
+        network.chain_id = 8453;
+        network.network_id = Some(8453);
+        network.currency = Some("ETH".to_string());
+
+        TokenCfg {
+            document: rain_orderbook_app_settings::yaml::default_document(),
+            key: format!("{address:#x}"),
+            address,
+            network: Arc::new(network),
+            decimals: Some(18),
+            label: Some("Wrapped MicroStrategy ST0x".to_string()),
+            symbol: Some("wtMSTR".to_string()),
+            logo_uri: None,
+            extensions,
+        }
+    }
+
+    fn batch_item(vault_address: Address) -> Erc4626BatchItem {
+        Erc4626BatchItem {
+            vault_address,
+            success: false,
+            data: None,
+            error: Some("failed".to_string()),
+        }
+    }
+
+    fn successful_batch_item(vault_address: Address, asset_address: Address) -> Erc4626BatchItem {
+        Erc4626BatchItem {
+            vault_address,
+            success: true,
+            data: Some(Erc4626ShareAssetConversion {
+                share_token_address: vault_address,
+                share_token_decimals: 18,
+                asset_address,
+                asset_decimals: 18,
+                shares: U256::from(1_000_000_000_000_000_000u128),
+                shares_display: "1".to_string(),
+                assets: U256::from(1_000_000_000_000_000_000u128),
+                assets_display: "1".to_string(),
+            }),
+            error: None,
+        }
+    }
+
+    fn metadata() -> WrapRatioMetadata {
+        WrapRatioMetadata {
+            block_number: 123,
+            block_timestamp: Some(456),
+            captured_at: "2026-06-02T13:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_is_st0x_token_reads_category_extension() {
+        let st0x = token(
+            WT_MSTR,
+            Some(json!({
+                "category": "ST0x",
+                "unwrappedAddress": format!("{T_MSTR:#x}")
+            })),
+        );
+        let usdc = token(WT_BAD, None);
+
+        assert!(is_st0x_token(&st0x));
+        assert!(!is_st0x_token(&usdc));
+    }
+
+    #[test]
+    fn test_unwrapped_address_parses_registry_extension() {
+        let wrapped = token(
+            WT_MSTR,
+            Some(json!({
+                "category": "ST0x",
+                "unwrappedAddress": format!("{T_MSTR:#x}")
+            })),
+        );
+
+        let parsed = unwrapped_address(&wrapped).expect("unwrapped address should parse");
+        assert_eq!(parsed, T_MSTR);
+    }
+
+    #[test]
+    fn test_unwrapped_address_rejects_missing_and_invalid_values() {
+        let missing = token(WT_MSTR, Some(json!({ "category": "ST0x" })));
+        let invalid = token(
+            WT_MSTR,
+            Some(json!({
+                "category": "ST0x",
+                "unwrappedAddress": "not-an-address"
+            })),
+        );
+
+        assert!(matches!(
+            unwrapped_address(&missing),
+            Err(WrapRatioLookupError::MissingUnwrappedAddress)
+        ));
+        assert!(matches!(
+            unwrapped_address(&invalid),
+            Err(WrapRatioLookupError::InvalidUnwrappedAddress(_))
+        ));
+    }
+
+    #[test]
+    fn test_find_wrap_ratio_item_rejects_missing_and_duplicate_items() {
+        let items = vec![batch_item(WT_BAD)];
+        let missing = find_wrap_ratio_item(&items, WT_MSTR).expect_err("missing item");
+        assert!(matches!(missing, WrapRatioLookupError::MissingBatchItem));
+
+        let items = vec![batch_item(WT_MSTR), batch_item(WT_MSTR)];
+        let duplicate = find_wrap_ratio_item(&items, WT_MSTR).expect_err("duplicate item");
+        assert!(matches!(
+            duplicate,
+            WrapRatioLookupError::DuplicateBatchItem
+        ));
+    }
+
+    #[test]
+    fn test_build_wrap_ratio_response_maps_successful_item() {
+        let item = successful_batch_item(WT_MSTR, T_MSTR);
+        let response =
+            build_wrap_ratio_response(&item, T_MSTR, &metadata()).expect("ratio should build");
+
+        assert_eq!(response.share_address, WT_MSTR);
+        assert_eq!(response.asset_address, T_MSTR);
+        assert_eq!(response.assets_per_share, "1.0");
+        assert_eq!(response.block_number, 123);
+        assert_eq!(response.block_timestamp, Some(456));
+        assert_eq!(response.captured_at, "2026-06-02T13:00:00Z");
+    }
+
+    #[test]
+    fn test_build_wrap_ratio_response_rejects_asset_mismatch() {
+        let item = successful_batch_item(WT_MSTR, WT_BAD);
+
+        let error =
+            build_wrap_ratio_response(&item, T_MSTR, &metadata()).expect_err("asset mismatch");
+        assert!(matches!(error, WrapRatioLookupError::AssetMismatch));
+    }
+
+    #[test]
+    fn test_batch_item_errors_map_to_api_and_batch_messages() {
+        let lookup_error = WrapRatioLookupError::BatchItem("rpc failed".to_string());
+        assert_eq!(lookup_error.batch_message(), "failed to read ERC4626 ratio");
+
+        let api_error = WrapRatioLookupError::MissingUnwrappedAddress.into_api_error();
+        assert!(
+            matches!(api_error, ApiError::Internal(message) if message == "token is missing unwrappedAddress")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a typed swap quote denomination enum with wrapped as the default
- support denomination=unwrapped by post-normalizing quote response amounts using wrapped token ratios
- document that unwrapped-normalized quote values should not be reused with calldata unless that endpoint supports the same denomination

## Testing
- nix develop -c cargo test routes::swap::quote
- agent reported: nix develop -c cargo fmt
- agent reported: nix develop -c rainix-rs-static
- agent reported: nix develop -c cargo check
- agent reported: nix develop -c cargo test