### PR TITLE
quotes: cache quote results across endpoints

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -3,6 +3,9 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 
+use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
+use rain_orderbook_common::take_orders::TakeOrderCandidate;
+
 use crate::types::orders::OrdersListResponse;
 use crate::types::trades::TradesByAddressResponse;
 
@@ -25,12 +28,10 @@ where
         )
     }
 
-    #[cfg(test)]
     pub(crate) async fn get(&self, key: &K) -> Option<V> {
         self.0.get(key).await
     }
 
-    #[cfg(test)]
     pub(crate) async fn insert(&self, key: K, value: V) {
         self.0.insert(key, value).await
     }
@@ -52,7 +53,9 @@ where
 
 pub(crate) struct RouteResponseCaches {
     enabled: bool,
+    pub order_quotes: AppCache<String, Vec<RaindexOrderQuote>>,
     pub orders_by_token: AppCache<String, OrdersListResponse>,
+    pub swap_candidates: AppCache<String, Vec<TakeOrderCandidate>>,
     pub trades_by_token: AppCache<String, TradesByAddressResponse>,
     pub trades_by_taker: AppCache<String, TradesByAddressResponse>,
     group: CacheGroup,
@@ -67,18 +70,24 @@ impl RouteResponseCaches {
         } else {
             ttl
         };
+        let order_quotes = AppCache::new(max_capacity, ttl);
         let orders_by_token = AppCache::new(max_capacity, ttl);
+        let swap_candidates = AppCache::new(max_capacity, ttl);
         let trades_by_token = AppCache::new(max_capacity, ttl);
         let trades_by_taker = AppCache::new(max_capacity, ttl);
 
         let mut group = CacheGroup::new();
+        group.register(&order_quotes);
         group.register(&orders_by_token);
+        group.register(&swap_candidates);
         group.register(&trades_by_token);
         group.register(&trades_by_taker);
 
         Self {
             enabled,
+            order_quotes,
             orders_by_token,
+            swap_candidates,
             trades_by_token,
             trades_by_taker,
             group,

--- a/src/routes/order/cancel.rs
+++ b/src/routes/order/cancel.rs
@@ -1,4 +1,5 @@
 use super::{OrderDataSource, RaindexOrderDataSource};
+use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
@@ -29,6 +30,7 @@ use tracing::Instrument;
 pub async fn post_order_cancel(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
+    app_state: &State<ApplicationState>,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     span: TracingSpan,
     request: Json<CancelOrderRequest>,
@@ -40,6 +42,7 @@ pub async fn post_order_cancel(
         let raindex = shared_raindex.read().await;
         let ds = RaindexOrderDataSource {
             client: raindex.client(),
+            caches: &app_state.response_caches,
         };
         let response = process_cancel_order(&ds, hash).await?;
         Ok(Json(response))

--- a/src/routes/order/get_order.rs
+++ b/src/routes/order/get_order.rs
@@ -1,4 +1,5 @@
 use super::{OrderDataSource, RaindexOrderDataSource};
+use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
@@ -33,6 +34,7 @@ pub async fn get_order(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
     span: TracingSpan,
     order_hash: ValidatedFixedBytes,
 ) -> Result<Json<OrderDetail>, ApiError> {
@@ -42,6 +44,7 @@ pub async fn get_order(
         let raindex = shared_raindex.read().await;
         let ds = RaindexOrderDataSource {
             client: raindex.client(),
+            caches: &app_state.response_caches,
         };
         let detail = process_get_order(&ds, hash).await?;
         Ok(Json(detail))

--- a/src/routes/order/mod.rs
+++ b/src/routes/order/mod.rs
@@ -3,6 +3,7 @@ mod deploy_dca;
 mod deploy_solver;
 mod get_order;
 
+use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
 use alloy::primitives::{Bytes, B256};
 use async_trait::async_trait;
@@ -28,6 +29,7 @@ pub(crate) trait OrderDataSource: Send + Sync {
 
 pub(crate) struct RaindexOrderDataSource<'a> {
     pub client: &'a RaindexClient,
+    pub caches: &'a RouteResponseCaches,
 }
 
 #[async_trait]
@@ -51,10 +53,22 @@ impl<'a> OrderDataSource for RaindexOrderDataSource<'a> {
         &self,
         order: &RaindexOrder,
     ) -> Result<Vec<RaindexOrderQuote>, ApiError> {
-        order.get_quotes(None, None).await.map_err(|e| {
-            tracing::error!(error = %e, "failed to query order quotes");
-            ApiError::Internal("failed to query order quotes".into())
-        })
+        let fetch = || async {
+            order.get_quotes(None, None).await.map_err(|e| {
+                tracing::error!(error = %e, "failed to query order quotes");
+                ApiError::Internal("failed to query order quotes".into())
+            })
+        };
+
+        if !self.caches.is_enabled() {
+            return fetch().await;
+        }
+
+        self.caches
+            .order_quotes
+            .get_or_try_insert(crate::routes::orders::order_quote_cache_key(order), fetch)
+            .await
+            .map_err(|e| (*e).clone())
     }
 
     async fn get_order_trades(&self, order: &RaindexOrder) -> Result<Vec<RaindexTrade>, ApiError> {

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -2,6 +2,7 @@ use super::{
     build_orders_list_response, OrdersListDataSource, RaindexOrdersListDataSource,
     DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
+use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
@@ -72,6 +73,7 @@ pub async fn get_orders_by_address(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
     span: TracingSpan,
     address: ValidatedAddress,
     params: OrdersPaginationParams,
@@ -84,6 +86,7 @@ pub async fn get_orders_by_address(
         let raindex = shared_raindex.read().await;
         let ds = RaindexOrdersListDataSource {
             client: raindex.client(),
+            caches: &app_state.response_caches,
         };
         let response = process_get_orders_by_owner(&ds, addr, page, page_size).await?;
         Ok(Json(response))

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -105,6 +105,7 @@ pub async fn get_orders_by_token(
             let raindex = shared_raindex.read().await;
             let ds = RaindexOrdersListDataSource {
                 client: raindex.client(),
+                caches: &app_state.response_caches,
             };
             let response = process_get_orders_by_token(&ds, addr, side, page, page_size).await?;
             return Ok(Json(response));
@@ -118,6 +119,7 @@ pub async fn get_orders_by_token(
                 let raindex = shared_raindex.read().await;
                 let ds = RaindexOrdersListDataSource {
                     client: raindex.client(),
+                    caches: &app_state.response_caches,
                 };
                 process_get_orders_by_token(&ds, addr, side, page, page_size).await
             })

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -2,6 +2,7 @@ mod get_by_owner;
 mod get_by_token;
 mod get_by_tx;
 
+use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
 use crate::types::common::TokenRef;
 use crate::types::orders::{OrderSummary, OrdersListResponse, OrdersPagination};
@@ -54,6 +55,16 @@ pub(crate) trait OrdersListDataSource: Send + Sync {
 
 pub(crate) struct RaindexOrdersListDataSource<'a> {
     pub client: &'a RaindexClient,
+    pub caches: &'a RouteResponseCaches,
+}
+
+pub(crate) fn order_quote_cache_key(order: &RaindexOrder) -> String {
+    format!(
+        "order-quotes/latest/default/{}/{}/{}",
+        order.chain_id(),
+        order.raindex(),
+        order.order_hash()
+    )
 }
 
 fn group_orders_by_chain(orders: &[RaindexOrder]) -> GroupedOrders {
@@ -193,21 +204,73 @@ impl<'a> OrdersListDataSource for RaindexOrdersListDataSource<'a> {
         &self,
         order: &RaindexOrder,
     ) -> Result<Vec<RaindexOrderQuote>, ApiError> {
-        order.get_quotes(None, None).await.map_err(|e| {
-            tracing::error!(error = %e, "failed to query order quotes");
-            ApiError::Internal("failed to query order quotes".into())
-        })
+        let fetch = || async {
+            order.get_quotes(None, None).await.map_err(|e| {
+                tracing::error!(error = %e, "failed to query order quotes");
+                ApiError::Internal("failed to query order quotes".into())
+            })
+        };
+
+        if !self.caches.is_enabled() {
+            return fetch().await;
+        }
+
+        self.caches
+            .order_quotes
+            .get_or_try_insert(order_quote_cache_key(order), fetch)
+            .await
+            .map_err(|e| (*e).clone())
     }
 
     async fn get_order_quotes_batch_for_chain(
         &self,
         orders: &[RaindexOrder],
     ) -> OrderQuoteBatchResult {
+        if !self.caches.is_enabled() {
+            return fetch_order_quotes_batch(orders, None, None)
+                .await
+                .map_err(|error| {
+                    let chain_id = orders
+                        .first()
+                        .map(RaindexOrder::chain_id)
+                        .unwrap_or_default();
+                    tracing::error!(
+                        chain_id,
+                        error = %error,
+                        "failed to batch query order quotes"
+                    );
+                    ApiError::Internal("failed to query order quotes".into())
+                });
+        }
+
+        let mut ordered_quotes: Vec<Option<Vec<RaindexOrderQuote>>> =
+            Vec::with_capacity(orders.len());
+        ordered_quotes.resize_with(orders.len(), || None);
+        let mut missed_orders = Vec::new();
+        let mut missed_keys = Vec::new();
+
+        for (index, order) in orders.iter().enumerate() {
+            let key = order_quote_cache_key(order);
+            if let Some(quotes) = self.caches.order_quotes.get(&key).await {
+                ordered_quotes[index] = Some(quotes);
+            } else {
+                missed_orders.push(order.clone());
+                missed_keys.push((index, key));
+            }
+        }
+
+        if missed_orders.is_empty() {
+            return Ok(ordered_quotes
+                .into_iter()
+                .map(|quotes| quotes.unwrap_or_default())
+                .collect());
+        }
+
         let chain_id = orders
             .first()
             .map(RaindexOrder::chain_id)
             .unwrap_or_default();
-        fetch_order_quotes_batch(orders, None, None)
+        let missed_quotes = fetch_order_quotes_batch(&missed_orders, None, None)
             .await
             .map_err(|error| {
                 tracing::error!(
@@ -216,7 +279,26 @@ impl<'a> OrdersListDataSource for RaindexOrdersListDataSource<'a> {
                     "failed to batch query order quotes"
                 );
                 ApiError::Internal("failed to query order quotes".into())
-            })
+            })?;
+
+        if missed_quotes.len() != missed_keys.len() {
+            tracing::error!(
+                expected_results = missed_keys.len(),
+                actual_results = missed_quotes.len(),
+                "order quote cache miss batch returned unexpected result count"
+            );
+            return Err(ApiError::Internal("failed to query order quotes".into()));
+        }
+
+        for ((index, key), quotes) in missed_keys.into_iter().zip(missed_quotes) {
+            self.caches.order_quotes.insert(key, quotes.clone()).await;
+            ordered_quotes[index] = Some(quotes);
+        }
+
+        Ok(ordered_quotes
+            .into_iter()
+            .map(|quotes| quotes.unwrap_or_default())
+            .collect())
     }
 }
 

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1,4 +1,5 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
+use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
@@ -29,6 +30,7 @@ pub async fn post_swap_calldata(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
     span: TracingSpan,
     request: Json<SwapCalldataRequest>,
 ) -> Result<Json<SwapCalldataResponse>, ApiError> {
@@ -38,6 +40,7 @@ pub async fn post_swap_calldata(
         let raindex = shared_raindex.read().await;
         let ds = RaindexSwapDataSource {
             client: raindex.client(),
+            caches: &app_state.response_caches,
         };
         let response = process_swap_calldata(&ds, req).await?;
         Ok(Json(response))

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -1,6 +1,7 @@
 mod calldata;
 mod quote;
 
+use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
 use crate::types::swap::SwapCalldataResponse;
 use alloy::primitives::Address;
@@ -45,6 +46,28 @@ pub(crate) trait SwapDataSource: Send + Sync {
 
 pub(crate) struct RaindexSwapDataSource<'a> {
     pub client: &'a RaindexClient,
+    pub caches: &'a RouteResponseCaches,
+}
+
+fn swap_candidates_cache_key(
+    orders: &[RaindexOrder],
+    input_token: Address,
+    output_token: Address,
+) -> String {
+    let mut order_keys = orders
+        .iter()
+        .map(|order| {
+            format!(
+                "{}:{}:{}",
+                order.chain_id(),
+                order.raindex(),
+                order.order_hash()
+            )
+        })
+        .collect::<Vec<_>>();
+    order_keys.sort_unstable();
+    let order_keys = order_keys.join(",");
+    format!("swap-candidates/latest/default/{input_token}/{output_token}/{order_keys}")
 }
 
 #[async_trait]
@@ -109,20 +132,35 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         input_token: Address,
         output_token: Address,
     ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
-        build_take_order_candidates_for_pair(
-            orders,
-            input_token,
-            output_token,
-            None,
-            None,
-            Address::ZERO,
-            &NoopInjector,
-        )
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "failed to build order candidates");
-            ApiError::Internal("failed to build order candidates".into())
-        })
+        let fetch = || async {
+            build_take_order_candidates_for_pair(
+                orders,
+                input_token,
+                output_token,
+                None,
+                None,
+                Address::ZERO,
+                &NoopInjector,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "failed to build order candidates");
+                ApiError::Internal("failed to build order candidates".into())
+            })
+        };
+
+        if !self.caches.is_enabled() {
+            return fetch().await;
+        }
+
+        self.caches
+            .swap_candidates
+            .get_or_try_insert(
+                swap_candidates_cache_key(orders, input_token, output_token),
+                fetch,
+            )
+            .await
+            .map_err(|e| (*e).clone())
     }
 
     async fn get_calldata(
@@ -200,6 +238,44 @@ pub use quote::*;
 
 pub fn routes() -> Vec<Route> {
     rocket::routes![quote::post_swap_quote, calldata::post_swap_calldata]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::swap_candidates_cache_key;
+    use alloy::primitives::address;
+    use rain_orderbook_common::raindex_client::orders::RaindexOrder;
+    use serde_json::json;
+
+    fn mock_order(chain_id: u32, order_hash: &str) -> RaindexOrder {
+        let mut value = crate::test_helpers::order_json();
+        value["chainId"] = json!(chain_id);
+        value["orderHash"] = json!(order_hash);
+        serde_json::from_value(value).expect("deserialize mock order")
+    }
+
+    #[test]
+    fn test_swap_candidates_cache_key_is_order_insensitive() {
+        let input_token = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let output_token = address!("4200000000000000000000000000000000000006");
+        let order_a = mock_order(
+            8453,
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        );
+        let order_b = mock_order(
+            8453,
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+        );
+
+        assert_eq!(
+            swap_candidates_cache_key(
+                &[order_a.clone(), order_b.clone()],
+                input_token,
+                output_token,
+            ),
+            swap_candidates_cache_key(&[order_b, order_a], input_token, output_token)
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -1,4 +1,5 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
+use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
@@ -30,6 +31,7 @@ pub async fn post_swap_quote(
     _global: GlobalRateLimit,
     _key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
     span: TracingSpan,
     request: Json<SwapQuoteRequest>,
 ) -> Result<Json<SwapQuoteResponse>, ApiError> {
@@ -39,6 +41,7 @@ pub async fn post_swap_quote(
         let raindex = shared_raindex.read().await;
         let ds = RaindexSwapDataSource {
             client: raindex.client(),
+            caches: &app_state.response_caches,
         };
         let response = process_swap_quote(&ds, req).await?;
         Ok(Json(response))

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -291,7 +291,7 @@ fn stub_raindex_client() -> serde_json::Value {
     })
 }
 
-fn order_json() -> serde_json::Value {
+pub(crate) fn order_json() -> serde_json::Value {
     let rc = stub_raindex_client();
     json!({
         "raindexClient": rc,


### PR DESCRIPTION
## Motivation

Production logs showed repeated polling against order and swap flows. The list/order lookups themselves are local where applicable, but the quote/candidate work still calls through the raindex submodule and can drive upstream RPC usage when the same inputs are requested repeatedly.

## Solution

- Add shared in-process caches for quote results and swap candidate results using the existing response-cache configuration, including the 5 second production TTL.
- Cache `RaindexOrderQuote` results by chain, raindex address, and order hash so order detail and order list endpoints can reuse the same recent quote values.
- Cache swap candidate results by token pair and active order set so repeated swap quote/calldata requests can reuse the returned submodule result.
- Keep the existing submodule API calls unchanged and cache only the results in this REST API layer.
- Leave existing route response caches for orders-by-token and trades in place, without adding a whole-response cache for orders-by-owner.

## Checks

- `nix develop -c cargo fmt`
- `nix develop -c cargo check`
- `nix develop -c cargo test routes::orders`
- `nix develop -c cargo test routes::order`
- `nix develop -c cargo test routes::swap`
- `nix develop -c cargo test`
- `nix develop -c rainix-rs-static`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Introduced response caching for order quotes throughout order operations to reduce redundant data fetches and improve API response times. Added caching support for swap candidate data to optimize swap-related operations.

* **Tests**
  * Added test coverage for cache key generation to ensure consistency and proper functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->