### PR TITLE
persist wrapped exchange rate history

### DIFF
--- a/migrations/20260604000000_create_wrapped_exchange_rate_snapshots.sql
+++ b/migrations/20260604000000_create_wrapped_exchange_rate_snapshots.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS wrapped_exchange_rate_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    share_token_address TEXT NOT NULL,
+    asset_token_address TEXT NOT NULL,
+    assets_per_share TEXT NOT NULL,
+    block_number INTEGER NOT NULL,
+    block_timestamp INTEGER,
+    captured_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (share_token_address, block_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_wrapped_exchange_rate_snapshots_share_captured_at
+    ON wrapped_exchange_rate_snapshots (share_token_address, captured_at);
+
+CREATE INDEX IF NOT EXISTS idx_wrapped_exchange_rate_snapshots_share_block_number
+    ON wrapped_exchange_rate_snapshots (share_token_address, block_number);
+
+CREATE INDEX IF NOT EXISTS idx_wrapped_exchange_rate_snapshots_asset_captured_at
+    ON wrapped_exchange_rate_snapshots (asset_token_address, captured_at);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,7 @@
 mod migrate;
 mod pool;
 pub(crate) mod registry_history;
+pub(crate) mod wrapped_exchange_rate_history;
 
 pub type DbPool = sqlx::Pool<sqlx::Sqlite>;
 

--- a/src/db/wrapped_exchange_rate_history.rs
+++ b/src/db/wrapped_exchange_rate_history.rs
@@ -1,0 +1,182 @@
+use super::DbPool;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NewWrappedExchangeRateSnapshot {
+    pub share_token_address: String,
+    pub asset_token_address: String,
+    pub assets_per_share: String,
+    pub block_number: i64,
+    pub block_timestamp: Option<i64>,
+    pub captured_at: String,
+}
+
+pub(crate) async fn insert_wrapped_exchange_rate_snapshots(
+    pool: &DbPool,
+    snapshots: &[NewWrappedExchangeRateSnapshot],
+) -> Result<u64, sqlx::Error> {
+    let mut rows_affected = 0;
+    let mut tx = pool.begin().await?;
+
+    for snapshot in snapshots {
+        let result = sqlx::query(
+            "INSERT OR IGNORE INTO wrapped_exchange_rate_snapshots \
+             (share_token_address, asset_token_address, assets_per_share, block_number, block_timestamp, captured_at) \
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&snapshot.share_token_address)
+        .bind(&snapshot.asset_token_address)
+        .bind(&snapshot.assets_per_share)
+        .bind(snapshot.block_number)
+        .bind(snapshot.block_timestamp)
+        .bind(&snapshot.captured_at)
+        .execute(&mut *tx)
+        .await?;
+        rows_affected += result.rows_affected();
+    }
+
+    tx.commit().await?;
+    Ok(rows_affected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, sqlx::FromRow)]
+    struct SnapshotTestRow {
+        share_token_address: String,
+        asset_token_address: String,
+        assets_per_share: String,
+        block_number: i64,
+        block_timestamp: Option<i64>,
+        captured_at: String,
+    }
+
+    async fn test_pool() -> DbPool {
+        let database_url = format!(
+            "sqlite:file:{}?mode=memory&cache=shared",
+            uuid::Uuid::new_v4()
+        );
+        crate::db::init(&database_url, 5)
+            .await
+            .expect("database init")
+    }
+
+    fn snapshot(
+        share_token_address: &str,
+        asset_token_address: &str,
+        assets_per_share: &str,
+        block_number: i64,
+        captured_at: &str,
+    ) -> NewWrappedExchangeRateSnapshot {
+        NewWrappedExchangeRateSnapshot {
+            share_token_address: share_token_address.to_string(),
+            asset_token_address: asset_token_address.to_string(),
+            assets_per_share: assets_per_share.to_string(),
+            block_number,
+            block_timestamp: Some(block_number + 1000),
+            captured_at: captured_at.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn inserts_snapshots_append_only_and_idempotently() {
+        let pool = test_pool().await;
+        let first = snapshot("0xshare", "0xasset", "1.0", 100, "2026-06-04T10:00:00Z");
+        let second = snapshot("0xshare", "0xasset", "1.1", 101, "2026-06-04T10:01:00Z");
+
+        let inserted = insert_wrapped_exchange_rate_snapshots(
+            &pool,
+            &[first.clone(), first.clone(), second.clone()],
+        )
+        .await
+        .expect("insert snapshots");
+
+        assert_eq!(inserted, 2);
+
+        let rows = list_snapshots_for_share(&pool, "0xshare")
+            .await
+            .expect("list snapshots");
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].block_number, 101);
+        assert_eq!(rows[1].block_number, 100);
+    }
+
+    #[tokio::test]
+    async fn stores_all_snapshot_fields() {
+        let pool = test_pool().await;
+        let snapshots = vec![snapshot(
+            "0xshare",
+            "0xasset",
+            "1.2",
+            120,
+            "2026-06-04T10:02:00Z",
+        )];
+        insert_wrapped_exchange_rate_snapshots(&pool, &snapshots)
+            .await
+            .expect("insert snapshots");
+
+        let row = sqlx::query_as::<_, SnapshotTestRow>(
+            "SELECT share_token_address, asset_token_address, assets_per_share, block_number, block_timestamp, captured_at \
+             FROM wrapped_exchange_rate_snapshots \
+             WHERE share_token_address = ?",
+        )
+        .bind("0xshare")
+        .fetch_one(&pool)
+        .await
+        .expect("read snapshot");
+
+        assert_eq!(row.share_token_address, "0xshare");
+        assert_eq!(row.asset_token_address, "0xasset");
+        assert_eq!(row.assets_per_share, "1.2");
+        assert_eq!(row.block_number, 120);
+        assert_eq!(row.block_timestamp, Some(1120));
+        assert_eq!(row.captured_at, "2026-06-04T10:02:00Z");
+    }
+
+    #[tokio::test]
+    async fn schema_supports_token_and_time_window_queries() {
+        let pool = test_pool().await;
+        let snapshots = vec![
+            snapshot("0xshare", "0xasset", "1.0", 100, "2026-06-04T10:00:00Z"),
+            snapshot("0xshare", "0xasset", "1.1", 101, "2026-06-04T10:01:00Z"),
+            snapshot("0xshare", "0xasset", "1.2", 102, "2026-06-04T10:02:00Z"),
+            snapshot("0xother", "0xasset", "9.9", 103, "2026-06-04T10:03:00Z"),
+        ];
+        insert_wrapped_exchange_rate_snapshots(&pool, &snapshots)
+            .await
+            .expect("insert snapshots");
+
+        let rows = sqlx::query_as::<_, SnapshotTestRow>(
+            "SELECT share_token_address, asset_token_address, assets_per_share, block_number, block_timestamp, captured_at \
+             FROM wrapped_exchange_rate_snapshots \
+             WHERE share_token_address = ? AND captured_at >= ? AND captured_at <= ? \
+             ORDER BY captured_at DESC, block_number DESC",
+        )
+        .bind("0xshare")
+        .bind("2026-06-04T10:01:00Z")
+        .bind("2026-06-04T10:02:00Z")
+        .fetch_all(&pool)
+        .await
+        .expect("query snapshots by window");
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].assets_per_share, "1.2");
+        assert_eq!(rows[1].assets_per_share, "1.1");
+    }
+
+    async fn list_snapshots_for_share(
+        pool: &DbPool,
+        share_token_address: &str,
+    ) -> Result<Vec<SnapshotTestRow>, sqlx::Error> {
+        sqlx::query_as::<_, SnapshotTestRow>(
+            "SELECT share_token_address, asset_token_address, assets_per_share, block_number, block_timestamp, captured_at \
+             FROM wrapped_exchange_rate_snapshots \
+             WHERE share_token_address = ? \
+             ORDER BY block_number DESC",
+        )
+        .bind(share_token_address)
+        .fetch_all(pool)
+        .await
+    }
+}

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1,6 +1,7 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::{
@@ -35,6 +36,7 @@ pub async fn post_swap_calldata(
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     request: Json<SwapCalldataRequest>,
 ) -> Result<Json<SwapCalldataResponse>, ApiError> {
@@ -45,6 +47,7 @@ pub async fn post_swap_calldata(
         let ds = RaindexSwapDataSource {
             client: raindex.client(),
             caches: &app_state.response_caches,
+            pool: pool.inner(),
         };
         let response = process_swap_calldata(&ds, req).await?;
         Ok(Json(response))

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -3,9 +3,13 @@ mod denomination;
 mod quote;
 
 use crate::cache::RouteResponseCaches;
+use crate::db::DbPool;
 use crate::error::ApiError;
 use crate::types::swap::{SwapCalldataResponse, SwapDenomination};
-use crate::wrap_ratio::{read_wrap_ratio_values_for_addresses, WrapRatioValue};
+use crate::wrap_ratio::{
+    persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
+    wrap_ratio_values_from_responses, WrapRatioValue,
+};
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::orders::{
@@ -57,6 +61,7 @@ pub(crate) trait SwapDataSource: Send + Sync {
 pub(crate) struct RaindexSwapDataSource<'a> {
     pub client: &'a RaindexClient,
     pub caches: &'a RouteResponseCaches,
+    pub pool: &'a DbPool,
 }
 
 fn swap_candidates_cache_key(
@@ -233,7 +238,9 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             .into_values()
             .collect();
 
-        read_wrap_ratio_values_for_addresses(&tokens, token_addresses).await
+        let responses = read_wrap_ratio_responses_for_addresses(&tokens, token_addresses).await?;
+        persist_wrap_ratio_snapshots_best_effort(self.pool, &responses).await;
+        Ok(wrap_ratio_values_from_responses(responses))
     }
 }
 

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -1,6 +1,7 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::normalize_quote_amounts;
@@ -34,6 +35,7 @@ pub async fn post_swap_quote(
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     request: Json<SwapQuoteRequest>,
 ) -> Result<Json<SwapQuoteResponse>, ApiError> {
@@ -44,6 +46,7 @@ pub async fn post_swap_quote(
         let ds = RaindexSwapDataSource {
             client: raindex.client(),
             caches: &app_state.response_caches,
+            pool: pool.inner(),
         };
         let response = process_swap_quote(&ds, req).await?;
         Ok(Json(response))

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -1,11 +1,13 @@
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::raindex::SharedRaindexProvider;
 use crate::types::common::ValidatedAddress;
 use crate::wrap_ratio::{
-    build_wrap_ratio_response, find_wrap_ratio_item, is_st0x_token, read_wrap_ratios_batch,
-    unwrapped_address, WrapRatioBatchInput, WrapRatioMetadata, WrapRatioResponse,
+    build_wrap_ratio_response, find_wrap_ratio_item, is_st0x_token,
+    persist_wrap_ratio_snapshots_best_effort, read_wrap_ratios_batch, unwrapped_address,
+    WrapRatioBatchInput, WrapRatioMetadata, WrapRatioResponse,
 };
 use alloy::primitives::Address;
 use rain_orderbook_app_settings::token::TokenCfg;
@@ -155,6 +157,7 @@ pub async fn get_wrap_ratios(
     _key: AuthenticatedKey,
     span: TracingSpan,
     shared_raindex: &State<SharedRaindexProvider>,
+    pool: &State<DbPool>,
 ) -> Result<Json<WrapRatioBatchResponse>, ApiError> {
     async move {
         tracing::info!("request received");
@@ -226,6 +229,8 @@ pub async fn get_wrap_ratios(
             }
         }
 
+        persist_wrap_ratio_snapshots_best_effort(pool.inner(), &data).await;
+
         tracing::info!(
             data_count = data.len(),
             error_count = errors.len(),
@@ -260,6 +265,7 @@ pub async fn get_wrap_ratio_by_address(
     _key: AuthenticatedKey,
     span: TracingSpan,
     shared_raindex: &State<SharedRaindexProvider>,
+    pool: &State<DbPool>,
     address: ValidatedAddress,
 ) -> Result<Json<WrapRatioResponse>, ApiError> {
     async move {
@@ -325,6 +331,9 @@ pub async fn get_wrap_ratio_by_address(
                 error.into_api_error()
             },
         )?;
+
+        persist_wrap_ratio_snapshots_best_effort(pool.inner(), std::slice::from_ref(&response))
+            .await;
 
         tracing::info!(share_address = %token.address, "returning wrapped token ratio");
         Ok(Json(response))
@@ -949,6 +958,25 @@ using-tokens-from:
         assert_eq!(data[0]["blockNumber"], 123);
         assert_eq!(data[0]["blockTimestamp"], 456);
         assert!(data[0]["capturedAt"].as_str().is_some());
+
+        let pool = client
+            .rocket()
+            .state::<crate::db::DbPool>()
+            .expect("pool in state");
+        let persisted = sqlx::query_as::<_, (String, String, String, i64, Option<i64>)>(
+            "SELECT share_token_address, asset_token_address, assets_per_share, block_number, block_timestamp \
+             FROM wrapped_exchange_rate_snapshots \
+             WHERE share_token_address = ?",
+        )
+        .bind(format!("{WT_MSTR:#x}"))
+        .fetch_one(pool)
+        .await
+        .expect("read persisted snapshot");
+        assert_eq!(persisted.0, format!("{WT_MSTR:#x}"));
+        assert_eq!(persisted.1, format!("{T_MSTR:#x}"));
+        assert_eq!(persisted.2, "1.0");
+        assert_eq!(persisted.3, 123);
+        assert_eq!(persisted.4, Some(456));
 
         assert_eq!(errors[0]["shareAddress"], format!("{WT_BAD:#x}"));
         assert_eq!(errors[0]["message"], "failed to read ERC4626 ratio");

--- a/src/wrap_ratio.rs
+++ b/src/wrap_ratio.rs
@@ -1,3 +1,7 @@
+use crate::db::wrapped_exchange_rate_history::{
+    insert_wrapped_exchange_rate_snapshots, NewWrappedExchangeRateSnapshot,
+};
+use crate::db::DbPool;
 use crate::erc4626::batch_share_ratios;
 use crate::error::ApiError;
 use alloy::primitives::Address;
@@ -13,15 +17,15 @@ pub struct WrapRatioResponse {
     #[schema(value_type = String, example = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2")]
     pub(crate) share_address: Address,
     #[schema(value_type = String, example = "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe")]
-    asset_address: Address,
+    pub(crate) asset_address: Address,
     #[schema(example = "1.0")]
     pub(crate) assets_per_share: String,
     #[schema(example = 123)]
-    block_number: u64,
+    pub(crate) block_number: u64,
     #[schema(nullable = true, example = 456)]
-    block_timestamp: Option<u64>,
+    pub(crate) block_timestamp: Option<u64>,
     #[schema(example = "1717351200")]
-    captured_at: String,
+    pub(crate) captured_at: String,
 }
 
 #[derive(Debug, Clone)]
@@ -259,10 +263,10 @@ pub(crate) async fn read_wrap_ratios_batch(
     Ok(responses)
 }
 
-pub(crate) async fn read_wrap_ratio_values_for_addresses(
+pub(crate) async fn read_wrap_ratio_responses_for_addresses(
     tokens: &[TokenCfg],
     share_addresses: &[Address],
-) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+) -> Result<Vec<WrapRatioResponse>, ApiError> {
     let requested: HashSet<Address> = share_addresses.iter().copied().collect();
     let mut inputs = Vec::new();
 
@@ -284,7 +288,7 @@ pub(crate) async fn read_wrap_ratio_values_for_addresses(
         });
     }
 
-    let mut ratios = HashMap::new();
+    let mut responses = Vec::new();
     for group in read_wrap_ratios_batch(&inputs).await? {
         let metadata = WrapRatioMetadata::from_batch_response(&group.response);
 
@@ -314,17 +318,86 @@ pub(crate) async fn read_wrap_ratio_values_for_addresses(
                     error.into_api_error()
                 })?;
 
-            ratios.insert(
+            responses.push(row);
+        }
+    }
+
+    Ok(responses)
+}
+
+pub(crate) fn wrap_ratio_values_from_responses(
+    responses: Vec<WrapRatioResponse>,
+) -> HashMap<Address, WrapRatioValue> {
+    responses
+        .into_iter()
+        .map(|row| {
+            (
                 row.share_address,
                 WrapRatioValue {
                     share_address: row.share_address,
                     assets_per_share: row.assets_per_share,
                 },
-            );
+            )
+        })
+        .collect()
+}
+
+pub(crate) async fn persist_wrap_ratio_snapshots_best_effort(
+    pool: &DbPool,
+    responses: &[WrapRatioResponse],
+) {
+    if responses.is_empty() {
+        return;
+    }
+
+    let mut snapshots = Vec::with_capacity(responses.len());
+    for response in responses {
+        match wrap_ratio_snapshot_from_response(response) {
+            Ok(snapshot) => snapshots.push(snapshot),
+            Err(error) => tracing::error!(
+                error = %error,
+                share_address = %response.share_address,
+                block_number = response.block_number,
+                block_timestamp = ?response.block_timestamp,
+                "failed to prepare wrapped exchange rate snapshot"
+            ),
         }
     }
 
-    Ok(ratios)
+    if snapshots.is_empty() {
+        return;
+    }
+
+    match insert_wrapped_exchange_rate_snapshots(pool, &snapshots).await {
+        Ok(inserted_count) => tracing::info!(
+            observed_count = responses.len(),
+            persisted_count = snapshots.len(),
+            inserted_count,
+            "persisted wrapped exchange rate snapshots"
+        ),
+        Err(error) => tracing::error!(
+            error = %error,
+            observed_count = responses.len(),
+            "failed to persist wrapped exchange rate snapshots"
+        ),
+    }
+}
+
+fn wrap_ratio_snapshot_from_response(
+    response: &WrapRatioResponse,
+) -> Result<NewWrappedExchangeRateSnapshot, std::num::TryFromIntError> {
+    Ok(NewWrappedExchangeRateSnapshot {
+        share_token_address: normalized_address(response.share_address),
+        asset_token_address: normalized_address(response.asset_address),
+        assets_per_share: response.assets_per_share.clone(),
+        block_number: i64::try_from(response.block_number)?,
+        block_timestamp: response.block_timestamp.map(i64::try_from).transpose()?,
+        captured_at: response.captured_at.clone(),
+    })
+}
+
+fn normalized_address(address: Address) -> String {
+    format!("{address:#x}").to_ascii_lowercase()
 }
 
 #[cfg(test)]
@@ -494,5 +567,28 @@ mod tests {
         assert!(
             matches!(api_error, ApiError::Internal(message) if message == "token is missing unwrappedAddress")
         );
+    }
+
+    #[test]
+    fn test_wrap_ratio_snapshot_from_response_normalizes_addresses() {
+        let item = successful_batch_item(WT_MSTR, T_MSTR);
+        let response =
+            build_wrap_ratio_response(&item, T_MSTR, &metadata()).expect("ratio should build");
+
+        let snapshot =
+            wrap_ratio_snapshot_from_response(&response).expect("snapshot should convert");
+
+        assert_eq!(
+            snapshot.share_token_address,
+            "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
+        );
+        assert_eq!(
+            snapshot.asset_token_address,
+            "0x013b782f402d61aa1004cca95b9f5bb402c9d5fe"
+        );
+        assert_eq!(snapshot.assets_per_share, "1.0");
+        assert_eq!(snapshot.block_number, 123);
+        assert_eq!(snapshot.block_timestamp, Some(456));
+        assert_eq!(snapshot.captured_at, "2026-06-02T13:00:00Z");
     }
 }


### PR DESCRIPTION
## Chained PRs

Depends on #132 (`arda/calldata-denomination-unwrapped`).

## Motivation

RAI-662 needs every observed wrapped-token exchange rate to be persisted as an append-only historical snapshot so later API work can reason about ratios observed at a specific token/time/block.

## Solution

- Add a `wrapped_exchange_rate_snapshots` SQLite table with indexed token/time/block lookup paths.
- Persist successful wrap-ratio observations from the batch token endpoint, single-token endpoint, and internal unwrapped quote/calldata ratio reads.
- Keep persistence best-effort so live API responses are not failed by snapshot write errors.
- Avoid duplicate rows for the same share token and observed block with a unique `(share_token_address, block_number)` constraint.
- Store the normalized snapshot fields required by the issue: share token, asset token, assets per share, block number, block timestamp, and captured-at.

## Checks

- `nix develop -c cargo fmt`
- `nix develop -c cargo test wrapped_exchange_rate_history`
- `nix develop -c cargo test wrap_ratio`
- `nix develop -c cargo check`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test`

Closes RAI-662: https://linear.app/makeitrain/issue/RAI-662/persist-a-historical-snapshot-of-every-observed-wrapped-exchange-rate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database persistence for wrapped exchange rate snapshots to enable historical tracking of wrap-ratio data across the swap and token endpoints.

* **Chores**
  * Enhanced data infrastructure to store and retrieve wrapped exchange rate snapshot records with optimized query indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->