### PR TITLE
calldata: support unwrapped denomination

### DIFF
--- a/docs/src/swap-flow.md
+++ b/docs/src/swap-flow.md
@@ -64,10 +64,8 @@ is not pre-converted.
 
 Do not pass unwrapped-normalized quote values into other endpoints unless those
 endpoints explicitly support `denomination=unwrapped` and you call them that
-way. In particular, `/v1/swap/calldata` currently expects `outputAmount` and
-`maximumIoRatio` in wrapped/orderbook-denominated units, so using an
-unwrapped-normalized `estimatedIoRatio` as calldata slippage input will produce
-different calculations.
+way. `/v1/swap/calldata` supports the same `denomination` field, but the swap
+still purchases wrapped/orderbook tokens.
 
 ## Step 2: Get Calldata
 
@@ -86,20 +84,28 @@ curl -X POST https://api.st0x.io/v1/swap/calldata \
     "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "outputToken": "0x4200000000000000000000000000000000000006",
     "outputAmount": "1.0",
-    "maximumIoRatio": "2600.0"
+    "maximumIoRatio": "2600.0",
+    "denomination": "wrapped"
   }'
 ```
 
-| Field            | Type   | Description                                           |
-| ---------------- | ------ | ----------------------------------------------------- |
-| `taker`          | string | Your wallet address that will execute the transaction |
-| `inputToken`     | string | Address of the token you are selling                  |
-| `outputToken`    | string | Address of the token you want to receive              |
-| `outputAmount`   | string | Desired output amount (human-readable)                |
-| `maximumIoRatio` | string | Maximum acceptable IO ratio (slippage protection)     |
+| Field            | Type   | Description                                                                                                                                                                     |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `taker`          | string | Your wallet address that will execute the transaction                                                                                                                           |
+| `inputToken`     | string | Wrapped/orderbook token address you are selling                                                                                                                                 |
+| `outputToken`    | string | Wrapped/orderbook token address you want to receive                                                                                                                             |
+| `outputAmount`   | string | Desired output amount in the selected `denomination`                                                                                                                            |
+| `maximumIoRatio` | string | Maximum acceptable IO ratio in the selected `denomination`                                                                                                                      |
+| `denomination`   | string | Optional. `"wrapped"` (default) uses orderbook units. `"unwrapped"` interprets `outputAmount` and `maximumIoRatio` as unwrapped display values for wrapped ST0x/ERC4626 tokens. |
 
 Set `maximumIoRatio` slightly above the `estimatedIoRatio` from the quote to
 allow for price movement.
+
+For calldata, `denomination=unwrapped` only changes how numeric fields are
+interpreted and displayed. The API converts `outputAmount` and `maximumIoRatio`
+to wrapped/orderbook units before generating calldata. Clients must still pass
+the wrapped/orderbook token addresses for `inputToken` and `outputToken`; the
+endpoint does not translate unwrapped asset addresses.
 
 ### Response
 
@@ -115,6 +121,7 @@ required transactions:
   "data": "0x",
   "value": "0x0",
   "estimatedInput": "2500.0",
+  "denomination": "wrapped",
   "approvals": [
     {
       "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
@@ -136,6 +143,7 @@ the swap calldata:
   "data": "0xabcdef...",
   "value": "0x0",
   "estimatedInput": "2500.0",
+  "denomination": "wrapped",
   "approvals": []
 }
 ```
@@ -145,8 +153,13 @@ the swap calldata:
 | `to`             | string | Contract address to send the transaction to                                        |
 | `data`           | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed            |
 | `value`          | string | Native token value to send (usually `"0x0"`)                                       |
-| `estimatedInput` | string | Expected input amount                                                              |
+| `estimatedInput` | string | Expected input amount in the requested `denomination`                              |
+| `denomination`   | string | Denomination used for `estimatedInput`                                             |
 | `approvals`      | array  | Token approvals needed — if non-empty, approve first then call this endpoint again |
