### PR TITLE
RAI-753 support inactive order summaries

### DIFF
--- a/docs/src/orders.md
+++ b/docs/src/orders.md
@@ -146,7 +146,7 @@ response.
 ## List Orders by Owner
 
 ```
-GET /v1/orders/{address}
+GET /v1/orders/owner/{address}
 ```
 
 Paginated list of orders for a wallet address.
@@ -154,21 +154,22 @@ Paginated list of orders for a wallet address.
 ### Request
 
 ```bash
-curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10" \
+curl "https://api.st0x.io/v1/orders/owner/0xOwnerAddress?state=active&page=1&pageSize=10" \
   -H "Authorization: Basic <credentials>"
 ```
 
-| Parameter      | Type                     | Default   | Description                                                                                               |
-| -------------- | ------------------------ | --------- | --------------------------------------------------------------------------------------------------------- |
-| `page`         | number                   | 1         | Page number                                                                                               |
-| `pageSize`     | number                   | 20        | Results per page                                                                                          |
-| `denomination` | `wrapped` or `unwrapped` | `wrapped` | Return wrapped token amounts as-is, or normalize wrapped token balances and IO ratios to unwrapped values |
+| Parameter      | Type                           | Default   | Description                                                                                               |
+| -------------- | ------------------------------ | --------- | --------------------------------------------------------------------------------------------------------- |
+| `state`        | `active`, `inactive`, or `all` | `active`  | Filter by current order state                                                                             |
+| `page`         | number                         | 1         | Page number                                                                                               |
+| `pageSize`     | number                         | 20        | Results per page                                                                                          |
+| `denomination` | `wrapped` or `unwrapped`       | `wrapped` | Return wrapped token amounts as-is, or normalize wrapped token balances and IO ratios to unwrapped values |
 
 Use `denomination=unwrapped` to view order balances and IO ratios normalized to
 the current unwrapped asset value:
 
 ```bash
-curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10&denomination=unwrapped" \
+curl "https://api.st0x.io/v1/orders/owner/0xOwnerAddress?state=active&page=1&pageSize=10&denomination=unwrapped" \
   -H "Authorization: Basic <credentials>"
 ```
 
