### PR TITLE
orders: support unwrapped denomination

### DIFF
--- a/docs/src/orders.md
+++ b/docs/src/orders.md
@@ -2,7 +2,10 @@
 
 Orders are persistent on-chain strategies that execute over time.
 
-The order endpoints return transaction calldata — the API does not execute transactions for you. You receive `to`, `data`, and `value` fields (plus any required token `approvals`) and submit those transactions on-chain yourself, the same pattern as the [Swap Flow](./swap-flow.md).
+The order endpoints return transaction calldata — the API does not execute
+transactions for you. You receive `to`, `data`, and `value` fields (plus any
+required token `approvals`) and submit those transactions on-chain yourself, the
+same pattern as the [Swap Flow](./swap-flow.md).
 
 ## Get DCA Order Calldata
 
@@ -10,7 +13,8 @@ The order endpoints return transaction calldata — the API does not execute tra
 POST /v1/order/dca
 ```
 
-Returns calldata to deploy a DCA order that periodically buys a token at a set interval, with price bounds.
+Returns calldata to deploy a DCA order that periodically buys a token at a set
+interval, with price bounds.
 
 ### Request
 
@@ -29,21 +33,22 @@ curl -X POST https://api.st0x.io/v1/order/dca \
   }'
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `inputToken` | string | Token to spend |
-| `outputToken` | string | Token to receive |
-| `budgetAmount` | string | Total budget in human-readable units (e.g. `"10000"` for 10,000 USDC) |
-| `period` | number | Time between executions |
-| `periodUnit` | string | `"days"`, `"hours"`, or `"minutes"` |
-| `startIo` | string | Starting IO ratio |
-| `floorIo` | string | Minimum acceptable IO ratio |
-| `inputVaultId` | string (optional) | Existing vault ID for input token |
-| `outputVaultId` | string (optional) | Existing vault ID for output token |
+| Field           | Type              | Description                                                           |
+| --------------- | ----------------- | --------------------------------------------------------------------- |
+| `inputToken`    | string            | Token to spend                                                        |
+| `outputToken`   | string            | Token to receive                                                      |
+| `budgetAmount`  | string            | Total budget in human-readable units (e.g. `"10000"` for 10,000 USDC) |
+| `period`        | number            | Time between executions                                               |
+| `periodUnit`    | string            | `"days"`, `"hours"`, or `"minutes"`                                   |
+| `startIo`       | string            | Starting IO ratio                                                     |
+| `floorIo`       | string            | Minimum acceptable IO ratio                                           |
+| `inputVaultId`  | string (optional) | Existing vault ID for input token                                     |
+| `outputVaultId` | string (optional) | Existing vault ID for output token                                    |
 
 ### Response
 
-The response always includes all fields. If approvals are needed, `data` is empty and `approvals` contains the required transactions:
+The response always includes all fields. If approvals are needed, `data` is
+empty and `approvals` contains the required transactions:
 
 ```json
 {
@@ -62,7 +67,9 @@ The response always includes all fields. If approvals are needed, `data` is empt
 }
 ```
 
-Send each approval transaction on-chain, then call the endpoint again. Once approvals are in place, `approvals` is empty and `data` contains the deployment calldata:
+Send each approval transaction on-chain, then call the endpoint again. Once
+approvals are in place, `approvals` is empty and `data` contains the deployment
+calldata:
 
 ```json
 {
@@ -87,6 +94,14 @@ Retrieve the full state of an order including vault balances and trade history.
 curl https://api.st0x.io/v1/order/0xabc123... \
   -H "Authorization: Basic <credentials>"
 ```
+
+| Parameter      | Type                     | Default   | Description                                                                                                               |
+| -------------- | ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `denomination` | `wrapped` or `unwrapped` | `wrapped` | Return wrapped token amounts as-is, or normalize wrapped token balances, trade amounts, and IO ratios to unwrapped values |
+
+When `denomination=unwrapped`, order fields are normalized using the current
+wrapped exchange rate. Omit the parameter to keep the default wrapped-token
+response.
 
 ### Response
 
@@ -143,10 +158,19 @@ curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10" \
   -H "Authorization: Basic <credentials>"
 ```
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `page` | number | 1 | Page number |
-| `pageSize` | number | 20 | Results per page |
+| Parameter      | Type                     | Default   | Description                                                                                               |
+| -------------- | ------------------------ | --------- | --------------------------------------------------------------------------------------------------------- |
+| `page`         | number                   | 1         | Page number                                                                                               |
+| `pageSize`     | number                   | 20        | Results per page                                                                                          |
+| `denomination` | `wrapped` or `unwrapped` | `wrapped` | Return wrapped token amounts as-is, or normalize wrapped token balances and IO ratios to unwrapped values |
+
+Use `denomination=unwrapped` to view order balances and IO ratios normalized to
+the current unwrapped asset value:
+
+```bash
+curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10&denomination=unwrapped" \
+  -H "Authorization: Basic <credentials>"
+```
 
 ### Response
 
@@ -253,4 +277,5 @@ curl -X POST https://api.st0x.io/v1/order/cancel \
 }
 ```
 
-Execute each transaction in the `transactions` array sequentially. The `summary` shows what tokens you will receive back.
+Execute each transaction in the `transactions` array sequentially. The `summary`
+shows what tokens you will receive back.

--- a/src/denomination.rs
+++ b/src/denomination.rs
@@ -1,0 +1,146 @@
+use crate::error::ApiError;
+use crate::wrap_ratio::WrapRatioValue;
+use alloy::primitives::Address;
+use rain_math_float::Float;
+use std::collections::HashMap;
+use std::ops::{Div, Mul};
+
+pub(crate) type WrapRatioMap = HashMap<Address, WrapRatioValue>;
+
+pub(crate) fn convert_wrapped_amount_for_token(
+    amount: String,
+    token: Address,
+    ratios: &WrapRatioMap,
+) -> Result<String, ApiError> {
+    let Some(ratio) = ratios.get(&token) else {
+        return Ok(amount);
+    };
+
+    let amount = parse_float(amount, "amount")?;
+    let converted = amount.mul(parse_ratio(ratio)?).map_err(|e| {
+        tracing::error!(error = %e, "failed to convert wrapped amount");
+        ApiError::Internal("failed to convert wrapped amount".into())
+    })?;
+    format_float(converted, "amount")
+}
+
+pub(crate) fn convert_wrapped_io_ratio(
+    io_ratio: String,
+    input_token: Address,
+    output_token: Address,
+    ratios: &WrapRatioMap,
+) -> Result<String, ApiError> {
+    if io_ratio == "-" {
+        return Ok(io_ratio);
+    }
+
+    let io_ratio = parse_float(io_ratio, "io_ratio")?;
+    let input_assets_per_share = ratio_for_token(input_token, ratios)?;
+    let output_assets_per_share = ratio_for_token(output_token, ratios)?;
+
+    let converted = io_ratio
+        .mul(input_assets_per_share)
+        .and_then(|ratio| ratio.div(output_assets_per_share))
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to convert wrapped IO ratio");
+            ApiError::Internal("failed to convert wrapped IO ratio".into())
+        })?;
+
+    format_float(converted, "io_ratio")
+}
+
+fn ratio_for_token(token: Address, ratios: &WrapRatioMap) -> Result<Float, ApiError> {
+    match ratios.get(&token) {
+        Some(ratio) => parse_ratio(ratio),
+        None => Float::parse("1".to_string()).map_err(|e| {
+            tracing::error!(error = %e, token = %token, "failed to create identity wrap ratio");
+            ApiError::Internal("failed to convert denomination".into())
+        }),
+    }
+}
+
+fn parse_ratio(ratio: &WrapRatioValue) -> Result<Float, ApiError> {
+    Float::parse(ratio.assets_per_share.clone()).map_err(|e| {
+        tracing::error!(
+            error = %e,
+            share_address = %ratio.share_address,
+            assets_per_share = %ratio.assets_per_share,
+            "failed to parse wrapped token ratio"
+        );
+        ApiError::Internal("failed to read wrapped token ratio".into())
+    })
+}
+
+fn parse_float(value: String, label: &str) -> Result<Float, ApiError> {
+    Float::parse(value).map_err(|e| {
+        tracing::error!(error = %e, label, "failed to parse denomination value");
+        ApiError::Internal(format!("failed to parse {label}"))
+    })
+}
+
+fn format_float(value: Float, label: &str) -> Result<String, ApiError> {
+    value.format().map_err(|e| {
+        tracing::error!(error = %e, label, "failed to format denomination value");
+        ApiError::Internal(format!("failed to format {label}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::address;
+
+    const WT_MSTR: Address = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
+    const WT_COIN: Address = address!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+    const USDC: Address = address!("833589fcd6edb6e08f4c7c32d4f71b54bda02913");
+
+    fn ratio(share_address: Address, assets_per_share: &str) -> WrapRatioValue {
+        WrapRatioValue {
+            share_address,
+            assets_per_share: assets_per_share.to_string(),
+        }
+    }
+
+    #[test]
+    fn converts_amount_for_wrapped_token() {
+        let ratios = HashMap::from([(WT_MSTR, ratio(WT_MSTR, "2"))]);
+
+        let result = convert_wrapped_amount_for_token("1.5".to_string(), WT_MSTR, &ratios)
+            .expect("convert amount");
+
+        assert_eq!(result, "3");
+    }
+
+    #[test]
+    fn leaves_amount_for_unwrapped_token() {
+        let ratios = HashMap::from([(WT_MSTR, ratio(WT_MSTR, "2"))]);
+
+        let result = convert_wrapped_amount_for_token("1.5".to_string(), USDC, &ratios)
+            .expect("convert amount");
+
+        assert_eq!(result, "1.5");
+    }
+
+    #[test]
+    fn converts_io_ratio_for_wrapped_sides() {
+        let ratios = HashMap::from([
+            (WT_MSTR, ratio(WT_MSTR, "2")),
+            (WT_COIN, ratio(WT_COIN, "4")),
+        ]);
+
+        let result = convert_wrapped_io_ratio("10".to_string(), WT_MSTR, WT_COIN, &ratios)
+            .expect("convert ratio");
+
+        assert_eq!(result, "5");
+    }
+
+    #[test]
+    fn preserves_dash_io_ratio() {
+        let ratios = HashMap::from([(WT_MSTR, ratio(WT_MSTR, "2"))]);
+
+        let result = convert_wrapped_io_ratio("-".to_string(), WT_MSTR, USDC, &ratios)
+            .expect("convert ratio");
+
+        assert_eq!(result, "-");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod catchers;
 mod cli;
 mod config;
 mod db;
+mod denomination;
 mod erc4626;
 mod error;
 mod fairings;

--- a/src/routes/order/cancel.rs
+++ b/src/routes/order/cancel.rs
@@ -43,6 +43,7 @@ pub async fn post_order_cancel(
         let ds = RaindexOrderDataSource {
             client: raindex.client(),
             caches: &app_state.response_caches,
+            pool: None,
         };
         let response = process_cancel_order(&ds, hash).await?;
         Ok(Json(response))

--- a/src/routes/order/get_order.rs
+++ b/src/routes/order/get_order.rs
@@ -1,16 +1,21 @@
 use super::{OrderDataSource, RaindexOrderDataSource};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::common::{TokenRef, ValidatedFixedBytes};
-use crate::types::order::{OrderDetail, OrderDetailsInfo, OrderTradeEntry, OrderType};
-use alloy::primitives::B256;
+use crate::types::common::{Denomination, TokenRef, ValidatedFixedBytes};
+use crate::types::order::{
+    OrderDetail, OrderDetailParams, OrderDetailsInfo, OrderTradeEntry, OrderType,
+};
+use crate::wrap_ratio::WrapRatioValue;
+use alloy::primitives::{Address, B256};
 use rain_orderbook_common::parsed_meta::ParsedMeta;
 use rain_orderbook_common::raindex_client::orders::RaindexOrder;
 use rain_orderbook_common::raindex_client::trades::RaindexTrade;
 use rocket::serde::json::Json;
 use rocket::State;
+use std::collections::HashMap;
 use tracing::Instrument;
 
 #[utoipa::path(
@@ -20,6 +25,7 @@ use tracing::Instrument;
     security(("basicAuth" = [])),
     params(
         ("order_hash" = String, Path, description = "The order hash"),
+        OrderDetailParams,
     ),
     responses(
         (status = 200, description = "Order details", body = OrderDetail),
@@ -29,31 +35,40 @@ use tracing::Instrument;
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
-#[get("/<order_hash>")]
+#[allow(clippy::too_many_arguments)]
+#[get("/<order_hash>?<params..>")]
 pub async fn get_order(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     order_hash: ValidatedFixedBytes,
+    params: OrderDetailParams,
 ) -> Result<Json<OrderDetail>, ApiError> {
     async move {
-        tracing::info!(order_hash = ?order_hash, "request received");
+        tracing::info!(order_hash = ?order_hash, params = ?params, "request received");
         let hash = order_hash.0;
+        let denomination = params.denomination.unwrap_or_default();
         let raindex = shared_raindex.read().await;
         let ds = RaindexOrderDataSource {
             client: raindex.client(),
             caches: &app_state.response_caches,
+            pool: Some(pool.inner()),
         };
-        let detail = process_get_order(&ds, hash).await?;
+        let detail = process_get_order(&ds, hash, denomination).await?;
         Ok(Json(detail))
     }
     .instrument(span.0)
     .await
 }
 
-async fn process_get_order(ds: &dyn OrderDataSource, hash: B256) -> Result<OrderDetail, ApiError> {
+async fn process_get_order(
+    ds: &dyn OrderDataSource,
+    hash: B256,
+    denomination: Denomination,
+) -> Result<OrderDetail, ApiError> {
     let orders = ds.get_orders_by_hash(hash).await?;
     let order = orders
         .into_iter()
@@ -66,8 +81,17 @@ async fn process_get_order(ds: &dyn OrderDataSource, hash: B256) -> Result<Order
         .map(|d| d.formatted_ratio.clone())
         .unwrap_or_else(|| "-".into());
     let trades = ds.get_order_trades(&order).await?;
+    let wrap_ratios =
+        current_wrap_ratios_for_order_detail(ds, denomination, &order, &trades).await?;
     let order_type = determine_order_type(&order);
-    build_order_detail(&order, order_type, &io_ratio, &trades)
+    build_order_detail(
+        &order,
+        order_type,
+        &io_ratio,
+        &trades,
+        denomination,
+        &wrap_ratios,
+    )
 }
 
 fn determine_order_type(order: &RaindexOrder) -> OrderType {
@@ -90,22 +114,55 @@ fn build_order_detail(
     order_type: OrderType,
     io_ratio: &str,
     trades: &[RaindexTrade],
+    denomination: Denomination,
+    wrap_ratios: &HashMap<Address, WrapRatioValue>,
 ) -> Result<OrderDetail, ApiError> {
     let (input, output) = crate::routes::resolve_io_vaults(order)?;
 
     let input_token_info = input.token();
     let output_token_info = output.token();
 
-    let trade_entries: Vec<OrderTradeEntry> = trades.iter().map(map_trade).collect();
+    let trade_entries: Vec<OrderTradeEntry> = trades
+        .iter()
+        .map(|trade| map_trade(trade, denomination, wrap_ratios))
+        .collect::<Result<Vec<_>, ApiError>>()?;
 
     let created_at: u64 = order.timestamp_added().try_into().unwrap_or(0);
+    let input_vault_balance = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            input.formatted_balance(),
+            input_token_info.address(),
+            wrap_ratios,
+        )?
+    } else {
+        input.formatted_balance()
+    };
+    let output_vault_balance = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            output.formatted_balance(),
+            output_token_info.address(),
+            wrap_ratios,
+        )?
+    } else {
+        output.formatted_balance()
+    };
+    let converted_io_ratio = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_io_ratio(
+            io_ratio.to_string(),
+            input_token_info.address(),
+            output_token_info.address(),
+            wrap_ratios,
+        )?
+    } else {
+        io_ratio.to_string()
+    };
 
     Ok(OrderDetail {
         order_hash: order.order_hash(),
         owner: order.owner(),
         order_details: OrderDetailsInfo {
             type_: order_type,
-            io_ratio: io_ratio.to_string(),
+            io_ratio: converted_io_ratio.clone(),
         },
         input_token: TokenRef {
             address: input_token_info.address(),
@@ -119,26 +176,75 @@ fn build_order_detail(
         },
         input_vault_id: input.vault_id(),
         output_vault_id: output.vault_id(),
-        input_vault_balance: input.formatted_balance(),
-        output_vault_balance: output.formatted_balance(),
-        io_ratio: io_ratio.to_string(),
+        input_vault_balance,
+        output_vault_balance,
+        io_ratio: converted_io_ratio,
         created_at,
         orderbook_id: order.raindex(),
         trades: trade_entries,
     })
 }
 
-fn map_trade(trade: &RaindexTrade) -> OrderTradeEntry {
+fn map_trade(
+    trade: &RaindexTrade,
+    denomination: Denomination,
+    wrap_ratios: &HashMap<Address, WrapRatioValue>,
+) -> Result<OrderTradeEntry, ApiError> {
     let timestamp: u64 = trade.timestamp().try_into().unwrap_or(0);
     let tx = trade.transaction();
-    OrderTradeEntry {
+    let input_vc = trade.input_vault_balance_change();
+    let output_vc = trade.output_vault_balance_change();
+    let input_token = input_vc.token().address();
+    let output_token = output_vc.token().address();
+    let input_amount = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            input_vc.formatted_amount(),
+            input_token,
+            wrap_ratios,
+        )?
+    } else {
+        input_vc.formatted_amount()
+    };
+    let output_amount = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            output_vc.formatted_amount(),
+            output_token,
+            wrap_ratios,
+        )?
+    } else {
+        output_vc.formatted_amount()
+    };
+
+    Ok(OrderTradeEntry {
         id: trade.id().to_string(),
         tx_hash: tx.id(),
-        input_amount: trade.input_vault_balance_change().formatted_amount(),
-        output_amount: trade.output_vault_balance_change().formatted_amount(),
+        input_amount,
+        output_amount,
         timestamp,
         sender: tx.from(),
+    })
+}
+
+async fn current_wrap_ratios_for_order_detail(
+    ds: &dyn OrderDataSource,
+    denomination: Denomination,
+    order: &RaindexOrder,
+    trades: &[RaindexTrade],
+) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+    if denomination == Denomination::Wrapped {
+        return Ok(HashMap::new());
     }
+
+    let (input, output) = crate::routes::resolve_io_vaults(order)?;
+    let mut token_addresses = vec![input.token().address(), output.token().address()];
+    for trade in trades {
+        token_addresses.push(trade.input_vault_balance_change().token().address());
+        token_addresses.push(trade.output_vault_balance_change().token().address());
+    }
+    token_addresses.sort_unstable();
+    token_addresses.dedup();
+
+    ds.get_wrap_ratios_for_tokens(&token_addresses).await
 }
 
 #[cfg(test)]
@@ -147,8 +253,11 @@ mod tests {
     use crate::error::ApiError;
     use crate::routes::order::test_fixtures::*;
     use crate::test_helpers::TestClientBuilder;
+    use crate::wrap_ratio::WrapRatioValue;
+    use alloy::primitives::address;
     use alloy::primitives::{Address, Bytes};
     use rocket::http::Status;
+    use std::collections::HashMap;
 
     #[rocket::async_test]
     async fn test_process_get_order_success() {
@@ -158,7 +267,9 @@ mod tests {
             quotes: Ok(vec![mock_quote("1.5")]),
             calldata: Ok(Bytes::new()),
         };
-        let detail = process_get_order(&ds, test_hash()).await.unwrap();
+        let detail = process_get_order(&ds, test_hash(), Denomination::Wrapped)
+            .await
+            .unwrap();
 
         assert_eq!(detail.order_hash, test_hash());
         assert_eq!(
@@ -189,7 +300,7 @@ mod tests {
             quotes: Ok(vec![]),
             calldata: Ok(Bytes::new()),
         };
-        let result = process_get_order(&ds, test_hash()).await;
+        let result = process_get_order(&ds, test_hash(), Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::NotFound(_))));
     }
 
@@ -201,7 +312,9 @@ mod tests {
             quotes: Ok(vec![mock_quote("2.0")]),
             calldata: Ok(Bytes::new()),
         };
-        let detail = process_get_order(&ds, test_hash()).await.unwrap();
+        let detail = process_get_order(&ds, test_hash(), Denomination::Wrapped)
+            .await
+            .unwrap();
         assert!(detail.trades.is_empty());
         assert_eq!(detail.io_ratio, "2.0");
     }
@@ -214,7 +327,9 @@ mod tests {
             quotes: Ok(vec![mock_failed_quote()]),
             calldata: Ok(Bytes::new()),
         };
-        let detail = process_get_order(&ds, test_hash()).await.unwrap();
+        let detail = process_get_order(&ds, test_hash(), Denomination::Wrapped)
+            .await
+            .unwrap();
         assert_eq!(detail.io_ratio, "-");
         assert_eq!(detail.order_details.io_ratio, "-");
     }
@@ -227,7 +342,7 @@ mod tests {
             quotes: Ok(vec![]),
             calldata: Ok(Bytes::new()),
         };
-        let result = process_get_order(&ds, test_hash()).await;
+        let result = process_get_order(&ds, test_hash(), Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -239,7 +354,7 @@ mod tests {
             quotes: Err(ApiError::Internal("failed to query order quotes".into())),
             calldata: Ok(Bytes::new()),
         };
-        let result = process_get_order(&ds, test_hash()).await;
+        let result = process_get_order(&ds, test_hash(), Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -251,7 +366,7 @@ mod tests {
             quotes: Ok(vec![mock_quote("1.5")]),
             calldata: Ok(Bytes::new()),
         };
-        let result = process_get_order(&ds, test_hash()).await;
+        let result = process_get_order(&ds, test_hash(), Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -266,12 +381,39 @@ mod tests {
         let hash = "0x000000000000000000000000000000000000000000000000000000000000beef"
             .parse()
             .unwrap();
-        let detail = process_get_order(&ds, hash).await.unwrap();
+        let detail = process_get_order(&ds, hash, Denomination::Wrapped)
+            .await
+            .unwrap();
 
         assert_eq!(detail.input_token.symbol, "wtMSTR");
         assert_eq!(detail.output_token.symbol, "wtMSTR");
         assert_eq!(detail.input_vault_balance, "0");
         assert_eq!(detail.output_vault_balance, "0");
+    }
+
+    #[test]
+    fn test_map_trade_converts_unwrapped_amounts() {
+        let wrapped_output = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
+        let mut value = trade_json();
+        value["outputVaultBalanceChange"]["token"]["address"] =
+            serde_json::json!(format!("{wrapped_output:#x}"));
+        value["outputVaultBalanceChange"]["token"]["id"] =
+            serde_json::json!(format!("{wrapped_output:#x}"));
+        value["outputVaultBalanceChange"]["token"]["symbol"] = serde_json::json!("wtMSTR");
+        let trade: RaindexTrade =
+            serde_json::from_value(value).expect("deserialize wrapped-output trade");
+        let ratios = HashMap::from([(
+            wrapped_output,
+            WrapRatioValue {
+                share_address: wrapped_output,
+                assets_per_share: "2".to_string(),
+            },
+        )]);
+
+        let entry = map_trade(&trade, Denomination::Unwrapped, &ratios).expect("map trade");
+
+        assert_eq!(entry.input_amount, "0.500000");
+        assert_eq!(entry.output_amount, "-0.5");
     }
 
     #[rocket::async_test]

--- a/src/routes/order/mod.rs
+++ b/src/routes/order/mod.rs
@@ -5,7 +5,11 @@ mod get_order;
 
 use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
-use alloy::primitives::{Bytes, B256};
+use crate::wrap_ratio::{
+    persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
+    wrap_ratio_values_from_responses, WrapRatioValue,
+};
+use alloy::primitives::{Address, Bytes, B256};
 use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
 use rain_orderbook_common::raindex_client::orders::{GetOrdersFilters, RaindexOrder};
@@ -15,6 +19,7 @@ use rain_orderbook_common::raindex_client::trades::{
 use rain_orderbook_common::raindex_client::types::TimeFilter;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rocket::Route;
+use std::collections::HashMap;
 
 #[async_trait]
 pub(crate) trait OrderDataSource: Send + Sync {
@@ -25,11 +30,18 @@ pub(crate) trait OrderDataSource: Send + Sync {
     ) -> Result<Vec<RaindexOrderQuote>, ApiError>;
     async fn get_order_trades(&self, order: &RaindexOrder) -> Result<Vec<RaindexTrade>, ApiError>;
     async fn get_remove_calldata(&self, order: &RaindexOrder) -> Result<Bytes, ApiError>;
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        _token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        Ok(HashMap::new())
+    }
 }
 
 pub(crate) struct RaindexOrderDataSource<'a> {
     pub client: &'a RaindexClient,
     pub caches: &'a RouteResponseCaches,
+    pub pool: Option<&'a crate::db::DbPool>,
 }
 
 #[async_trait]
@@ -100,6 +112,28 @@ impl<'a> OrderDataSource for RaindexOrderDataSource<'a> {
             tracing::error!(error = %e, "failed to get remove calldata");
             ApiError::Internal("failed to get remove calldata".into())
         })
+    }
+
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        let Some(pool) = self.pool else {
+            return Ok(HashMap::new());
+        };
+        let tokens: Vec<_> = self
+            .client
+            .get_all_tokens()
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to retrieve curated tokens");
+                ApiError::Internal("failed to retrieve curated tokens".into())
+            })?
+            .into_values()
+            .collect();
+
+        let responses = read_wrap_ratio_responses_for_addresses(&tokens, token_addresses).await?;
+        persist_wrap_ratio_snapshots_best_effort(pool, &responses).await;
+        Ok(wrap_ratio_values_from_responses(responses))
     }
 }
 

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -1,12 +1,13 @@
 use super::{
-    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
-    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+    build_orders_list_response, current_wrap_ratios_for_orders, OrdersListDataSource,
+    RaindexOrdersListDataSource, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::common::ValidatedAddress;
+use crate::types::common::{Denomination, ValidatedAddress};
 use crate::types::orders::{OrdersListResponse, OrdersPaginationParams};
 use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
@@ -19,6 +20,7 @@ pub(crate) async fn process_get_orders_by_owner(
     address: Address,
     page: Option<u16>,
     page_size: Option<u16>,
+    denomination: Denomination,
 ) -> Result<OrdersListResponse, ApiError> {
     let filters = GetOrdersFilters {
         owners: vec![address],
@@ -40,6 +42,7 @@ pub(crate) async fn process_get_orders_by_owner(
         "fetching batched quotes for orders by owner"
     );
     let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let wrap_ratios = current_wrap_ratios_for_orders(ds, denomination, &orders).await?;
 
     build_orders_list_response(
         &orders,
@@ -47,6 +50,8 @@ pub(crate) async fn process_get_orders_by_owner(
         page_num.into(),
         effective_page_size.into(),
         quote_results,
+        denomination,
+        &wrap_ratios,
     )
 }
 
@@ -68,12 +73,14 @@ pub(crate) async fn process_get_orders_by_owner(
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
+#[allow(clippy::too_many_arguments)]
 #[get("/owner/<address>?<params..>")]
 pub async fn get_orders_by_address(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: OrdersPaginationParams,
@@ -83,12 +90,15 @@ pub async fn get_orders_by_address(
         let addr = address.0;
         let page = params.page;
         let page_size = params.page_size;
+        let denomination = params.denomination.unwrap_or_default();
         let raindex = shared_raindex.read().await;
         let ds = RaindexOrdersListDataSource {
             client: raindex.client(),
             caches: &app_state.response_caches,
+            pool: pool.inner(),
         };
-        let response = process_get_orders_by_owner(&ds, addr, page, page_size).await?;
+        let response =
+            process_get_orders_by_owner(&ds, addr, page, page_size, denomination).await?;
         Ok(Json(response))
     }
     .instrument(span.0)
@@ -115,7 +125,7 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None)
+        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
             .await
             .unwrap();
 
@@ -139,7 +149,7 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None)
+        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
             .await
             .unwrap();
 
@@ -158,7 +168,7 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None)
+        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
             .await
             .unwrap();
 
@@ -175,7 +185,8 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None).await;
+        let result =
+            process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -189,7 +200,7 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None)
+        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
             .await
             .unwrap();
 

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -1,12 +1,13 @@
 use super::{
-    build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
-    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+    build_orders_list_response, current_wrap_ratios_for_orders, OrdersListDataSource,
+    RaindexOrdersListDataSource, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::common::ValidatedAddress;
+use crate::types::common::{Denomination, ValidatedAddress};
 use crate::types::orders::{OrderSide, OrdersByTokenParams, OrdersListResponse};
 use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
@@ -21,6 +22,7 @@ pub(crate) async fn process_get_orders_by_token(
     side: Option<OrderSide>,
     page: Option<u16>,
     page_size: Option<u16>,
+    denomination: Denomination,
 ) -> Result<OrdersListResponse, ApiError> {
     let token_filter = match side {
         Some(OrderSide::Input) => GetOrdersTokenFilter {
@@ -57,6 +59,7 @@ pub(crate) async fn process_get_orders_by_token(
         "fetching batched quotes for orders by token"
     );
     let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let wrap_ratios = current_wrap_ratios_for_orders(ds, denomination, &orders).await?;
 
     build_orders_list_response(
         &orders,
@@ -64,6 +67,8 @@ pub(crate) async fn process_get_orders_by_token(
         page_num.into(),
         effective_page_size.into(),
         quote_results,
+        denomination,
+        &wrap_ratios,
     )
 }
 
@@ -85,12 +90,14 @@ pub(crate) async fn process_get_orders_by_token(
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
+#[allow(clippy::too_many_arguments)]
 #[get("/token/<address>?<params..>")]
 pub async fn get_orders_by_token(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: OrdersByTokenParams,
@@ -101,17 +108,21 @@ pub async fn get_orders_by_token(
         let side = params.side;
         let page = params.page;
         let page_size = params.page_size;
+        let denomination = params.denomination.unwrap_or_default();
         if !app_state.response_caches.is_enabled() {
             let raindex = shared_raindex.read().await;
             let ds = RaindexOrdersListDataSource {
                 client: raindex.client(),
                 caches: &app_state.response_caches,
+                pool: pool.inner(),
             };
-            let response = process_get_orders_by_token(&ds, addr, side, page, page_size).await?;
+            let response =
+                process_get_orders_by_token(&ds, addr, side, page, page_size, denomination).await?;
             return Ok(Json(response));
         }
 
-        let cache_key = orders_by_token_cache_key(addr, side.as_ref(), page, page_size);
+        let cache_key =
+            orders_by_token_cache_key(addr, side.as_ref(), page, page_size, denomination);
         let response = app_state
             .response_caches
             .orders_by_token
@@ -120,8 +131,9 @@ pub async fn get_orders_by_token(
                 let ds = RaindexOrdersListDataSource {
                     client: raindex.client(),
                     caches: &app_state.response_caches,
+                    pool: pool.inner(),
                 };
-                process_get_orders_by_token(&ds, addr, side, page, page_size).await
+                process_get_orders_by_token(&ds, addr, side, page, page_size, denomination).await
             })
             .await
             .map_err(|e| (*e).clone())?;
@@ -136,6 +148,7 @@ fn orders_by_token_cache_key(
     side: Option<&OrderSide>,
     page: Option<u16>,
     page_size: Option<u16>,
+    denomination: Denomination,
 ) -> String {
     let side = match side {
         Some(OrderSide::Input) => "input",
@@ -147,7 +160,7 @@ fn orders_by_token_cache_key(
         .unwrap_or(DEFAULT_PAGE_SIZE as u16)
         .min(MAX_PAGE_SIZE);
     format!(
-        "orders/token/{}/{side}/{page}/{page_size}",
+        "orders/token/{}/{side}/{page}/{page_size}/{denomination:?}",
         address.to_string().to_ascii_lowercase()
     )
 }
@@ -172,9 +185,10 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_token(&ds, addr, None, None, None)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "USDC");
@@ -196,9 +210,16 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_token(&ds, addr, Some(OrderSide::Input), None, None)
-            .await
-            .unwrap();
+        let result = process_get_orders_by_token(
+            &ds,
+            addr,
+            Some(OrderSide::Input),
+            None,
+            None,
+            Denomination::Wrapped,
+        )
+        .await
+        .unwrap();
 
         assert!(result.orders.is_empty());
         assert_eq!(result.pagination.total_orders, 0);
@@ -215,9 +236,10 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_token(&ds, addr, None, None, None)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders[0].io_ratio, "-");
     }
@@ -232,7 +254,8 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_token(&ds, addr, None, None, None).await;
+        let result =
+            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -246,9 +269,10 @@ mod tests {
         let addr: Address = "0xff05e1bd696900dc6a52ca35ca61bb1024eda8e2"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_token(&ds, addr, None, None, None)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "wtMSTR");
@@ -291,8 +315,14 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            orders_by_token_cache_key(lower, None, None, None),
-            orders_by_token_cache_key(mixed, None, Some(1), Some(DEFAULT_PAGE_SIZE as u16))
+            orders_by_token_cache_key(lower, None, None, None, Denomination::Wrapped),
+            orders_by_token_cache_key(
+                mixed,
+                None,
+                Some(1),
+                Some(DEFAULT_PAGE_SIZE as u16),
+                Denomination::Wrapped
+            )
         );
     }
 

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -4,8 +4,13 @@ mod get_by_tx;
 
 use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
-use crate::types::common::TokenRef;
+use crate::types::common::{Denomination, TokenRef};
 use crate::types::orders::{OrderSummary, OrdersListResponse, OrdersPagination};
+use crate::wrap_ratio::{
+    persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
+    wrap_ratio_values_from_responses, WrapRatioValue,
+};
+use alloy::primitives::Address;
 use async_trait::async_trait;
 use futures::{future::join_all, stream, StreamExt};
 use rain_orderbook_common::raindex_client::order_quotes::{
@@ -15,6 +20,7 @@ use rain_orderbook_common::raindex_client::orders::{GetOrdersFilters, RaindexOrd
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rocket::Route;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 pub(crate) const DEFAULT_PAGE_SIZE: u32 = 20;
 pub(crate) const MAX_PAGE_SIZE: u16 = 50;
@@ -51,11 +57,19 @@ pub(crate) trait OrdersListDataSource: Send + Sync {
     async fn get_order_quotes_batch(&self, orders: &[RaindexOrder]) -> Vec<OrderQuoteResult> {
         fetch_order_quotes_grouped(self, orders).await
     }
+
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        _token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        Ok(HashMap::new())
+    }
 }
 
 pub(crate) struct RaindexOrdersListDataSource<'a> {
     pub client: &'a RaindexClient,
     pub caches: &'a RouteResponseCaches,
+    pub pool: &'a crate::db::DbPool,
 }
 
 pub(crate) fn order_quote_cache_key(order: &RaindexOrder) -> String {
@@ -300,17 +314,58 @@ impl<'a> OrdersListDataSource for RaindexOrdersListDataSource<'a> {
             .map(|quotes| quotes.unwrap_or_default())
             .collect())
     }
+
+    async fn get_wrap_ratios_for_tokens(
+        &self,
+        token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        let tokens: Vec<_> = self
+            .client
+            .get_all_tokens()
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to retrieve curated tokens");
+                ApiError::Internal("failed to retrieve curated tokens".into())
+            })?
+            .into_values()
+            .collect();
+
+        let responses = read_wrap_ratio_responses_for_addresses(&tokens, token_addresses).await?;
+        persist_wrap_ratio_snapshots_best_effort(self.pool, &responses).await;
+        Ok(wrap_ratio_values_from_responses(responses))
+    }
 }
 
 pub(crate) fn build_order_summary(
     order: &RaindexOrder,
     io_ratio: &str,
+    denomination: Denomination,
+    wrap_ratios: &HashMap<Address, WrapRatioValue>,
 ) -> Result<OrderSummary, ApiError> {
     let (input, output) = super::resolve_io_vaults(order)?;
 
     let input_token_info = input.token();
     let output_token_info = output.token();
     let created_at: u64 = order.timestamp_added().try_into().unwrap_or(0);
+
+    let output_vault_balance = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            output.formatted_balance(),
+            output_token_info.address(),
+            wrap_ratios,
+        )?
+    } else {
+        output.formatted_balance()
+    };
+    let io_ratio = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_io_ratio(
+            io_ratio.to_string(),
+            input_token_info.address(),
+            output_token_info.address(),
+            wrap_ratios,
+        )?
+    } else {
+        io_ratio.to_string()
+    };
 
     Ok(OrderSummary {
         order_hash: order.order_hash(),
@@ -326,8 +381,8 @@ pub(crate) fn build_order_summary(
             symbol: output_token_info.symbol().unwrap_or_default(),
             decimals: output_token_info.decimals(),
         },
-        output_vault_balance: output.formatted_balance(),
-        io_ratio: io_ratio.to_string(),
+        output_vault_balance,
+        io_ratio,
         created_at,
         orderbook_id: order.raindex(),
     })
@@ -376,6 +431,8 @@ pub(crate) fn build_orders_list_response(
     page: u32,
     page_size: u32,
     quote_results: Vec<OrderQuoteResult>,
+    denomination: Denomination,
+    wrap_ratios: &HashMap<Address, WrapRatioValue>,
 ) -> Result<OrdersListResponse, ApiError> {
     if quote_results.len() != orders.len() {
         tracing::error!(
@@ -389,13 +446,39 @@ pub(crate) fn build_orders_list_response(
     let mut summaries = Vec::with_capacity(orders.len());
     for (order, quotes_result) in orders.iter().zip(quote_results) {
         let io_ratio = quote_result_to_io_ratio(order, quotes_result);
-        summaries.push(build_order_summary(order, &io_ratio)?);
+        summaries.push(build_order_summary(
+            order,
+            &io_ratio,
+            denomination,
+            wrap_ratios,
+        )?);
     }
 
     Ok(OrdersListResponse {
         orders: summaries,
         pagination: build_pagination(total_count, page, page_size),
     })
+}
+
+pub(crate) async fn current_wrap_ratios_for_orders(
+    ds: &dyn OrdersListDataSource,
+    denomination: Denomination,
+    orders: &[RaindexOrder],
+) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+    if denomination == Denomination::Wrapped || orders.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut token_addresses = Vec::new();
+    for order in orders {
+        let (input, output) = super::resolve_io_vaults(order)?;
+        token_addresses.push(input.token().address());
+        token_addresses.push(output.token().address());
+    }
+    token_addresses.sort_unstable();
+    token_addresses.dedup();
+
+    ds.get_wrap_ratios_for_tokens(&token_addresses).await
 }
 
 pub use get_by_owner::*;
@@ -454,6 +537,8 @@ pub(crate) mod test_fixtures {
 mod tests {
     use super::*;
     use crate::routes::order::test_fixtures::{mock_quote, order_json};
+    use crate::wrap_ratio::WrapRatioValue;
+    use alloy::primitives::address;
     use serde_json::json;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
@@ -529,6 +614,13 @@ mod tests {
 
     fn order_hash_key(order: &RaindexOrder) -> String {
         format!("{:?}", order.order_hash())
+    }
+
+    fn wrap_ratio(share_address: Address, assets_per_share: &str) -> WrapRatioValue {
+        WrapRatioValue {
+            share_address,
+            assets_per_share: assets_per_share.to_string(),
+        }
     }
 
     #[rocket::async_test]
@@ -655,8 +747,35 @@ mod tests {
             "0x0000000000000000000000000000000000000000000000000000000000000101",
         )];
 
-        let result = build_orders_list_response(&orders, 1, 1, 20, vec![]);
+        let result = build_orders_list_response(
+            &orders,
+            1,
+            1,
+            20,
+            vec![],
+            Denomination::Wrapped,
+            &HashMap::new(),
+        );
 
         assert!(matches!(result, Err(ApiError::Internal(_))));
+    }
+
+    #[test]
+    fn test_build_order_summary_converts_unwrapped_output_values() {
+        let wrapped_output = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
+        let mut value = order_json();
+        value["outputs"][0]["formattedBalance"] = json!("2");
+        value["outputs"][0]["token"]["address"] = json!(format!("{wrapped_output:#x}"));
+        value["outputs"][0]["token"]["id"] = json!(format!("{wrapped_output:#x}"));
+        value["outputs"][0]["token"]["symbol"] = json!("wtMSTR");
+        let order: RaindexOrder =
+            serde_json::from_value(value).expect("deserialize wrapped-output order");
+        let ratios = HashMap::from([(wrapped_output, wrap_ratio(wrapped_output, "3"))]);
+
+        let summary =
+            build_order_summary(&order, "9", Denomination::Unwrapped, &ratios).expect("summary");
+
+        assert_eq!(summary.output_vault_balance, "6");
+        assert_eq!(summary.io_ratio, "3");
     }
 }

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -1,6 +1,17 @@
 use alloy::primitives::{Address, Bytes, FixedBytes};
+use rocket::form::FromFormField;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, FromFormField, ToSchema,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum Denomination {
+    #[default]
+    Wrapped,
+    Unwrapped,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]

--- a/src/types/order.rs
+++ b/src/types/order.rs
@@ -1,7 +1,8 @@
-use crate::types::common::{Approval, TokenRef};
+use crate::types::common::{Approval, Denomination, TokenRef};
 use alloy::primitives::{Address, Bytes, FixedBytes, U256};
+use rocket::form::FromForm;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -105,6 +106,15 @@ pub struct CancelSummary {
 pub struct CancelOrderResponse {
     pub transactions: Vec<CancelTransaction>,
     pub summary: CancelSummary,
+}
+
+#[derive(Debug, Clone, FromForm, Serialize, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+#[serde(rename_all = "camelCase")]
+pub struct OrderDetailParams {
+    #[field(name = "denomination")]
+    #[param(example = "wrapped")]
+    pub denomination: Option<Denomination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]

--- a/src/types/orders.rs
+++ b/src/types/orders.rs
@@ -1,4 +1,4 @@
-use crate::types::common::TokenRef;
+use crate::types::common::{Denomination, TokenRef};
 use alloy::primitives::{Address, Bytes, FixedBytes};
 use rocket::form::{FromForm, FromFormField};
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,9 @@ pub struct OrdersPaginationParams {
     #[field(name = "pageSize")]
     #[param(example = 20)]
     pub page_size: Option<u16>,
+    #[field(name = "denomination")]
+    #[param(example = "wrapped")]
+    pub denomination: Option<Denomination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, FromFormField, ToSchema)]
@@ -35,6 +38,9 @@ pub struct OrdersByTokenParams {
     #[field(name = "pageSize")]
     #[param(example = 20)]
     pub page_size: Option<u16>,
+    #[field(name = "denomination")]
+    #[param(example = "wrapped")]
+    pub denomination: Option<Denomination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
## Motivation

RAI-710: consumers need current order balances and IO ratios in unwrapped/tStock denomination while preserving wrapped default behavior.

## Solution

- Add a shared denomination enum and conversion helpers.
- Add `denomination=unwrapped` to order detail, orders by owner, and orders by token.
- Fetch current wrap ratios through the shared wrap-ratio path and persist observations best-effort.
- Include denomination in order-token cache keys.
- Document default/current-rate unwrapped behavior in the orders docs.

## Checks

- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test routes::orders`
- `nix develop -c cargo test routes::order::get_order`
- `nix develop -c cargo test`

Closes RAI-710

Linear: https://linear.app/makeitrain/issue/RAI-710/add-denominationtstock-toggle-to-v1orders-endpoints