+
+Approval entries always describe the actual on-chain approval requirements in
+wrapped/orderbook token units. They are not converted or relabeled when
+`denomination=unwrapped`.
 
 ## Step 3: Handle Approvals
 

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -3,6 +3,9 @@ use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
+use crate::routes::swap::denomination::{
+    normalize_calldata_request_values, normalize_calldata_response,
+};
 use crate::types::swap::{SwapCalldataRequest, SwapCalldataResponse};
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::take_orders::TakeOrdersMode;
@@ -21,6 +24,7 @@ use tracing::Instrument;
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 404, description = "No liquidity found", body = ApiErrorResponse),
+        (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
@@ -56,17 +60,28 @@ async fn process_swap_calldata(
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await?;
 
+    let (output_amount, maximum_io_ratio, wrap_ratios) = normalize_calldata_request_values(
+        ds,
+        req.denomination,
+        req.input_token,
+        req.output_token,
+        req.output_amount,
+        req.maximum_io_ratio,
+    )
+    .await?;
+
     let take_req = TakeOrdersRequest {
         taker: req.taker.to_string(),
         chain_id: crate::CHAIN_ID,
         sell_token: req.input_token.to_string(),
         buy_token: req.output_token.to_string(),
         mode: TakeOrdersMode::BuyUpTo,
-        amount: req.output_amount,
-        price_cap: req.maximum_io_ratio,
+        amount: output_amount,
+        price_cap: maximum_io_ratio,
     };
 
-    ds.get_calldata(take_req).await
+    let response = ds.get_calldata(take_req).await?;
+    normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)
 }
 
 #[cfg(test)]