@@ -180,6 +181,11 @@ curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10&denominati
     {
       "orderHash": "0xabc123...",
       "owner": "0xOwnerAddress",
+      "chainId": 8453,
+      "orderBytes": "0x...",
+      "active": true,
+      "removedAt": null,
+      "orderType": "limit",
       "inputToken": { "address": "0x...", "symbol": "USDC", "decimals": 6 },
       "outputToken": { "address": "0x...", "symbol": "WETH", "decimals": 18 },
       "outputVaultBalance": "0.5",
@@ -201,6 +207,37 @@ curl "https://api.st0x.io/v1/orders/0xOwnerAddress?page=1&pageSize=10&denominati
 
 `maxOutput` is the quote-derived executable output amount for the listed order.
 It is `null` when quote data is unavailable.
+
+`orderType` is one of `limit`, `dca`, `dynamic-spread`, or `custom`.
+
+When `state=inactive`, orders are returned without live quote data: `ioRatio` is
+`"-"`, `maxOutput` is `null`, and `outputVaultBalance` is `"0"`. `chainId`,
+`orderBytes`, token refs, `orderType`, `active`, and `removedAt` remain
+populated when available.
+
+## List Orders by Token
+
+```
+GET /v1/orders/token/{address}
+```
+
+Paginated list of orders for a token address.
+
+### Request
+
+```bash
+curl "https://api.st0x.io/v1/orders/token/0xTokenAddress?state=all&side=output&page=1&pageSize=10" \
+  -H "Authorization: Basic <credentials>"
+```
+
+| Parameter  | Type                           | Default  | Description                          |
+| ---------- | ------------------------------ | -------- | ------------------------------------ |
+| `state`    | `active`, `inactive`, or `all` | `active` | Filter by current order state        |
+| `side`     | `input` or `output`            | all      | Match token as an input/output token |
+| `page`     | number                         | 1        | Page number                          |
+| `pageSize` | number                         | 20       | Results per page                     |
+
+The response shape is the same as list orders by owner.
 
 ## List Orders by Transaction
 

--- a/src/routes/orders/get_by_owner.rs
+++ b/src/routes/orders/get_by_owner.rs
@@ -1,6 +1,7 @@
 use super::{
-    build_orders_list_response, current_wrap_ratios_for_orders, OrdersListDataSource,
-    RaindexOrdersListDataSource, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+    active_filter_for_state, build_orders_list_response, current_wrap_ratios_for_orders,
+    get_order_quotes_for_summaries, OrdersListDataSource, RaindexOrdersListDataSource,
+    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
@@ -8,7 +9,7 @@ use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::{Denomination, ValidatedAddress};
-use crate::types::orders::{OrdersListResponse, OrdersPaginationParams};
+use crate::types::orders::{OrderState, OrdersListResponse, OrdersPaginationParams};
 use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rocket::serde::json::Json;
@@ -18,14 +19,16 @@ use tracing::Instrument;
 pub(crate) async fn process_get_orders_by_owner(
     ds: &dyn OrdersListDataSource,
     address: Address,
+    state: Option<OrderState>,
     page: Option<u16>,
     page_size: Option<u16>,
     denomination: Denomination,
 ) -> Result<OrdersListResponse, ApiError> {
+    let active_filter = active_filter_for_state(state);
     let filters = GetOrdersFilters {
         owners: vec![address],
-        active: Some(true),
-        has_positive_output_vault_balance: Some(true),
+        active: active_filter,
+        has_positive_output_vault_balance: (active_filter == Some(true)).then_some(true),
         ..Default::default()
     };
 
@@ -41,7 +44,7 @@ pub(crate) async fn process_get_orders_by_owner(
         quoted_orders = orders.len(),
         "fetching batched quotes for orders by owner"
     );
-    let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let quote_results = get_order_quotes_for_summaries(ds, &orders).await;
     let wrap_ratios = current_wrap_ratios_for_orders(ds, denomination, &orders).await?;
 
     build_orders_list_response(
@@ -88,6 +91,7 @@ pub async fn get_orders_by_address(
     async move {
         tracing::info!(address = ?address, params = ?params, "request received");
         let addr = address.0;
+        let state = params.state;
         let page = params.page;
         let page_size = params.page_size;
         let denomination = params.denomination.unwrap_or_default();
@@ -98,7 +102,7 @@ pub async fn get_orders_by_address(
             pool: pool.inner(),
         };
         let response =
-            process_get_orders_by_owner(&ds, addr, page, page_size, denomination).await?;
+            process_get_orders_by_owner(&ds, addr, state, page, page_size, denomination).await?;
         Ok(Json(response))
     }
     .instrument(span.0)
@@ -111,8 +115,11 @@ mod tests {
     use crate::routes::order::test_fixtures::{
         mock_order, mock_order_with_shared_vaults, mock_quote,
     };
-    use crate::routes::orders::test_fixtures::MockOrdersListDataSource;
+    use crate::routes::orders::test_fixtures::{
+        MockOrdersListDataSource, RecordingOrdersListDataSource,
+    };
     use crate::test_helpers::{basic_auth_header, seed_api_key, TestClientBuilder};
+    use crate::types::orders::OrderSummaryOrderType;
     use rocket::http::{Header, Status};
 
     #[rocket::async_test]
@@ -125,14 +132,19 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_owner(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "USDC");
         assert_eq!(result.orders[0].output_token.symbol, "WETH");
+        assert_eq!(result.orders[0].chain_id, 8453);
         assert_eq!(result.orders[0].order_bytes.as_ref(), &[1]);
+        assert!(result.orders[0].active);
+        assert_eq!(result.orders[0].removed_at, None);
+        assert_eq!(result.orders[0].order_type, OrderSummaryOrderType::Custom);
         assert_eq!(result.orders[0].io_ratio, "1.5");
         assert_eq!(result.orders[0].max_output.as_deref(), Some("1"));
         assert_eq!(result.pagination.total_orders, 1);
@@ -150,9 +162,10 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_owner(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert!(result.orders.is_empty());
         assert_eq!(result.pagination.total_orders, 0);
@@ -169,9 +182,10 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_owner(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders[0].io_ratio, "-");
         assert_eq!(result.orders[0].max_output, None);
@@ -188,7 +202,7 @@ mod tests {
             .parse()
             .unwrap();
         let result =
-            process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped).await;
+            process_get_orders_by_owner(&ds, addr, None, None, None, Denomination::Wrapped).await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -202,14 +216,64 @@ mod tests {
         let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
             .parse()
             .unwrap();
-        let result = process_get_orders_by_owner(&ds, addr, None, None, Denomination::Wrapped)
-            .await
-            .unwrap();
+        let result =
+            process_get_orders_by_owner(&ds, addr, None, None, None, Denomination::Wrapped)
+                .await
+                .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "wtMSTR");
         assert_eq!(result.orders[0].output_token.symbol, "wtMSTR");
+        assert_eq!(result.orders[0].chain_id, 8453);
         assert_eq!(result.orders[0].io_ratio, "200.0");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_owner_inactive_state_sets_active_false_filter() {
+        let ds = RecordingOrdersListDataSource::default();
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        let result = process_get_orders_by_owner(
+            &ds,
+            addr,
+            Some(OrderState::Inactive),
+            None,
+            None,
+            Denomination::Wrapped,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let filters = ds.filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].active, Some(false));
+        assert_eq!(filters[0].has_positive_output_vault_balance, None);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_owner_all_state_omits_active_filter() {
+        let ds = RecordingOrdersListDataSource::default();
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        let result = process_get_orders_by_owner(
+            &ds,
+            addr,
+            Some(OrderState::All),
+            None,
+            None,
+            Denomination::Wrapped,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let filters = ds.filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].active, None);
+        assert_eq!(filters[0].has_positive_output_vault_balance, None);
     }
 
     #[rocket::async_test]

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -1,6 +1,7 @@
 use super::{
-    build_orders_list_response, current_wrap_ratios_for_orders, OrdersListDataSource,
-    RaindexOrdersListDataSource, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
+    active_filter_for_state, build_orders_list_response, current_wrap_ratios_for_orders,
+    get_order_quotes_for_summaries, OrdersListDataSource, RaindexOrdersListDataSource,
+    DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE,
 };
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
@@ -8,7 +9,7 @@ use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::{Denomination, ValidatedAddress};
-use crate::types::orders::{OrderSide, OrdersByTokenParams, OrdersListResponse};
+use crate::types::orders::{OrderSide, OrderState, OrdersByTokenParams, OrdersListResponse};
 use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::orders::GetOrdersFilters;
 use rain_orderbook_common::raindex_client::orders::GetOrdersTokenFilter;
@@ -19,6 +20,7 @@ use tracing::Instrument;
 pub(crate) async fn process_get_orders_by_token(
     ds: &dyn OrdersListDataSource,
     address: Address,
+    state: Option<OrderState>,
     side: Option<OrderSide>,
     page: Option<u16>,
     page_size: Option<u16>,
@@ -39,10 +41,11 @@ pub(crate) async fn process_get_orders_by_token(
         },
     };
 
+    let active_filter = active_filter_for_state(state);
     let filters = GetOrdersFilters {
-        active: Some(true),
+        active: active_filter,
         tokens: Some(token_filter),
-        has_positive_output_vault_balance: Some(true),
+        has_positive_output_vault_balance: (active_filter == Some(true)).then_some(true),
         ..Default::default()
     };
 
@@ -58,7 +61,7 @@ pub(crate) async fn process_get_orders_by_token(
         quoted_orders = orders.len(),
         "fetching batched quotes for orders by token"
     );
-    let quote_results = ds.get_order_quotes_batch(&orders).await;
+    let quote_results = get_order_quotes_for_summaries(ds, &orders).await;
     let wrap_ratios = current_wrap_ratios_for_orders(ds, denomination, &orders).await?;
 
     build_orders_list_response(
@@ -105,6 +108,7 @@ pub async fn get_orders_by_token(
     async move {
         tracing::info!(address = ?address, params = ?params, "request received");
         let addr = address.0;
+        let state = params.state;
         let side = params.side;
         let page = params.page;
         let page_size = params.page_size;
@@ -117,12 +121,13 @@ pub async fn get_orders_by_token(
                 pool: pool.inner(),
             };
             let response =
-                process_get_orders_by_token(&ds, addr, side, page, page_size, denomination).await?;
+                process_get_orders_by_token(&ds, addr, state, side, page, page_size, denomination)
+                    .await?;
             return Ok(Json(response));
         }
 
         let cache_key =
-            orders_by_token_cache_key(addr, side.as_ref(), page, page_size, denomination);
+            orders_by_token_cache_key(addr, state, side.as_ref(), page, page_size, denomination);
         let response = app_state
             .response_caches
             .orders_by_token
@@ -133,7 +138,8 @@ pub async fn get_orders_by_token(
                     caches: &app_state.response_caches,
                     pool: pool.inner(),
                 };
-                process_get_orders_by_token(&ds, addr, side, page, page_size, denomination).await
+                process_get_orders_by_token(&ds, addr, state, side, page, page_size, denomination)
+                    .await
             })
             .await
             .map_err(|e| (*e).clone())?;
@@ -145,11 +151,17 @@ pub async fn get_orders_by_token(
 
 fn orders_by_token_cache_key(
     address: Address,
+    state: Option<OrderState>,
     side: Option<&OrderSide>,
     page: Option<u16>,
     page_size: Option<u16>,
     denomination: Denomination,
 ) -> String {
+    let state = match state.unwrap_or(OrderState::Active) {
+        OrderState::Active => "active",
+        OrderState::Inactive => "inactive",
+        OrderState::All => "all",
+    };
     let side = match side {
         Some(OrderSide::Input) => "input",
         Some(OrderSide::Output) => "output",
@@ -160,7 +172,7 @@ fn orders_by_token_cache_key(
         .unwrap_or(DEFAULT_PAGE_SIZE as u16)
         .min(MAX_PAGE_SIZE);
     format!(
-        "orders/token/{}/{side}/{page}/{page_size}/{denomination:?}",
+        "orders/token/{}/{state}/{side}/{page}/{page_size}/{denomination:?}",
         address.to_string().to_ascii_lowercase()
     )
 }
@@ -171,8 +183,11 @@ mod tests {
     use crate::routes::order::test_fixtures::{
         mock_order, mock_order_with_shared_vaults, mock_quote,
     };
-    use crate::routes::orders::test_fixtures::MockOrdersListDataSource;
+    use crate::routes::orders::test_fixtures::{
+        MockOrdersListDataSource, RecordingOrdersListDataSource,
+    };
     use crate::test_helpers::{basic_auth_header, seed_api_key, TestClientBuilder};
+    use crate::types::orders::OrderSummaryOrderType;
     use rocket::http::{Header, Status};
 
     #[rocket::async_test]
@@ -186,14 +201,18 @@ mod tests {
             .parse()
             .unwrap();
         let result =
-            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+            process_get_orders_by_token(&ds, addr, None, None, None, None, Denomination::Wrapped)
                 .await
                 .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "USDC");
         assert_eq!(result.orders[0].output_token.symbol, "WETH");
+        assert_eq!(result.orders[0].chain_id, 8453);
         assert_eq!(result.orders[0].order_bytes.as_ref(), &[1]);
+        assert!(result.orders[0].active);
+        assert_eq!(result.orders[0].removed_at, None);
+        assert_eq!(result.orders[0].order_type, OrderSummaryOrderType::Custom);
         assert_eq!(result.orders[0].io_ratio, "1.5");
         assert_eq!(result.orders[0].max_output.as_deref(), Some("1"));
         assert_eq!(result.pagination.total_orders, 1);
@@ -214,6 +233,7 @@ mod tests {
         let result = process_get_orders_by_token(
             &ds,
             addr,
+            None,
             Some(OrderSide::Input),
             None,
             None,
@@ -238,7 +258,7 @@ mod tests {
             .parse()
             .unwrap();
         let result =
-            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+            process_get_orders_by_token(&ds, addr, None, None, None, None, Denomination::Wrapped)
                 .await
                 .unwrap();
 
@@ -257,7 +277,8 @@ mod tests {
             .parse()
             .unwrap();
         let result =
-            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped).await;
+            process_get_orders_by_token(&ds, addr, None, None, None, None, Denomination::Wrapped)
+                .await;
         assert!(matches!(result, Err(ApiError::Internal(_))));
     }
 
@@ -272,13 +293,64 @@ mod tests {
             .parse()
             .unwrap();
         let result =
-            process_get_orders_by_token(&ds, addr, None, None, None, Denomination::Wrapped)
+            process_get_orders_by_token(&ds, addr, None, None, None, None, Denomination::Wrapped)
                 .await
                 .unwrap();
 
         assert_eq!(result.orders.len(), 1);
         assert_eq!(result.orders[0].input_token.symbol, "wtMSTR");
         assert_eq!(result.orders[0].output_token.symbol, "wtMSTR");
+        assert_eq!(result.orders[0].chain_id, 8453);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_token_inactive_state_sets_active_false_filter() {
+        let ds = RecordingOrdersListDataSource::default();
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        let result = process_get_orders_by_token(
+            &ds,
+            addr,
+            Some(OrderState::Inactive),
+            None,
+            None,
+            None,
+            Denomination::Wrapped,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let filters = ds.filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].active, Some(false));
+        assert_eq!(filters[0].has_positive_output_vault_balance, None);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_get_orders_by_token_all_state_omits_active_filter() {
+        let ds = RecordingOrdersListDataSource::default();
+        let addr: Address = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+            .parse()
+            .unwrap();
+
+        let result = process_get_orders_by_token(
+            &ds,
+            addr,
+            Some(OrderState::All),
+            None,
+            None,
+            None,
+            Denomination::Wrapped,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let filters = ds.filters.lock().expect("lock filters");
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].active, None);
+        assert_eq!(filters[0].has_positive_output_vault_balance, None);
     }
 
     #[rocket::async_test]
@@ -317,12 +389,31 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            orders_by_token_cache_key(lower, None, None, None, Denomination::Wrapped),
+            orders_by_token_cache_key(lower, None, None, None, None, Denomination::Wrapped),
             orders_by_token_cache_key(
                 mixed,
                 None,
+                None,
                 Some(1),
                 Some(DEFAULT_PAGE_SIZE as u16),
+                Denomination::Wrapped
+            )
+        );
+        assert_ne!(
+            orders_by_token_cache_key(
+                lower,
+                Some(OrderState::Inactive),
+                None,
+                None,
+                None,
+                Denomination::Wrapped
+            ),
+            orders_by_token_cache_key(
+                lower,
+                Some(OrderState::All),
+                None,
+                None,
+                None,
                 Denomination::Wrapped
             )
         );

--- a/src/routes/orders/mod.rs
+++ b/src/routes/orders/mod.rs
@@ -5,7 +5,9 @@ mod get_by_tx;
 use crate::cache::RouteResponseCaches;
 use crate::error::ApiError;
 use crate::types::common::{Denomination, TokenRef};
-use crate::types::orders::{OrderSummary, OrdersListResponse, OrdersPagination};
+use crate::types::orders::{
+    OrderState, OrderSummary, OrderSummaryOrderType, OrdersListResponse, OrdersPagination,
+};
 use crate::wrap_ratio::{
     persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
     wrap_ratio_values_from_responses, WrapRatioValue,
@@ -85,6 +87,79 @@ pub(crate) fn order_quote_cache_key(order: &RaindexOrder) -> String {
         order.raindex(),
         order.order_hash()
     )
+}
+
+pub(crate) fn active_filter_for_state(state: Option<OrderState>) -> Option<bool> {
+    match state.unwrap_or(OrderState::Active) {
+        OrderState::Active => Some(true),
+        OrderState::Inactive => Some(false),
+        OrderState::All => None,
+    }
+}
+
+pub(crate) fn classify_order_type(order: &RaindexOrder) -> OrderSummaryOrderType {
+    let source = order.rainlang().or_else(|| order.dotrain_source());
+    let Some(source) = source else {
+        return OrderSummaryOrderType::Custom;
+    };
+
+    if source.contains("other-vwaio") {
+        return OrderSummaryOrderType::DynamicSpread;
+    }
+
+    let handle_io = handle_io_section(&source);
+    let has_dca_markers = handle_io.as_deref().is_some_and(|section| {
+        section.contains("min-amount:")
+            || section.contains("linear-growth")
+            || section.contains("amount-epochs")
+            || section.contains("halflife")
+    });
+    if has_dca_markers {
+        return OrderSummaryOrderType::Dca;
+    }
+
+    if handle_io.as_deref().is_some_and(is_empty_handle_io_section) {
+        return OrderSummaryOrderType::Limit;
+    }
+
+    OrderSummaryOrderType::Custom
+}
+
+fn handle_io_section(source: &str) -> Option<String> {
+    let mut section = Vec::new();
+    let mut in_handle_io = false;
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+        let is_section_header =
+            trimmed.starts_with("/*") || trimmed.starts_with('#') || trimmed.starts_with("//");
+
+        if in_handle_io && is_section_header && !trimmed.contains("handle-io") {
+            break;
+        }
+
+        if in_handle_io {
+            section.push(line);
+            continue;
+        }
+
+        if trimmed.contains("handle-io") {
+            in_handle_io = true;
+            let after_marker = trimmed
+                .split_once("*/")
+                .map(|(_, after)| after.trim())
+                .filter(|after| !after.is_empty());
+            if let Some(after_marker) = after_marker {
+                section.push(after_marker);
+            }
+        }
+    }
+
+    in_handle_io.then(|| section.join("\n"))
+}
+
+fn is_empty_handle_io_section(section: &str) -> bool {
+    matches!(section.trim(), ":" | ":;")
 }
 
 fn group_orders_by_chain(orders: &[RaindexOrder]) -> GroupedOrders {
@@ -387,7 +462,13 @@ pub(crate) fn build_order_summary(
     Ok(OrderSummary {
         order_hash: order.order_hash(),
         owner: order.owner(),
+        chain_id: order.chain_id(),
         order_bytes: order.order_bytes(),
+        active: order.active(),
+        removed_at: order
+            .timestamp_removed()
+            .and_then(|timestamp| timestamp.try_into().ok()),
+        order_type: classify_order_type(order),
         input_token: TokenRef {
             address: input_token_info.address(),
             symbol: input_token_info.symbol().unwrap_or_default(),
@@ -398,7 +479,11 @@ pub(crate) fn build_order_summary(
             symbol: output_token_info.symbol().unwrap_or_default(),
             decimals: output_token_info.decimals(),
         },
-        output_vault_balance,
+        output_vault_balance: if order.active() {
+            output_vault_balance
+        } else {
+            "0".into()
+        },
         max_output,
         io_ratio,
         created_at,
@@ -432,6 +517,42 @@ pub(crate) fn quote_result_to_summary(
             }
         }
     }
+}
+
+pub(crate) async fn get_order_quotes_for_summaries(
+    ds: &dyn OrdersListDataSource,
+    orders: &[RaindexOrder],
+) -> Vec<OrderQuoteResult> {
+    let mut quote_results: Vec<Option<OrderQuoteResult>> =
+        (0..orders.len()).map(|_| None).collect();
+    let active_orders: Vec<(usize, RaindexOrder)> = orders
+        .iter()
+        .enumerate()
+        .filter_map(|(index, order)| {
+            if order.active() {
+                Some((index, order.clone()))
+            } else {
+                quote_results[index] = Some(Ok(Vec::new()));
+                None
+            }
+        })
+        .collect();
+
+    if !active_orders.is_empty() {
+        let active_order_values: Vec<RaindexOrder> = active_orders
+            .iter()
+            .map(|(_, order)| order.clone())
+            .collect();
+        let active_quote_results = ds.get_order_quotes_batch(&active_order_values).await;
+        for ((index, _), quote_result) in active_orders.into_iter().zip(active_quote_results) {
+            quote_results[index] = Some(quote_result);
+        }
+    }
+
+    quote_results
+        .into_iter()
+        .map(|quote_result| quote_result.unwrap_or_else(|| Ok(Vec::new())))
+        .collect()
 }
 
 pub(crate) fn build_pagination(total_count: u32, page: u32, page_size: u32) -> OrdersPagination {
@@ -526,11 +647,17 @@ pub(crate) mod test_fixtures {
     use async_trait::async_trait;
     use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
     use rain_orderbook_common::raindex_client::orders::{GetOrdersFilters, RaindexOrder};
+    use std::sync::Mutex;
 
     pub struct MockOrdersListDataSource {
         pub orders: Result<Vec<RaindexOrder>, ApiError>,
         pub total_count: u32,
         pub quotes: Result<Vec<RaindexOrderQuote>, ApiError>,
+    }
+
+    #[derive(Default)]
+    pub struct RecordingOrdersListDataSource {
+        pub filters: Mutex<Vec<GetOrdersFilters>>,
     }
 
     #[async_trait]
@@ -555,6 +682,26 @@ pub(crate) mod test_fixtures {
                 Ok(quotes) => Ok(quotes.clone()),
                 Err(_) => Err(ApiError::Internal("failed to query order quotes".into())),
             }
+        }
+    }
+
+    #[async_trait]
+    impl OrdersListDataSource for RecordingOrdersListDataSource {
+        async fn get_orders_list(
+            &self,
+            filters: GetOrdersFilters,
+            _page: Option<u16>,
+            _page_size: Option<u16>,
+        ) -> Result<(Vec<RaindexOrder>, u32), ApiError> {
+            self.filters.lock().expect("lock filters").push(filters);
+            Ok((vec![], 0))
+        }
+
+        async fn get_order_quotes(
+            &self,
+            _order: &RaindexOrder,
+        ) -> Result<Vec<RaindexOrderQuote>, ApiError> {
+            unreachable!("recording datasource returns no orders")
         }
     }
 }
@@ -628,6 +775,20 @@ mod tests {
         serde_json::from_value(value).expect("deserialize chain-specific mock order")
     }
 
+    fn mock_order_with_source(source: Option<&str>) -> RaindexOrder {
+        let mut value = order_json();
+        value["rainlang"] = source.map_or(serde_json::Value::Null, |source| json!(source));
+        serde_json::from_value(value).expect("deserialize mock order with source")
+    }
+
+    fn mock_inactive_order(order_hash: &str, removed_at: u64) -> RaindexOrder {
+        let mut value = order_json();
+        value["active"] = json!(false);
+        value["orderHash"] = json!(order_hash);
+        value["timestampRemoved"] = json!(format!("0x{removed_at:x}"));
+        serde_json::from_value(value).expect("deserialize inactive mock order")
+    }
+
     fn quote_ratio(result: &OrderQuoteResult) -> String {
         result
             .as_ref()
@@ -647,6 +808,162 @@ mod tests {
             share_address,
             assets_per_share: assets_per_share.to_string(),
         }
+    }
+
+    #[test]
+    fn test_active_filter_for_state_defaults_to_active() {
+        assert_eq!(active_filter_for_state(None), Some(true));
+        assert_eq!(
+            active_filter_for_state(Some(OrderState::Active)),
+            Some(true)
+        );
+        assert_eq!(
+            active_filter_for_state(Some(OrderState::Inactive)),
+            Some(false)
+        );
+        assert_eq!(active_filter_for_state(Some(OrderState::All)), None);
+    }
+
+    #[test]
+    fn test_classify_order_type_no_source_is_custom() {
+        let order = mock_order_with_source(None);
+        assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Custom);
+    }
+
+    #[test]
+    fn test_classify_order_type_dynamic_spread() {
+        let order = mock_order_with_source(Some("using-words-from 0xabc\n_: other-vwaio();"));
+        assert_eq!(
+            classify_order_type(&order),
+            OrderSummaryOrderType::DynamicSpread
+        );
+    }
+
+    #[test]
+    fn test_classify_order_type_dca_from_handle_io_min_amount() {
+        let order = mock_order_with_source(Some(
+            r#"/* 0. calculate-io */
+_: 1;
+
+/* 1. handle-io */
+min-amount: 1;
+:;"#,
+        ));
+        assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Dca);
+    }
+
+    #[test]
+    fn test_classify_order_type_dca_from_source_markers() {
+        for marker in ["linear-growth", "amount-epochs", "halflife"] {
+            let order = mock_order_with_source(Some(&format!(
+                r#"/* 0. calculate-io */
+_: 1;
+
+/* 1. handle-io */
+_: {marker}();
+:;"#
+            )));
+            assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Dca);
+        }
+    }
+
+    #[test]
+    fn test_classify_order_type_ignores_dca_markers_outside_handle_io() {
+        let order = mock_order_with_source(Some(
+            r#"/* 0. calculate-io */
+// linear-growth appears in an unrelated comment.
+_: 1;
+
+/* 1. handle-io */
+:;"#,
+        ));
+
+        assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Limit);
+    }
+
+    #[test]
+    fn test_classify_order_type_limit_from_simple_handle_io() {
+        for handle_io in [":;", ":"] {
+            let order = mock_order_with_source(Some(&format!(
+                r#"/* 0. calculate-io */
+_: 1;
+
+/* 1. handle-io */
+{handle_io}"#
+            )));
+            assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Limit);
+        }
+    }
+
+    #[test]
+    fn test_classify_order_type_custom_fallback() {
+        let order = mock_order_with_source(Some(
+            r#"/* 0. calculate-io */
+_: 1;
+
+/* 1. handle-io */
+_: custom-handle-io();"#,
+        ));
+        assert_eq!(classify_order_type(&order), OrderSummaryOrderType::Custom);
+    }
+
+    #[rocket::async_test]
+    async fn test_get_order_quotes_for_summaries_skips_inactive_orders() {
+        let active_order = mock_order_for_chain(
+            1,
+            "0x0000000000000000000000000000000000000000000000000000000000000101",
+        );
+        let inactive_order = mock_inactive_order(
+            "0x0000000000000000000000000000000000000000000000000000000000000102",
+            1_718_452_900,
+        );
+        let batch_calls = Arc::new(Mutex::new(Vec::new()));
+        let single_calls = Arc::new(Mutex::new(Vec::new()));
+        let ds = BatchingTestDataSource {
+            per_order_quotes: HashMap::new(),
+            batched_quotes: HashMap::from([(1, Ok(vec![vec![mock_quote("1.7")]]))]),
+            batch_calls: Arc::clone(&batch_calls),
+            single_calls: Arc::clone(&single_calls),
+        };
+
+        let results =
+            get_order_quotes_for_summaries(&ds, &[active_order.clone(), inactive_order]).await;
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(quote_ratio(&results[0]), "1.7");
+        assert!(results[1].as_ref().expect("inactive result").is_empty());
+        assert_eq!(
+            batch_calls.lock().expect("lock batch calls").as_slice(),
+            &[(1, 1)]
+        );
+        assert!(single_calls.lock().expect("lock single calls").is_empty());
+    }
+
+    #[test]
+    fn test_build_orders_list_response_uses_non_live_fields_for_inactive_order() {
+        let order = mock_inactive_order(
+            "0x0000000000000000000000000000000000000000000000000000000000000201",
+            1_718_452_900,
+        );
+        let response = build_orders_list_response(
+            &[order],
+            1,
+            1,
+            20,
+            vec![Ok(Vec::new())],
+            Denomination::Wrapped,
+            &HashMap::new(),
+        )
+        .expect("build inactive response");
+
+        let summary = &response.orders[0];
+        assert!(!summary.active);
+        assert_eq!(summary.removed_at, Some(1_718_452_900));
+        assert_eq!(summary.io_ratio, "-");
+        assert_eq!(summary.max_output, None);
+        assert_eq!(summary.output_vault_balance, "0");
+        assert_eq!(summary.order_type, OrderSummaryOrderType::Custom);
+        assert_eq!(summary.order_bytes.as_ref(), &[1]);
     }
 
     #[rocket::async_test]

--- a/src/types/orders.rs
+++ b/src/types/orders.rs
@@ -8,6 +8,8 @@ use utoipa::{IntoParams, ToSchema};
 #[into_params(parameter_in = Query)]
 #[serde(rename_all = "camelCase")]
 pub struct OrdersPaginationParams {
+    #[field(name = "state")]
+    pub state: Option<OrderState>,
     #[field(name = "page")]
     #[param(example = 1)]
     pub page: Option<u16>,
@@ -22,14 +24,38 @@ pub struct OrdersPaginationParams {
 #[derive(Debug, Clone, Serialize, Deserialize, FromFormField, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum OrderSide {
+    #[field(value = "input")]
     Input,
+    #[field(value = "output")]
     Output,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, FromFormField, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderState {
+    #[field(value = "active")]
+    Active,
+    #[field(value = "inactive")]
+    Inactive,
+    #[field(value = "all")]
+    All,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OrderSummaryOrderType {
+    Limit,
+    Dca,
+    DynamicSpread,
+    Custom,
 }
 
 #[derive(Debug, Clone, FromForm, Serialize, Deserialize, IntoParams)]
 #[into_params(parameter_in = Query)]
 #[serde(rename_all = "camelCase")]
 pub struct OrdersByTokenParams {
+    #[field(name = "state")]
+    pub state: Option<OrderState>,
     #[field(name = "side")]
     pub side: Option<OrderSide>,
     #[field(name = "page")]
@@ -50,8 +76,16 @@ pub struct OrderSummary {
     pub order_hash: FixedBytes<32>,
     #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
     pub owner: Address,
+    #[schema(example = 8453)]
+    pub chain_id: u32,
     #[schema(value_type = String, example = "0x01")]
     pub order_bytes: Bytes,
+    #[schema(example = true)]
+    pub active: bool,
+    #[schema(example = 1718452900)]
+    pub removed_at: Option<u64>,
+    #[schema(example = "limit")]
+    pub order_type: OrderSummaryOrderType,
     pub input_token: TokenRef,
     pub output_token: TokenRef,
     #[schema(example = "500000")]


### PR DESCRIPTION
## Linear
Refs RAI-753: https://linear.app/makeitrain/issue/RAI-753/support-inactiveclosed-orders-in-order-list-endpoints

## Dependencies
Stacked on REST API PR: https://github.com/ST0x-Technology/st0x.rest.api/pull/137
Depends on rain.orderbook PR: https://github.com/rainlanguage/raindex/pull/2688

## Summary
- Add `state=active|inactive|all` to owner and token order list endpoints, defaulting to `active` to preserve current behavior.
- Add stable `orderType`, `active`, `removedAt`, and `chainId` fields to order summaries without exposing raw `parsedMeta` or raw Rainlang.
- Return inactive order summaries without live quoting: `ioRatio` is `"-"`, `maxOutput` is `null`, and `outputVaultBalance` is `"0"`.
- Populate `removedAt` from the rain.orderbook removed timestamp accessor when available, while active orders continue returning `null`.
- Update order list docs and route/filter tests for active, inactive, all-state, and chain-scoped summary behavior.

## Checks
- `cargo fmt --all -- --check` (rain.orderbook)
- `cargo test -p raindex_common raindex_client::orders` (rain.orderbook)
- `nix develop -c cargo fmt`
- `nix develop -c cargo test routes::orders`
- `nix develop -c cargo check`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test`
