### PR TITLE
trades: support unwrapped denomination

### DIFF
--- a/docs/src/trades.md
+++ b/docs/src/trades.md
@@ -17,12 +17,20 @@ curl "https://api.st0x.io/v1/trades/0xYourAddress?page=1&pageSize=20" \
   -H "Authorization: Basic <credentials>"
 ```
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `page` | number | 1 | Page number |
-| `pageSize` | number | 20 | Results per page |
-| `startTime` | number | - | Filter: only trades after this Unix timestamp |
-| `endTime` | number | - | Filter: only trades before this Unix timestamp |
+| Parameter      | Type                     | Default   | Description                                                                                                                  |
+| -------------- | ------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `page`         | number                   | 1         | Page number                                                                                                                  |
+| `pageSize`     | number                   | 20        | Results per page                                                                                                             |
+| `startTime`    | number                   | -         | Filter: only trades after this Unix timestamp                                                                                |
+| `endTime`      | number                   | -         | Filter: only trades before this Unix timestamp                                                                               |
+| `denomination` | `wrapped` or `unwrapped` | `wrapped` | Return wrapped token amounts as-is, or normalize observed wrapped token amounts and IO ratios to their unwrapped asset value |
+
+When `denomination=unwrapped`, amount and IO ratio fields are normalized from
+the wrapped token value using the current wrapped exchange rate. This is a
+current-rate normalized view, not a historically exact reconstruction of the
+rate at the trade block. Do not combine unwrapped-normalized trade values with
+wrapped-denomination values from endpoints that were called without
+`denomination=unwrapped`; the calculations will differ.
 
 ### Response
 
@@ -65,14 +73,19 @@ curl "https://api.st0x.io/v1/trades/0xYourAddress?startTime=1708000000&endTime=1
 GET /v1/trades/tx/{tx_hash}
 ```
 
-Detailed breakdown of all trades within a specific transaction, including per-trade request/result and aggregate totals.
+Detailed breakdown of all trades within a specific transaction, including
+per-trade request/result and aggregate totals.
 
 ### Request
 
 ```bash
-curl https://api.st0x.io/v1/trades/tx/0xTxHash... \
+curl "https://api.st0x.io/v1/trades/tx/0xTxHash...?denomination=unwrapped" \
   -H "Authorization: Basic <credentials>"
 ```
+
+| Parameter      | Type                     | Default   | Description                                                                                                                           |
+| -------------- | ------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `denomination` | `wrapped` or `unwrapped` | `wrapped` | Return wrapped token amounts as-is, or normalize observed wrapped token amounts, IO ratios, and totals to their unwrapped asset value |
 
 ### Response
 