@@ -75,13 +90,20 @@ mod tests {
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::TestClientBuilder;
     use crate::types::common::Approval;
+    use crate::types::swap::SwapDenomination;
+    use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::{address, Address, Bytes, U256};
+    use async_trait::async_trait;
     use rocket::http::{ContentType, Status};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     const USDC: Address = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
     const WETH: Address = address!("4200000000000000000000000000000000000006");
     const TAKER: Address = address!("1111111111111111111111111111111111111111");
     const ORDERBOOK: Address = address!("d2938e7c9fe3597f78832ce780feb61945c377d7");
+    const WT_MSTR: Address = address!("Ff05e1BD696900DC6A52cA35cA61bB1024eDA8e2");
+    const WT_COIN: Address = address!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
 
     fn calldata_request(output_amount: &str, max_ratio: &str) -> SwapCalldataRequest {
         SwapCalldataRequest {
@@ -90,6 +112,23 @@ mod tests {
             output_token: WETH,
             output_amount: output_amount.to_string(),
             maximum_io_ratio: max_ratio.to_string(),
+            denomination: SwapDenomination::Wrapped,
+        }
+    }
+
+    fn unwrapped_calldata_request(
+        input_token: Address,
+        output_token: Address,
+        output_amount: &str,
+        max_ratio: &str,
+    ) -> SwapCalldataRequest {
+        SwapCalldataRequest {
+            taker: TAKER,
+            input_token,
+            output_token,
+            output_amount: output_amount.to_string(),
+            maximum_io_ratio: max_ratio.to_string(),
+            denomination: SwapDenomination::Unwrapped,
         }
     }
 
@@ -99,6 +138,7 @@ mod tests {
             data: Bytes::from(vec![0xab, 0xcd, 0xef]),
             value: U256::ZERO,
             estimated_input: "150".to_string(),
+            denomination: SwapDenomination::Wrapped,
             approvals: vec![],
         }
     }
@@ -109,6 +149,7 @@ mod tests {
             data: Bytes::new(),
             value: U256::ZERO,
             estimated_input: "1000".to_string(),
+            denomination: SwapDenomination::Wrapped,
             approvals: vec![Approval {
                 token: USDC,
                 spender: ORDERBOOK,
@@ -117,6 +158,120 @@ mod tests {
                 approval_data: Bytes::from(vec![0x09, 0x5e, 0xa7, 0xb3]),
             }],
         }
+    }
+
+    fn wrap_ratio(share_address: Address, assets_per_share: &str) -> WrapRatioValue {
+        WrapRatioValue {
+            share_address,
+            assets_per_share: assets_per_share.to_string(),
+        }
+    }
+
+    fn capture_ds(
+        response: SwapCalldataResponse,
+        wrap_ratios: HashMap<Address, WrapRatioValue>,
+    ) -> (
+        MockCalldataDataSource,
+        Arc<Mutex<Option<TakeOrdersRequest>>>,
+    ) {
+        capture_ds_with_wrap_result(response, Ok(wrap_ratios))
+    }
+
+    fn capture_ds_with_wrap_result(
+        response: SwapCalldataResponse,
+        wrap_ratios: Result<HashMap<Address, WrapRatioValue>, ApiError>,
+    ) -> (
+        MockCalldataDataSource,
+        Arc<Mutex<Option<TakeOrdersRequest>>>,
+    ) {
+        let captured_request = Arc::new(Mutex::new(None));
+        (
+            MockCalldataDataSource {
+                base: MockSwapDataSource {
+                    supported_tokens: Ok(()),
+                    orders: Ok(vec![]),
+                    candidates: vec![],
+                    calldata_result: Ok(response),
+                },
+                wrap_ratios,
+                captured_request: Arc::clone(&captured_request),
+            },
+            captured_request,
+        )
+    }
+
+    struct MockCalldataDataSource {
+        base: MockSwapDataSource,
+        wrap_ratios: Result<HashMap<Address, WrapRatioValue>, ApiError>,
+        captured_request: Arc<Mutex<Option<TakeOrdersRequest>>>,
+    }
+
+    #[async_trait]
+    impl SwapDataSource for MockCalldataDataSource {
+        async fn validate_supported_tokens(
+            &self,
+            input_token: Address,
+            output_token: Address,
+        ) -> Result<(), ApiError> {
+            self.base
+                .validate_supported_tokens(input_token, output_token)
+                .await
+        }
+
+        async fn get_orders_for_pair(
+            &self,
+            input_token: Address,
+            output_token: Address,
+        ) -> Result<Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder>, ApiError>
+        {
+            self.base
+                .get_orders_for_pair(input_token, output_token)
+                .await
+        }
+
+        async fn build_candidates_for_pair(
+            &self,
+            orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
+            input_token: Address,
+            output_token: Address,
+        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+            self.base
+                .build_candidates_for_pair(orders, input_token, output_token)
+                .await
+        }
+
+        async fn get_calldata(
+            &self,
+            request: TakeOrdersRequest,
+        ) -> Result<SwapCalldataResponse, ApiError> {
+            *self.captured_request.lock().unwrap() = Some(request);
+            self.base.calldata_result.clone()
+        }
+
+        async fn get_wrap_ratios_for_tokens(
+            &self,
+            token_addresses: &[Address],
+        ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+            let wrap_ratios = self.wrap_ratios.clone()?;
+            Ok(token_addresses
+                .iter()
+                .filter_map(|address| {
+                    wrap_ratios
+                        .get(address)
+                        .map(|ratio| (*address, ratio.clone()))
+                })
+                .collect())
+        }
+    }
+
+    fn captured_take_orders_request(
+        captured_request: &Arc<Mutex<Option<TakeOrdersRequest>>>,
+    ) -> TakeOrdersRequest {
+        captured_request.lock().unwrap().clone().unwrap()
+    }
+
+    fn no_take_orders_request_was_made(captured_request: &Arc<Mutex<Option<TakeOrdersRequest>>>) {
+        assert!(captured_request.lock().unwrap().is_none());
     }
 
     #[rocket::async_test]
@@ -135,6 +290,7 @@ mod tests {
         assert!(!result.data.is_empty());
         assert_eq!(result.value, U256::ZERO);
         assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
         assert!(result.approvals.is_empty());
     }
 
@@ -152,9 +308,244 @@ mod tests {
 
         assert_eq!(result.to, ORDERBOOK);
         assert!(result.data.is_empty());
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
         assert_eq!(result.approvals.len(), 1);
         assert_eq!(result.approvals[0].token, USDC);
         assert_eq!(result.approvals[0].spender, ORDERBOOK);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_default_denomination_preserves_request() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result = process_swap_calldata(&ds, calldata_request("100", "2.5"))
+            .await
+            .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.sell_token, USDC.to_string());
+        assert_eq!(request.buy_token, WETH.to_string());
+        assert_eq!(request.amount, "100");
+        assert_eq!(request.price_cap, "2.5");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_explicit_wrapped_preserves_request() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let mut request = calldata_request("100", "2.5");
+        request.denomination = SwapDenomination::Wrapped;
+        let result = process_swap_calldata(&ds, request).await.unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.amount, "100");
+        assert_eq!(request.price_cap, "2.5");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_converts_wrapped_output_amount() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(USDC, WT_MSTR, "100", "2.5"))
+                .await
+                .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.sell_token, USDC.to_string());
+        assert_eq!(request.buy_token, WT_MSTR.to_string());
+        assert_eq!(request.amount, "50");
+        assert_eq!(request.price_cap, "5");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_converts_wrapped_input_ratio_and_response() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(WT_MSTR, WETH, "100", "2.5"))
+                .await
+                .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.sell_token, WT_MSTR.to_string());
+        assert_eq!(request.buy_token, WETH.to_string());
+        assert_eq!(request.amount, "100");
+        assert_eq!(request.price_cap, "1.25");
+        assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_converts_both_wrapped_sides() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([
+                (WT_MSTR, wrap_ratio(WT_MSTR, "2")),
+                (WT_COIN, wrap_ratio(WT_COIN, "4")),
+            ]),
+        );
+        let result = process_swap_calldata(
+            &ds,
+            unwrapped_calldata_request(WT_MSTR, WT_COIN, "100", "2.5"),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.amount, "25");
+        assert_eq!(request.price_cap, "5");
+        assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_noop_for_non_wrapped_tokens() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(USDC, WETH, "100.0", "2.50"))
+                .await
+                .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.amount, "100.0");
+        assert_eq!(request.price_cap, "2.50");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_keeps_approval_amount_wrapped() {
+        let (ds, captured_request) = capture_ds(
+            SwapCalldataResponse {
+                estimated_input: "1000".to_string(),
+                approvals: vec![Approval {
+                    token: WT_MSTR,
+                    spender: ORDERBOOK,
+                    amount: "1000".to_string(),
+                    symbol: "wtMSTR".to_string(),
+                    approval_data: Bytes::from(vec![0x09, 0x5e, 0xa7, 0xb3]),
+                }],
+                ..approval_response()
+            },
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(WT_MSTR, WETH, "100", "2.5"))
+                .await
+                .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.price_cap, "1.25");
+        assert_eq!(result.estimated_input, "2000");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+        assert_eq!(result.approvals.len(), 1);
+        assert_eq!(result.approvals[0].token, WT_MSTR);
+        assert_eq!(result.approvals[0].amount, "1000");
+        assert_eq!(result.approvals[0].symbol, "wtMSTR");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_invalid_output_amount_is_bad_request() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result = process_swap_calldata(
+            &ds,
+            unwrapped_calldata_request(USDC, WT_MSTR, "not-a-number", "2.5"),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ApiError::BadRequest(msg)) if msg == "invalid output_amount"));
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_invalid_maximum_io_ratio_is_bad_request() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result = process_swap_calldata(
+            &ds,
+            unwrapped_calldata_request(USDC, WT_MSTR, "100", "not-a-number"),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(msg)) if msg == "invalid maximum_io_ratio")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_wrap_ratio_lookup_failure() {
+        let (ds, captured_request) = capture_ds_with_wrap_result(
+            ready_response(),
+            Err(ApiError::Internal("failed to read wrap ratios".into())),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(WT_MSTR, WETH, "100", "2.5"))
+                .await;
+
+        assert!(
+            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read wrap ratios")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_malformed_wrap_ratio_is_internal_error() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "not-a-number"))]),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(USDC, WT_MSTR, "100", "2.5"))
+                .await;
+
+        assert!(
+            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read wrapped token ratio")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_unwrapped_invalid_estimated_input_is_internal_error() {
+        let (ds, captured_request) = capture_ds(
+            SwapCalldataResponse {
+                estimated_input: "not-a-number".to_string(),
+                ..ready_response()
+            },
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result =
+            process_swap_calldata(&ds, unwrapped_calldata_request(WT_MSTR, WETH, "100", "2.5"))
+                .await;
+
+        let request = captured_take_orders_request(&captured_request);
+        assert_eq!(request.price_cap, "1.25");
+        assert!(
+            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read estimated_input")
+        );
+    }
+
+    #[test]
+    fn test_swap_calldata_request_defaults_to_wrapped_denomination() {
+        let request: SwapCalldataRequest = serde_json::from_str(
+            r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100","maximumIoRatio":"2.5"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(request.denomination, SwapDenomination::Wrapped);
     }
 
     #[rocket::async_test]
@@ -236,5 +627,20 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::BadRequest);
+    }
+
+    #[rocket::async_test]
+    async fn test_swap_calldata_422_for_invalid_denomination() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v1/swap/calldata")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100","maximumIoRatio":"2.5","denomination":"invalid"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 }

--- a/src/routes/swap/denomination.rs
+++ b/src/routes/swap/denomination.rs
@@ -1,0 +1,183 @@
+use super::SwapDataSource;
+use crate::error::ApiError;
+use crate::types::swap::{SwapCalldataResponse, SwapDenomination};
+use crate::wrap_ratio::WrapRatioValue;
+use alloy::primitives::Address;
+use rain_math_float::Float;
+use std::collections::HashMap;
+use std::ops::{Div, Mul};
+
+pub(crate) async fn normalize_quote_amounts(
+    ds: &dyn SwapDataSource,
+    denomination: SwapDenomination,
+    input_token: Address,
+    output_token: Address,
+    estimated_input: Float,
+    estimated_output: Float,
+) -> Result<(Float, Float), ApiError> {
+    match denomination {
+        SwapDenomination::Wrapped => Ok((estimated_input, estimated_output)),
+        SwapDenomination::Unwrapped => {
+            tracing::info!("normalizing swap quote response to unwrapped denomination");
+            let ratios = ds
+                .get_wrap_ratios_for_tokens(&[input_token, output_token])
+                .await?;
+
+            let converted_input =
+                convert_wrapped_amount_for_token(estimated_input, input_token, &ratios)?;
+            let converted_output =
+                convert_wrapped_amount_for_token(estimated_output, output_token, &ratios)?;
+
+            Ok((converted_input, converted_output))
+        }
+    }
+}
+
+pub(crate) async fn normalize_calldata_request_values(
+    ds: &dyn SwapDataSource,
+    denomination: SwapDenomination,
+    input_token: Address,
+    output_token: Address,
+    output_amount: String,
+    maximum_io_ratio: String,
+) -> Result<(String, String, HashMap<Address, WrapRatioValue>), ApiError> {
+    match denomination {
+        SwapDenomination::Wrapped => Ok((output_amount, maximum_io_ratio, HashMap::new())),
+        SwapDenomination::Unwrapped => {
+            tracing::info!("normalizing swap calldata request to wrapped denomination");
+            let ratios = ds
+                .get_wrap_ratios_for_tokens(&[input_token, output_token])
+                .await?;
+            let input_is_wrapped = ratios.contains_key(&input_token);
+            let output_is_wrapped = ratios.contains_key(&output_token);
+
+            if !input_is_wrapped && !output_is_wrapped {
+                return Ok((output_amount, maximum_io_ratio, ratios));
+            }
+
+            let input_assets_per_share = ratio_for_token(input_token, &ratios)?;
+            let output_assets_per_share = ratio_for_token(output_token, &ratios)?;
+
+            let maximum_io_ratio = parse_user_float(maximum_io_ratio, "maximum_io_ratio")?;
+
+            let normalized_output_amount = if output_is_wrapped {
+                let output_amount = parse_user_float(output_amount, "output_amount")?;
+                let wrapped_output_amount =
+                    output_amount.div(output_assets_per_share).map_err(|e| {
+                        tracing::error!(error = %e, "failed to normalize calldata output amount");
+                        ApiError::Internal("failed to normalize output amount".into())
+                    })?;
+                format_float(wrapped_output_amount, "output amount")?
+            } else {
+                output_amount
+            };
+
+            let normalized_io_ratio = maximum_io_ratio
+                .mul(output_assets_per_share)
+                .and_then(|ratio| ratio.div(input_assets_per_share))
+                .map_err(|e| {
+                    tracing::error!(error = %e, "failed to normalize calldata IO ratio");
+                    ApiError::Internal("failed to normalize IO ratio".into())
+                })?;
+
+            Ok((
+                normalized_output_amount,
+                format_float(normalized_io_ratio, "IO ratio")?,
+                ratios,
+            ))
+        }
+    }
+}
+
+pub(crate) fn normalize_calldata_response(
+    ratios: &HashMap<Address, WrapRatioValue>,
+    denomination: SwapDenomination,
+    input_token: Address,
+    mut response: SwapCalldataResponse,
+) -> Result<SwapCalldataResponse, ApiError> {
+    response.denomination = denomination;
+
+    if denomination == SwapDenomination::Wrapped {
+        return Ok(response);
+    }
+
+    tracing::info!("normalizing swap calldata response to unwrapped denomination");
+    if ratios.contains_key(&input_token) {
+        let estimated_input = parse_internal_float(response.estimated_input, "estimated_input")?;
+        response.estimated_input = format_float(
+            convert_wrapped_amount_for_token(estimated_input, input_token, ratios)?,
+            "estimated input",
+        )?;
+    }
+
+    Ok(response)
+}
+
+fn convert_wrapped_amount_for_token(
+    amount: Float,
+    token: Address,
+    ratios: &HashMap<Address, WrapRatioValue>,
+) -> Result<Float, ApiError> {
+    match ratios.get(&token) {
+        Some(ratio) => {
+            tracing::info!(
+                share_address = %ratio.share_address,
+                assets_per_share = %ratio.assets_per_share,
+                "normalizing wrapped token amount"
+            );
+            amount.mul(parse_ratio(ratio)?).map_err(|e| {
+                tracing::error!(error = %e, "failed to normalize wrapped token amount");
+                ApiError::Internal("failed to normalize wrapped token amount".into())
+            })
+        }
+        None => Ok(amount),
+    }
+}
+
+fn ratio_for_token(
+    token: Address,
+    ratios: &HashMap<Address, WrapRatioValue>,
+) -> Result<Float, ApiError> {
+    match ratios.get(&token) {
+        Some(ratio) => {
+            tracing::info!(
+                share_address = %ratio.share_address,
+                assets_per_share = %ratio.assets_per_share,
+                "using wrapped token ratio"
+            );
+            parse_ratio(ratio)
+        }
+        None => Float::parse("1".to_string()).map_err(|e| {
+            tracing::error!(error = %e, "failed to create identity wrap ratio");
+            ApiError::Internal("failed to normalize denomination".into())
+        }),
+    }
+}
+
+fn parse_ratio(ratio: &WrapRatioValue) -> Result<Float, ApiError> {
+    Float::parse(ratio.assets_per_share.clone()).map_err(|e| {
+        tracing::error!(error = %e, "failed to parse wrapped token ratio");
+        ApiError::Internal("failed to read wrapped token ratio".into())
+    })
+}
+
+fn parse_user_float(value: String, field: &str) -> Result<Float, ApiError> {
+    Float::parse(value).map_err(|e| {
+        tracing::error!(error = %e, field, "failed to parse swap denomination value");
+        ApiError::BadRequest(format!("invalid {field}"))
+    })
+}
+
+fn parse_internal_float(value: String, field: &str) -> Result<Float, ApiError> {
+    Float::parse(value).map_err(|e| {
+        tracing::error!(error = %e, field, "failed to parse swap denomination response value");
+        ApiError::Internal(format!("failed to read {field}"))
+    })
+}
+
+fn format_float(value: Float, label: &str) -> Result<String, ApiError> {
+    value.format().map_err(|e| {
+        tracing::error!(error = %e, label, "failed to format swap denomination value");
+        ApiError::Internal(format!("failed to format {label}"))
+    })
+}

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -1,9 +1,10 @@
 mod calldata;
+mod denomination;
 mod quote;
 
 use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
-use crate::types::swap::SwapCalldataResponse;
+use crate::types::swap::{SwapCalldataResponse, SwapDenomination};
 use crate::wrap_ratio::{read_wrap_ratio_values_for_addresses, WrapRatioValue};
 use alloy::primitives::Address;
 use async_trait::async_trait;
@@ -189,6 +190,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 data: alloy::primitives::Bytes::new(),
                 value: alloy::primitives::U256::ZERO,
                 estimated_input: formatted_amount.clone(),
+                denomination: SwapDenomination::Wrapped,
                 approvals: vec![crate::types::common::Approval {
                     token: approval_info.token(),
                     spender: approval_info.spender(),
@@ -207,6 +209,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 data: take_orders_info.calldata().clone(),
                 value: alloy::primitives::U256::ZERO,
                 estimated_input: expected_sell,
+                denomination: SwapDenomination::Wrapped,
                 approvals: vec![],
             })
         } else {

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -3,13 +3,13 @@ use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::swap::{SwapQuoteDenomination, SwapQuoteRequest, SwapQuoteResponse};
-use alloy::primitives::Address;
+use crate::routes::swap::denomination::normalize_quote_amounts;
+use crate::types::swap::{SwapQuoteRequest, SwapQuoteResponse};
 use rain_math_float::Float;
 use rain_orderbook_common::take_orders::simulate_buy_over_candidates;
 use rocket::serde::json::Json;
 use rocket::State;
-use std::ops::{Div, Mul};
+use std::ops::Div;
 use tracing::Instrument;
 
 #[utoipa::path(
@@ -137,68 +137,12 @@ async fn process_swap_quote(
     })
 }
 