@@ -108,3 +121,19 @@ curl https://api.st0x.io/v1/trades/tx/0xTxHash... \
 ```
 
 The `totals` field aggregates across all trades in the transaction.
+
+Historical-rate conversion for older trades will be handled separately once the
+exchange-rate history is incorporated into the trade response path.
+
+## Other Trade Queries
+
+The same denomination behavior is supported by the other trade endpoints:
+
+```text
+GET /v1/trades/token/{address}?denomination=unwrapped
+GET /v1/trades/taker/{address}?denomination=unwrapped
+POST /v1/trades/query
+```
+
+For `POST /v1/trades/query`, include `"denomination": "unwrapped"` in the JSON
+body with `orderHashes`, `startTime`, and `endTime`.

--- a/src/denomination.rs
+++ b/src/denomination.rs
@@ -16,12 +16,12 @@ pub(crate) fn convert_wrapped_amount_for_token(
         return Ok(amount);
     };
 
-    let amount = parse_float(amount, "amount")?;
+    let amount = parse_decimal_float(amount, "amount")?;
     let converted = amount.mul(parse_ratio(ratio)?).map_err(|e| {
         tracing::error!(error = %e, "failed to convert wrapped amount");
         ApiError::Internal("failed to convert wrapped amount".into())
     })?;
-    format_float(converted, "amount")
+    format_decimal_float(converted, "amount")
 }
 
 pub(crate) fn convert_wrapped_io_ratio(
@@ -34,7 +34,7 @@ pub(crate) fn convert_wrapped_io_ratio(
         return Ok(io_ratio);
     }
 
-    let io_ratio = parse_float(io_ratio, "io_ratio")?;
+    let io_ratio = parse_decimal_float(io_ratio, "io_ratio")?;
     let input_assets_per_share = ratio_for_token(input_token, ratios)?;
     let output_assets_per_share = ratio_for_token(output_token, ratios)?;
 
@@ -46,7 +46,7 @@ pub(crate) fn convert_wrapped_io_ratio(
             ApiError::Internal("failed to convert wrapped IO ratio".into())
         })?;
 
-    format_float(converted, "io_ratio")
+    format_decimal_float(converted, "io_ratio")
 }
 
 fn ratio_for_token(token: Address, ratios: &WrapRatioMap) -> Result<Float, ApiError> {
@@ -71,14 +71,14 @@ fn parse_ratio(ratio: &WrapRatioValue) -> Result<Float, ApiError> {
     })
 }
 
-fn parse_float(value: String, label: &str) -> Result<Float, ApiError> {
+pub(crate) fn parse_decimal_float(value: String, label: &str) -> Result<Float, ApiError> {
     Float::parse(value).map_err(|e| {
         tracing::error!(error = %e, label, "failed to parse denomination value");
         ApiError::Internal(format!("failed to parse {label}"))
     })
 }
 
-fn format_float(value: Float, label: &str) -> Result<String, ApiError> {
+pub(crate) fn format_decimal_float(value: Float, label: &str) -> Result<String, ApiError> {
     value.format().map_err(|e| {
         tracing::error!(error = %e, label, "failed to format denomination value");
         ApiError::Internal(format!("failed to format {label}"))

--- a/src/routes/trades/get_by_address.rs
+++ b/src/routes/trades/get_by_address.rs
@@ -2,6 +2,7 @@ use super::{
     build_trades_list_response, trades_pagination_params, RaindexTradesDataSource, TradesDataSource,
 };
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::ValidatedAddress;
@@ -34,6 +35,7 @@ pub async fn get_trades_by_address(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: TradesPaginationParams,
@@ -43,6 +45,7 @@ pub async fn get_trades_by_address(
         let raindex = shared_raindex.read().await;
         let ds = RaindexTradesDataSource {
             client: raindex.client(),
+            pool: pool.inner(),
         };
         process_get_trades_by_address(&ds, address.0, params).await
     }
@@ -55,6 +58,7 @@ pub(super) async fn process_get_trades_by_address(
     owner: Address,
     params: TradesPaginationParams,
 ) -> Result<Json<TradesByAddressResponse>, ApiError> {
+    let denomination = params.denomination.unwrap_or_default();
     let (page, page_size, sdk_page, sdk_page_size, time_filter) = trades_pagination_params(params)?;
 
     let result = ds
@@ -68,7 +72,7 @@ pub(super) async fn process_get_trades_by_address(
         )
         .await?;
 
-    build_trades_list_response(result, page, page_size)
+    build_trades_list_response(ds, result, page, page_size, denomination).await
 }
 
 #[cfg(test)]
@@ -150,6 +154,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_address(
             &ds,
@@ -184,6 +189,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_address(
             &ds,
@@ -210,6 +216,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_address(
             &ds,

--- a/src/routes/trades/get_by_order_hashes.rs
+++ b/src/routes/trades/get_by_order_hashes.rs
@@ -1,7 +1,11 @@
-use super::{map_trade_for_list, RaindexTradesDataSource, TradesDataSource};
+use super::{
+    current_wrap_ratios_for_trades, map_trade_for_list, RaindexTradesDataSource, TradesDataSource,
+};
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
+use crate::types::common::Denomination;
 use crate::types::trades::{
     TradesByOrderHashEntry, TradesByOrderHashesRequest, TradesByOrderHashesResponse,
 };
@@ -32,6 +36,7 @@ pub async fn get_trades_by_order_hashes(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     request: Json<TradesByOrderHashesRequest>,
 ) -> Result<Json<TradesByOrderHashesResponse>, ApiError> {
@@ -47,7 +52,10 @@ pub async fn get_trades_by_order_hashes(
             let raindex = shared_raindex.read().await;
             raindex.client().clone()
         };
-        let ds = RaindexTradesDataSource { client: &client };
+        let ds = RaindexTradesDataSource {
+            client: &client,
+            pool: pool.inner(),
+        };
         process_get_trades_by_order_hashes(&ds, request).await
     }
     .instrument(span.0)
@@ -63,6 +71,7 @@ pub(super) async fn process_get_trades_by_order_hashes(
         start: request.start_time,
         end: request.end_time,
     };
+    let denomination = request.denomination.unwrap_or_default();
 
     tracing::info!(
         order_hashes_count = order_hashes.len(),
@@ -72,7 +81,7 @@ pub(super) async fn process_get_trades_by_order_hashes(
         .get_trades_by_order_hashes(order_hashes, time_filter)
         .await?;
 
-    build_trades_by_order_hashes_response(result)
+    build_trades_by_order_hashes_response(ds, result, denomination).await
 }
 
 fn parse_order_hashes(order_hashes: &[String]) -> Result<Vec<B256>, ApiError> {
@@ -87,9 +96,17 @@ fn parse_order_hashes(order_hashes: &[String]) -> Result<Vec<B256>, ApiError> {
         .collect()
 }
 
-fn build_trades_by_order_hashes_response(
+async fn build_trades_by_order_hashes_response(
+    ds: &dyn TradesDataSource,
     result: RaindexTradesByOrderHashResult,
+    denomination: Denomination,
 ) -> Result<Json<TradesByOrderHashesResponse>, ApiError> {
+    let all_trades = result
+        .trades_by_order_hash()
+        .iter()
+        .flat_map(|entry| entry.trades().iter().cloned())
+        .collect::<Vec<_>>();
+    let trade_wrap_ratios = current_wrap_ratios_for_trades(ds, denomination, &all_trades).await?;
     let trades_by_order_hash = result
         .trades_by_order_hash()
         .iter()
@@ -97,7 +114,7 @@ fn build_trades_by_order_hashes_response(
             let trades = entry
                 .trades()
                 .iter()
-                .map(map_trade_for_list)
+                .map(|trade| map_trade_for_list(trade, denomination, &trade_wrap_ratios))
                 .collect::<Result<Vec<_>, ApiError>>()?;
             Ok(TradesByOrderHashEntry {
                 order_hash: entry.order_hash(),
@@ -225,6 +242,7 @@ mod tests {
             order_hashes: vec![hash_a().to_string(), hash_b().to_string()],
             start_time: Some(1700000000),
             end_time: Some(1700002000),
+            denomination: None,
         };
         let result = process_get_trades_by_order_hashes(&ds, request)
             .await
@@ -259,6 +277,7 @@ mod tests {
             order_hashes: vec![],
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_order_hashes(&ds, request)
             .await
@@ -286,6 +305,7 @@ mod tests {
             order_hashes: vec!["not-a-hash".to_string()],
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_order_hashes(&ds, request).await;
         assert!(matches!(result, Err(ApiError::BadRequest(_))));
@@ -301,6 +321,7 @@ mod tests {
             order_hashes: vec![hash_a().to_string()],
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_order_hashes(&ds, request).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));

--- a/src/routes/trades/get_by_taker.rs
+++ b/src/routes/trades/get_by_taker.rs
@@ -3,6 +3,7 @@ use super::{
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::ValidatedAddress;
@@ -30,12 +31,14 @@ use tracing::Instrument;
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
+#[allow(clippy::too_many_arguments)]
 #[get("/taker/<address>?<params..>")]
 pub async fn get_trades_by_taker(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: TradesPaginationParams,
@@ -48,7 +51,10 @@ pub async fn get_trades_by_taker(
                 let raindex = shared_raindex.read().await;
                 raindex.client().clone()
             };
-            let ds = RaindexTradesDataSource { client: &client };
+            let ds = RaindexTradesDataSource {
+                client: &client,
+                pool: pool.inner(),
+            };
             return process_get_trades_by_taker(&ds, addr, params).await;
         }
 
@@ -61,7 +67,10 @@ pub async fn get_trades_by_taker(
                     let raindex = shared_raindex.read().await;
                     raindex.client().clone()
                 };
-                let ds = RaindexTradesDataSource { client: &client };
+                let ds = RaindexTradesDataSource {
+                    client: &client,
+                    pool: pool.inner(),
+                };
                 process_get_trades_by_taker(&ds, addr, params)
                     .await
                     .map(Json::into_inner)
@@ -79,6 +88,7 @@ pub(super) async fn process_get_trades_by_taker(
     taker: Address,
     params: TradesPaginationParams,
 ) -> Result<Json<TradesByAddressResponse>, ApiError> {
+    let denomination = params.denomination.unwrap_or_default();
     let (page, page_size, sdk_page, sdk_page_size, time_filter) = trades_pagination_params(params)?;
 
     tracing::info!(taker = ?taker, page, page_size, "querying trades by taker");
@@ -86,7 +96,7 @@ pub(super) async fn process_get_trades_by_taker(
         .get_trades_for_taker(taker, sdk_page, sdk_page_size, time_filter)
         .await?;
 
-    build_trades_list_response(result, page, page_size)
+    build_trades_list_response(ds, result, page, page_size, denomination).await
 }
 
 #[cfg(test)]
@@ -189,6 +199,7 @@ mod tests {
             page_size: Some(10),
             start_time: Some(1700000000),
             end_time: Some(1700002000),
+            denomination: None,
         };
         let result = process_get_trades_by_taker(&ds, taker, params)
             .await
@@ -229,6 +240,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_taker(
             &ds,
@@ -256,6 +268,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_taker(
             &ds,

--- a/src/routes/trades/get_by_token.rs
+++ b/src/routes/trades/get_by_token.rs
@@ -3,6 +3,7 @@ use super::{
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::ValidatedAddress;
@@ -30,12 +31,14 @@ use tracing::Instrument;
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
+#[allow(clippy::too_many_arguments)]
 #[get("/token/<address>?<params..>")]
 pub async fn get_trades_by_token(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: TradesPaginationParams,
@@ -47,6 +50,7 @@ pub async fn get_trades_by_token(
             let raindex = shared_raindex.read().await;
             let ds = RaindexTradesDataSource {
                 client: raindex.client(),
+                pool: pool.inner(),
             };
             return process_get_trades_by_token(&ds, addr, params).await;
         }
@@ -59,6 +63,7 @@ pub async fn get_trades_by_token(
                 let raindex = shared_raindex.read().await;
                 let ds = RaindexTradesDataSource {
                     client: raindex.client(),
+                    pool: pool.inner(),
                 };
                 process_get_trades_by_token(&ds, addr, params)
                     .await
@@ -78,7 +83,7 @@ pub(super) fn trades_cache_key(
     params: &TradesPaginationParams,
 ) -> String {
     format!(
-        "{route}/{}/{}/{}/{}/{}",
+        "{route}/{}/{}/{}/{}/{}/{:?}",
         address.to_string().to_ascii_lowercase(),
         params.page.unwrap_or(1),
         params.page_size.unwrap_or(20),
@@ -89,7 +94,8 @@ pub(super) fn trades_cache_key(
         params
             .end_time
             .map(|value| value.to_string())
-            .unwrap_or_default()
+            .unwrap_or_default(),
+        params.denomination.unwrap_or_default()
     )
 }
 
@@ -98,6 +104,7 @@ pub(super) async fn process_get_trades_by_token(
     token: Address,
     params: TradesPaginationParams,
 ) -> Result<Json<TradesByAddressResponse>, ApiError> {
+    let denomination = params.denomination.unwrap_or_default();
     let (page, page_size, sdk_page, sdk_page_size, time_filter) = trades_pagination_params(params)?;
 
     tracing::info!(token = ?token, page, page_size, "querying trades by token");
@@ -105,7 +112,7 @@ pub(super) async fn process_get_trades_by_token(
         .get_trades_for_token(token, sdk_page, sdk_page_size, time_filter)
         .await?;
 
-    build_trades_list_response(result, page, page_size)
+    build_trades_list_response(ds, result, page, page_size, denomination).await
 }
 
 #[cfg(test)]
@@ -189,6 +196,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_token(
             &ds,
@@ -224,12 +232,14 @@ mod tests {
             page_size: None,
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let explicit_params = TradesPaginationParams {
             page: Some(1),
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: Some(crate::types::common::Denomination::Wrapped),
         };
 
         assert_eq!(
@@ -248,6 +258,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_token(
             &ds,
@@ -274,6 +285,7 @@ mod tests {
             page_size: Some(20),
             start_time: None,
             end_time: None,
+            denomination: None,
         };
         let result = process_get_trades_by_token(
             &ds,

--- a/src/routes/trades/get_by_tx.rs
+++ b/src/routes/trades/get_by_tx.rs
@@ -1,14 +1,20 @@
-use super::{RaindexTradesDataSource, TradesDataSource};
+use super::{
+    current_wrap_ratios_for_trades, trade_block_number, wrap_ratio_map_for_trade,
+    RaindexTradesDataSource, TradesDataSource,
+};
 use crate::auth::AuthenticatedKey;
+use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::types::common::ValidatedFixedBytes;
+use crate::types::common::{Denomination, ValidatedFixedBytes};
 use crate::types::trades::{
-    TradeByTxEntry, TradeRequest, TradeResult, TradesByTxResponse, TradesTotals,
+    TradeByTxEntry, TradeRequest, TradeResult, TradesByTxParams, TradesByTxResponse, TradesTotals,
 };
 use alloy::primitives::{Address, B256};
+use rain_math_float::Float;
 use rocket::serde::json::Json;
 use rocket::State;
+use std::ops::{Add, Div, Sub};
 use tracing::Instrument;
 
 #[utoipa::path(
@@ -18,6 +24,7 @@ use tracing::Instrument;
     security(("basicAuth" = [])),
     params(
         ("tx_hash" = String, Path, description = "Transaction hash"),
+        TradesByTxParams,
     ),
     responses(
         (status = 200, description = "Trades from transaction", body = TradesByTxResponse),
@@ -28,21 +35,29 @@ use tracing::Instrument;
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
     )
 )]
-#[get("/tx/<tx_hash>")]
+#[get("/tx/<tx_hash>?<params..>")]
 pub async fn get_trades_by_tx(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    pool: &State<DbPool>,
     span: TracingSpan,
     tx_hash: ValidatedFixedBytes,
+    params: TradesByTxParams,
 ) -> Result<Json<TradesByTxResponse>, ApiError> {
     async move {
-        tracing::info!(tx_hash = ?tx_hash, "request received");
+        tracing::info!(tx_hash = ?tx_hash, params = ?params, "request received");
         let raindex = shared_raindex.read().await;
         let trades_ds = RaindexTradesDataSource {
             client: raindex.client(),
+            pool: pool.inner(),
         };
-        process_get_trades_by_tx(&trades_ds, tx_hash.0).await
+        process_get_trades_by_tx(
+            &trades_ds,
+            tx_hash.0,
+            params.denomination.unwrap_or_default(),
+        )
+        .await
     }
     .instrument(span.0)
     .await
@@ -51,6 +66,7 @@ pub async fn get_trades_by_tx(
 pub(super) async fn process_get_trades_by_tx(
     trades_ds: &dyn TradesDataSource,
     tx_hash: B256,
+    denomination: Denomination,
 ) -> Result<Json<TradesByTxResponse>, ApiError> {
     let result = trades_ds.get_trades_by_tx(tx_hash).await?;
     let trades = result.trades();
@@ -71,37 +87,87 @@ pub(super) async fn process_get_trades_by_tx(
         ApiError::Internal("timestamp overflow".into())
     })?;
     let sender: Address = first_tx.from();
+    let trade_wrap_ratios = current_wrap_ratios_for_trades(trades_ds, denomination, trades).await?;
 
     let trade_entries: Vec<TradeByTxEntry> = trades
         .iter()
         .map(|trade| {
             let input_vc = trade.input_vault_balance_change();
             let output_vc = trade.output_vault_balance_change();
-            let io_ratio = trade.formatted_io_ratio().to_string();
-            let input_amount = input_vc.formatted_amount();
+            let input_token = input_vc.token().address();
+            let output_token = output_vc.token().address();
+            let block_number = trade_block_number(trade)?;
+            let wrap_ratios = if denomination == Denomination::Unwrapped {
+                wrap_ratio_map_for_trade(
+                    input_token,
+                    output_token,
+                    block_number,
+                    &trade_wrap_ratios,
+                )
+            } else {
+                Default::default()
+            };
+            let io_ratio = if denomination == Denomination::Unwrapped {
+                crate::denomination::convert_wrapped_io_ratio(
+                    trade.formatted_io_ratio().to_string(),
+                    input_token,
+                    output_token,
+                    &wrap_ratios,
+                )?
+            } else {
+                trade.formatted_io_ratio().to_string()
+            };
+            let input_amount = if denomination == Denomination::Unwrapped {
+                crate::denomination::convert_wrapped_amount_for_token(
+                    input_vc.formatted_amount(),
+                    input_token,
+                    &wrap_ratios,
+                )?
+            } else {
+                input_vc.formatted_amount()
+            };
+            let output_amount = if denomination == Denomination::Unwrapped {
+                crate::denomination::convert_wrapped_amount_for_token(
+                    output_vc.formatted_amount(),
+                    output_token,
+                    &wrap_ratios,
+                )?
+            } else {
+                output_vc.formatted_amount()
+            };
 
-            TradeByTxEntry {
+            Ok(TradeByTxEntry {
                 order_hash: trade.order_hash(),
                 order_owner: trade.owner(),
                 request: TradeRequest {
-                    input_token: input_vc.token().address(),
-                    output_token: output_vc.token().address(),
+                    input_token,
+                    output_token,
                     maximum_input: input_amount.clone(),
                     maximum_io_ratio: io_ratio.clone(),
                 },
                 result: TradeResult {
                     input_amount,
-                    output_amount: output_vc.formatted_amount(),
+                    output_amount,
                     actual_io_ratio: io_ratio,
                 },
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, ApiError>>()?;
 
     let summary = result.summary().and_then(|s| s.first()).ok_or_else(|| {
         tracing::error!("no pair summary in trades result");
         ApiError::Internal("missing pair summary".into())
     })?;
+
+    let totals = if denomination == Denomination::Unwrapped {
+        totals_from_trade_entries(&trade_entries)?
+    } else {
+        TradesTotals {
+            total_input_amount: summary.formatted_total_input().to_string(),
+            total_output_amount: summary.formatted_total_output().to_string(),
+            average_io_ratio: summary.formatted_average_io_ratio().to_string(),
+        }
+    };
 
     Ok(Json(TradesByTxResponse {
         tx_hash,
@@ -109,12 +175,74 @@ pub(super) async fn process_get_trades_by_tx(
         timestamp,
         sender,
         trades: trade_entries,
-        totals: TradesTotals {
-            total_input_amount: summary.formatted_total_input().to_string(),
-            total_output_amount: summary.formatted_total_output().to_string(),
-            average_io_ratio: summary.formatted_average_io_ratio().to_string(),
-        },
+        totals,
     }))
+}
+
+fn totals_from_trade_entries(trades: &[TradeByTxEntry]) -> Result<TradesTotals, ApiError> {
+    let mut total_input = Float::zero().map_err(|error| {
+        tracing::error!(error = %error, "failed to create zero float");
+        ApiError::Internal("failed to calculate trade totals".into())
+    })?;
+    let mut total_output = Float::zero().map_err(|error| {
+        tracing::error!(error = %error, "failed to create zero float");
+        ApiError::Internal("failed to calculate trade totals".into())
+    })?;
+    let zero = Float::zero().map_err(|error| {
+        tracing::error!(error = %error, "failed to create zero float");
+        ApiError::Internal("failed to calculate trade totals".into())
+    })?;
+
+    for trade in trades {
+        let input =
+            crate::denomination::parse_decimal_float(trade.result.input_amount.clone(), "input")?;
+        let output =
+            crate::denomination::parse_decimal_float(trade.result.output_amount.clone(), "output")?;
+        let normalized_output = zero.sub(output).map_err(|error| {
+            tracing::error!(error = %error, "failed to normalize output amount");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?;
+        total_input = total_input.add(input).map_err(|error| {
+            tracing::error!(error = %error, "failed to calculate total input");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?;
+        total_output = total_output.add(normalized_output).map_err(|error| {
+            tracing::error!(error = %error, "failed to calculate total output");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?;
+    }
+
+    let average_io_ratio = if total_output
+        .eq(Float::zero().map_err(|error| {
+            tracing::error!(error = %error, "failed to create zero float");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?)
+        .map_err(|error| {
+            tracing::error!(error = %error, "failed to compare total output");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })? {
+        Float::zero().map_err(|error| {
+            tracing::error!(error = %error, "failed to create zero float");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?
+    } else {
+        total_input.div(total_output).map_err(|error| {
+            tracing::error!(error = %error, "failed to calculate average IO ratio");
+            ApiError::Internal("failed to calculate trade totals".into())
+        })?
+    };
+
+    Ok(TradesTotals {
+        total_input_amount: crate::denomination::format_decimal_float(total_input, "total_input")?,
+        total_output_amount: crate::denomination::format_decimal_float(
+            total_output,
+            "total_output",
+        )?,
+        average_io_ratio: crate::denomination::format_decimal_float(
+            average_io_ratio,
+            "average_io_ratio",
+        )?,
+    })
 }
 
 #[cfg(test)]
@@ -123,14 +251,17 @@ mod tests {
     use crate::error::ApiError;
     use crate::routes::order::test_fixtures::*;
     use crate::test_helpers::TestClientBuilder;
+    use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::address;
     use async_trait::async_trait;
     use rain_orderbook_common::raindex_client::trades::RaindexTradesListResult;
     use rain_orderbook_common::raindex_client::types::{PaginationParams, TimeFilter};
     use rocket::http::Status;
+    use std::collections::HashMap;
 
     struct MockTradesDataSource {
         result: Result<RaindexTradesListResult, ApiError>,
+        current_wrap_ratios: HashMap<Address, WrapRatioValue>,
     }
 
     #[async_trait]
@@ -184,18 +315,27 @@ mod tests {
         > {
             unimplemented!()
         }
+
+        async fn get_current_wrap_ratios_for_tokens(
+            &self,
+            _token_addresses: &[Address],
+        ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+            Ok(self.current_wrap_ratios.clone())
+        }
     }
 
     #[rocket::async_test]
     async fn test_process_success() {
         let trades_ds = MockTradesDataSource {
             result: Ok(mock_trades_list_result()),
+            current_wrap_ratios: Default::default(),
         };
         let result = process_get_trades_by_tx(
             &trades_ds,
             "0x0000000000000000000000000000000000000000000000000000000000000088"
                 .parse()
                 .unwrap(),
+            Denomination::Wrapped,
         )
         .await
         .unwrap();
@@ -215,15 +355,52 @@ mod tests {
     }
 
     #[rocket::async_test]
+    async fn test_process_converts_unwrapped_amounts_and_totals() {
+        let wrapped_output = address!("4200000000000000000000000000000000000006");
+        let trades_ds = MockTradesDataSource {
+            result: Ok(mock_trades_list_result()),
+            current_wrap_ratios: HashMap::from([(
+                wrapped_output,
+                WrapRatioValue {
+                    share_address: wrapped_output,
+                    assets_per_share: "2".to_string(),
+                },
+            )]),
+        };
+
+        let result = process_get_trades_by_tx(
+            &trades_ds,
+            "0x0000000000000000000000000000000000000000000000000000000000000088"
+                .parse()
+                .unwrap(),
+            Denomination::Unwrapped,
+        )
+        .await
+        .unwrap();
+
+        let response = result.into_inner();
+        assert_eq!(response.trades[0].request.maximum_input, "0.500000");
+        assert_eq!(response.trades[0].request.maximum_io_ratio, "1");
+        assert_eq!(response.trades[0].result.input_amount, "0.500000");
+        assert_eq!(response.trades[0].result.output_amount, "-0.5");
+        assert_eq!(response.trades[0].result.actual_io_ratio, "1");
+        assert_eq!(response.totals.total_input_amount, "0.5");
+        assert_eq!(response.totals.total_output_amount, "0.5");
+        assert_eq!(response.totals.average_io_ratio, "1");
+    }
+
+    #[rocket::async_test]
     async fn test_process_tx_not_found() {
         let trades_ds = MockTradesDataSource {
             result: Ok(mock_empty_trades_list_result()),
+            current_wrap_ratios: Default::default(),
         };
         let result = process_get_trades_by_tx(
             &trades_ds,
             "0x0000000000000000000000000000000000000000000000000000000000000001"
                 .parse()
                 .unwrap(),
+            Denomination::Wrapped,
         )
         .await;
         assert!(matches!(result, Err(ApiError::NotFound(_))));
@@ -233,12 +410,14 @@ mod tests {
     async fn test_process_tx_not_indexed() {
         let trades_ds = MockTradesDataSource {
             result: Err(ApiError::NotYetIndexed("not indexed".into())),
+            current_wrap_ratios: Default::default(),
         };
         let result = process_get_trades_by_tx(
             &trades_ds,
             "0x0000000000000000000000000000000000000000000000000000000000000001"
                 .parse()
                 .unwrap(),
+            Denomination::Wrapped,
         )
         .await;
         assert!(matches!(result, Err(ApiError::NotYetIndexed(_))));
@@ -248,12 +427,14 @@ mod tests {
     async fn test_process_query_failure() {
         let trades_ds = MockTradesDataSource {
             result: Err(ApiError::Internal("subgraph error".into())),
+            current_wrap_ratios: Default::default(),
         };
         let result = process_get_trades_by_tx(
             &trades_ds,
             "0x0000000000000000000000000000000000000000000000000000000000000001"
                 .parse()
                 .unwrap(),
+            Denomination::Wrapped,
         )
         .await;
         assert!(matches!(result, Err(ApiError::Internal(_))));

--- a/src/routes/trades/mod.rs
+++ b/src/routes/trades/mod.rs
@@ -5,9 +5,13 @@ pub(crate) mod get_by_token;
 pub(crate) mod get_by_tx;
 
 use crate::error::ApiError;
-use crate::types::common::TokenRef;
+use crate::types::common::{Denomination, TokenRef};
 use crate::types::trades::{
     TradeByAddress, TradesByAddressResponse, TradesPagination, TradesPaginationParams,
+};
+use crate::wrap_ratio::{
+    persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
+    wrap_ratio_values_from_responses, WrapRatioValue,
 };
 use alloy::primitives::{Address, B256};
 use async_trait::async_trait;
@@ -19,6 +23,9 @@ use rain_orderbook_common::raindex_client::types::{PaginationParams, TimeFilter}
 use rain_orderbook_common::raindex_client::{RaindexClient, RaindexError};
 use rocket::serde::json::Json;
 use rocket::Route;
+use std::collections::HashMap;
+
+pub(crate) type TradeWrapRatioMap = HashMap<(Address, u64), WrapRatioValue>;
 
 #[async_trait]
 pub(crate) trait TradesDataSource: Send + Sync {
@@ -52,10 +59,18 @@ pub(crate) trait TradesDataSource: Send + Sync {
         order_hashes: Vec<B256>,
         time_filter: TimeFilter,
     ) -> Result<RaindexTradesByOrderHashResult, ApiError>;
+
+    async fn get_current_wrap_ratios_for_tokens(
+        &self,
+        _token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        Ok(HashMap::new())
+    }
 }
 
 pub(crate) struct RaindexTradesDataSource<'a> {
     pub client: &'a RaindexClient,
+    pub pool: &'a crate::db::DbPool,
 }
 
 #[async_trait]
@@ -163,9 +178,32 @@ impl TradesDataSource for RaindexTradesDataSource<'_> {
                 ApiError::Internal("failed to query trades".into())
             })
     }
+
+    async fn get_current_wrap_ratios_for_tokens(
+        &self,
+        token_addresses: &[Address],
+    ) -> Result<HashMap<Address, WrapRatioValue>, ApiError> {
+        let tokens: Vec<_> = self
+            .client
+            .get_all_tokens()
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to retrieve curated tokens");
+                ApiError::Internal("failed to retrieve curated tokens".into())
+            })?
+            .into_values()
+            .collect();
+
+        let responses = read_wrap_ratio_responses_for_addresses(&tokens, token_addresses).await?;
+        persist_wrap_ratio_snapshots_best_effort(self.pool, &responses).await;
+        Ok(wrap_ratio_values_from_responses(responses))
+    }
 }
 
-pub(super) fn map_trade_for_list(trade: &RaindexTrade) -> Result<TradeByAddress, ApiError> {
+pub(super) fn map_trade_for_list(
+    trade: &RaindexTrade,
+    denomination: Denomination,
+    trade_wrap_ratios: &TradeWrapRatioMap,
+) -> Result<TradeByAddress, ApiError> {
     let tx_hash = trade.transaction().id();
     let input_vc = trade.input_vault_balance_change();
     let output_vc = trade.output_vault_balance_change();
@@ -177,15 +215,40 @@ pub(super) fn map_trade_for_list(trade: &RaindexTrade) -> Result<TradeByAddress,
         tracing::error!("timestamp does not fit in u64");
         ApiError::Internal("timestamp overflow".into())
     })?;
-    let block_number: u64 = trade.transaction().block_number().try_into().map_err(|_| {
-        tracing::error!("block number does not fit in u64");
-        ApiError::Internal("block number overflow".into())
-    })?;
+    let block_number = trade_block_number(trade)?;
+    let wrap_ratios = if denomination == Denomination::Unwrapped {
+        wrap_ratio_map_for_trade(
+            input_token_data.address(),
+            output_token_data.address(),
+            block_number,
+            trade_wrap_ratios,
+        )
+    } else {
+        HashMap::new()
+    };
+    let input_amount = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            input_vc.formatted_amount(),
+            input_token_data.address(),
+            &wrap_ratios,
+        )?
+    } else {
+        input_vc.formatted_amount()
+    };
+    let output_amount = if denomination == Denomination::Unwrapped {
+        crate::denomination::convert_wrapped_amount_for_token(
+            output_vc.formatted_amount(),
+            output_token_data.address(),
+            &wrap_ratios,
+        )?
+    } else {
+        output_vc.formatted_amount()
+    };
 
     Ok(TradeByAddress {
         tx_hash,
-        input_amount: input_vc.formatted_amount(),
-        output_amount: output_vc.formatted_amount(),
+        input_amount,
+        output_amount,
         input_token: TokenRef {
             address: input_token_data.address(),
             symbol: input_token_data.symbol().unwrap_or_default(),
@@ -202,15 +265,19 @@ pub(super) fn map_trade_for_list(trade: &RaindexTrade) -> Result<TradeByAddress,
     })
 }
 
-pub(super) fn build_trades_list_response(
+pub(super) async fn build_trades_list_response(
+    ds: &dyn TradesDataSource,
     result: RaindexTradesListResult,
     page: u32,
     page_size: u32,
+    denomination: Denomination,
 ) -> Result<Json<TradesByAddressResponse>, ApiError> {
+    let trade_wrap_ratios =
+        current_wrap_ratios_for_trades(ds, denomination, result.trades()).await?;
     let trades = result
         .trades()
         .iter()
-        .map(map_trade_for_list)
+        .map(|trade| map_trade_for_list(trade, denomination, &trade_wrap_ratios))
         .collect::<Result<Vec<_>, ApiError>>()?;
 
     let total_trades = result.total_count();
@@ -231,6 +298,66 @@ pub(super) fn build_trades_list_response(
             has_more,
         },
     }))
+}
+
+pub(super) async fn current_wrap_ratios_for_trades(
+    ds: &dyn TradesDataSource,
+    denomination: Denomination,
+    trades: &[RaindexTrade],
+) -> Result<TradeWrapRatioMap, ApiError> {
+    if denomination == Denomination::Wrapped || trades.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut token_addresses = Vec::new();
+    for trade in trades {
+        token_addresses.push(trade.input_vault_balance_change().token().address());
+        token_addresses.push(trade.output_vault_balance_change().token().address());
+    }
+    token_addresses.sort_unstable();
+    token_addresses.dedup();
+
+    let current_ratios = ds
+        .get_current_wrap_ratios_for_tokens(&token_addresses)
+        .await?;
+    let mut ratios = HashMap::new();
+
+    for trade in trades {
+        let block_number = trade_block_number(trade)?;
+        for token in [
+            trade.input_vault_balance_change().token().address(),
+            trade.output_vault_balance_change().token().address(),
+        ] {
+            if let Some(ratio) = current_ratios.get(&token) {
+                ratios.insert((token, block_number), ratio.clone());
+            }
+        }
+    }
+
+    Ok(ratios)
+}
+
+pub(super) fn wrap_ratio_map_for_trade(
+    input_token: Address,
+    output_token: Address,
+    block_number: u64,
+    trade_wrap_ratios: &TradeWrapRatioMap,
+) -> crate::denomination::WrapRatioMap {
+    let mut ratios = HashMap::new();
+    if let Some(ratio) = trade_wrap_ratios.get(&(input_token, block_number)) {
+        ratios.insert(input_token, ratio.clone());
+    }
+    if let Some(ratio) = trade_wrap_ratios.get(&(output_token, block_number)) {
+        ratios.insert(output_token, ratio.clone());
+    }
+    ratios
+}
+
+pub(super) fn trade_block_number(trade: &RaindexTrade) -> Result<u64, ApiError> {
+    trade.transaction().block_number().try_into().map_err(|_| {
+        tracing::error!("block number does not fit in u64");
+        ApiError::Internal("block number overflow".into())
+    })
 }
 
 pub(super) fn trades_pagination_params(

--- a/src/types/trades.rs
+++ b/src/types/trades.rs
@@ -1,4 +1,4 @@
-use crate::types::common::TokenRef;
+use crate::types::common::{Denomination, TokenRef};
 use alloy::primitives::{Address, FixedBytes, B256};
 use rocket::form::FromForm;
 use serde::{Deserialize, Serialize};
@@ -20,6 +20,18 @@ pub struct TradesPaginationParams {
     #[field(name = "endTime")]
     #[param(example = 1718539200)]
     pub end_time: Option<u64>,
+    #[field(name = "denomination")]
+    #[param(example = "wrapped")]
+    pub denomination: Option<Denomination>,
+}
+
+#[derive(Debug, Clone, FromForm, Serialize, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+#[serde(rename_all = "camelCase")]
+pub struct TradesByTxParams {
+    #[field(name = "denomination")]
+    #[param(example = "wrapped")]
+    pub denomination: Option<Denomination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -75,6 +87,8 @@ pub struct TradesByOrderHashesRequest {
     pub start_time: Option<u64>,
     #[schema(example = 1718539200)]
     pub end_time: Option<u64>,
+    #[schema(example = "wrapped")]
+    pub denomination: Option<Denomination>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]


### PR DESCRIPTION
## Motivation

RAI-663: consumers need trade responses in unwrapped/tStock denomination while wrapped responses stay backwards-compatible.

## Solution

- Add denomination params to trade list, taker/token, tx, and order-hash query endpoints.
- Normalize wrapped trade amounts and IO ratios using the current wrap-ratio source for this velocity version.
- Recompute tx totals from converted trade entries.
- Include denomination in cached trade keys.
- Document that this is current-rate normalization; historical-rate conversion is a follow-up.

## Checks

- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test routes::trades`
- `nix develop -c cargo test`

Closes RAI-663

Linear: https://linear.app/makeitrain/issue/RAI-663/add-denominationtstock-toggle-to-v1trades-endpoints