-async fn normalize_quote_amounts(
-    ds: &dyn SwapDataSource,
-    denomination: SwapQuoteDenomination,
-    input_token: Address,
-    output_token: Address,
-    estimated_input: Float,
-    estimated_output: Float,
-) -> Result<(Float, Float), ApiError> {
-    match denomination {
-        SwapQuoteDenomination::Wrapped => Ok((estimated_input, estimated_output)),
-        SwapQuoteDenomination::Unwrapped => {
-            tracing::info!("normalizing swap quote response to unwrapped denomination");
-            let ratios = ds
-                .get_wrap_ratios_for_tokens(&[input_token, output_token])
-                .await?;
-
-            let converted_input = match ratios.get(&input_token) {
-                Some(ratio) => {
-                    tracing::info!(
-                        share_address = %ratio.share_address,
-                        assets_per_share = %ratio.assets_per_share,
-                        "normalizing estimated input to unwrapped denomination"
-                    );
-                    convert_wrapped_amount(estimated_input, &ratio.assets_per_share)?
-                }
-                None => estimated_input,
-            };
-
-            let converted_output = match ratios.get(&output_token) {
-                Some(ratio) => {
-                    tracing::info!(
-                        share_address = %ratio.share_address,
-                        assets_per_share = %ratio.assets_per_share,
-                        "normalizing estimated output to unwrapped denomination"
-                    );
-                    convert_wrapped_amount(estimated_output, &ratio.assets_per_share)?
-                }
-                None => estimated_output,
-            };
-
-            Ok((converted_input, converted_output))
-        }
-    }
-}
-
-fn convert_wrapped_amount(amount: Float, assets_per_share: &str) -> Result<Float, ApiError> {
-    let ratio = Float::parse(assets_per_share.to_string()).map_err(|e| {
-        tracing::error!(error = %e, "failed to parse wrapped token ratio");
-        ApiError::Internal("failed to read wrapped token ratio".into())
-    })?;
-
-    amount.mul(ratio).map_err(|e| {
-        tracing::error!(error = %e, "failed to normalize wrapped token amount");
-        ApiError::Internal("failed to normalize wrapped token amount".into())
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
+    use crate::types::swap::SwapDenomination;
     use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::address;
     use async_trait::async_trait;
@@ -213,7 +157,7 @@ mod tests {
             input_token: USDC,
             output_token: WETH,
             output_amount: output_amount.to_string(),
-            denomination: SwapQuoteDenomination::Wrapped,
+            denomination: SwapDenomination::Wrapped,
         }
     }
 
@@ -226,7 +170,7 @@ mod tests {
             input_token,
             output_token,
             output_amount: output_amount.to_string(),
-            denomination: SwapQuoteDenomination::Unwrapped,
+            denomination: SwapDenomination::Unwrapped,
         }
     }
 
@@ -314,7 +258,7 @@ mod tests {
         assert_eq!(result.input_token, USDC);
         assert_eq!(result.output_token, WETH);
         assert_eq!(result.output_amount, "100");
-        assert_eq!(result.denomination, SwapQuoteDenomination::Wrapped);
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
         assert_eq!(result.estimated_output, "100");
         assert_eq!(result.estimated_input, "150");
         assert_eq!(result.estimated_io_ratio, "1.5");
@@ -386,7 +330,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
         assert_eq!(result.output_amount, "100");
         assert_eq!(result.estimated_output, "100");
         assert_eq!(result.estimated_input, "300");
@@ -410,7 +354,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
         assert_eq!(result.output_amount, "100");
         assert_eq!(result.estimated_output, "200");
         assert_eq!(result.estimated_input, "150");
@@ -438,7 +382,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
         assert_eq!(result.output_amount, "100");
         assert_eq!(result.estimated_output, "300");
         assert_eq!(result.estimated_input, "300");
@@ -461,7 +405,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(result.denomination, SwapQuoteDenomination::Unwrapped);
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
         assert_eq!(result.output_amount, "100");
         assert_eq!(result.estimated_output, "100");
         assert_eq!(result.estimated_input, "150");

--- a/src/types/swap.rs
+++ b/src/types/swap.rs
@@ -5,7 +5,7 @@ use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
-pub enum SwapQuoteDenomination {
+pub enum SwapDenomination {
     #[default]
     Wrapped,
     Unwrapped,
@@ -22,7 +22,7 @@ pub struct SwapQuoteRequest {
     pub output_amount: String,
     #[serde(default)]
     #[schema(example = "wrapped", default = "wrapped")]
-    pub denomination: SwapQuoteDenomination,
+    pub denomination: SwapDenomination,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -35,7 +35,7 @@ pub struct SwapQuoteResponse {
     #[schema(example = "0.5")]
     pub output_amount: String,
     #[schema(example = "wrapped")]
-    pub denomination: SwapQuoteDenomination,
+    pub denomination: SwapDenomination,
     #[schema(example = "0.5")]
     pub estimated_output: String,
     #[schema(example = "1250.75")]
@@ -57,6 +57,9 @@ pub struct SwapCalldataRequest {
     pub output_amount: String,
     #[schema(example = "2600")]
     pub maximum_io_ratio: String,
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapDenomination,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -70,5 +73,7 @@ pub struct SwapCalldataResponse {
     pub value: U256,
     #[schema(example = "1250.75")]
     pub estimated_input: String,
+    #[schema(example = "wrapped")]
+    pub denomination: SwapDenomination,
     pub approvals: Vec<Approval>,
 }


### PR DESCRIPTION
## Summary

- add `denomination` support to `/v1/swap/calldata`, defaulting to `wrapped`
- reuse a shared `SwapDenomination` enum across quote and calldata
- convert unwrapped calldata `outputAmount` and `maximumIoRatio` into wrapped/orderbook units before calling Raindex
- return calldata `estimatedInput` in the requested denomination while keeping approvals in actual on-chain wrapped/orderbook units
- move shared denomination conversion logic into `routes::swap::denomination`
- update swap-flow docs for calldata `denomination=unwrapped`

## Notes

This stacks on top of the quote denomination PR and uses the same wrap-ratio datasource path. `inputToken` and `outputToken` remain wrapped/orderbook token addresses; the endpoint does not translate unwrapped asset addresses.

The calldata request and response normalization now share the same wrap-ratio snapshot so the response display uses the ratios that were used to build the calldata request.

Closes RAI-711: https://linear.app/makeitrain/issue/RAI-711/support-denominationunwrapped-in-calldata-generation

## Validation

- `nix develop -c cargo fmt`
- `nix develop -c cargo test routes::swap`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783079499&installation_id=125569124&pr_number=132&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F132&signature=d9193047a8bb44e8046535021a466e7e6fd98d8c60f074a070d39c1c06c5a295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
