### PR TITLE
RAI-739 support v2 swap calldata modes

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -3,7 +3,8 @@
 ## Prerequisites
 
 1. An API key (contact the st0x team to obtain one)
-2. A tool that can make HTTP requests (curl, Postman, or any HTTP client library)
+2. A tool that can make HTTP requests (curl, Postman, or any HTTP client
+   library)
 
 ## Base URL
 
@@ -27,7 +28,8 @@ curl https://api.st0x.io/health
 }
 ```
 
-The health endpoint is the only public endpoint — all other requests require authentication.
+The health endpoint is the only public endpoint — all other requests require
+authentication.
 
 ## First Authenticated Request
 
@@ -52,15 +54,21 @@ A common integration flow looks like this:
 
 1. **List tokens** — `GET /v1/tokens` to discover available trading pairs
 2. **Get a quote** — `POST /v1/swap/quote` to see estimated pricing
-3. **Get calldata** — `POST /v1/swap/calldata` to generate the transaction
-4. **Handle approvals** — If the response includes `approvals`, send those transactions on-chain, then call the calldata endpoint again
-5. **Execute the swap** — Once approvals are in place, the calldata response contains the transaction to submit on-chain
+3. **Get calldata** — `POST /v2/swap/calldata` to generate the transaction
+4. **Handle approvals** — If the response includes `approvals`, send those
+   transactions on-chain, then call the calldata endpoint again
+5. **Execute the swap** — Once approvals are in place, the calldata response
+   contains the transaction to submit on-chain
 
-You can also create orders and monitor their trades. Like swaps, the order endpoints return calldata that you execute on-chain yourself:
+You can also create orders and monitor their trades. Like swaps, the order
+endpoints return calldata that you execute on-chain yourself:
 
 1. **Get order calldata** — `POST /v1/order/dca`
-2. **Handle approvals** — If approvals are returned, send them on-chain, then call the endpoint again to get the deployment calldata
-3. **Monitor** — `GET /v1/order/{order_hash}` for status, `GET /v1/trades/{address}` for fills
-4. **Cancel** — `POST /v1/order/cancel` to get cancellation calldata, then execute on-chain
+2. **Handle approvals** — If approvals are returned, send them on-chain, then
+   call the endpoint again to get the deployment calldata
+3. **Monitor** — `GET /v1/order/{order_hash}` for status,
+   `GET /v1/trades/{address}` for fills
+4. **Cancel** — `POST /v1/order/cancel` to get cancellation calldata, then
+   execute on-chain
 
 Each of these flows is covered in detail in the following sections.

--- a/docs/src/swap-flow.md
+++ b/docs/src/swap-flow.md
@@ -64,16 +64,67 @@ is not pre-converted.
 
 Do not pass unwrapped-normalized quote values into other endpoints unless those
 endpoints explicitly support `denomination=unwrapped` and you call them that
-way. `/v1/swap/calldata` supports the same `denomination` field, but the swap
-still purchases wrapped/orderbook tokens.
+way. The calldata endpoints support the same `denomination` field, but swaps
+still use wrapped/orderbook token addresses.
 
 ## Step 2: Get Calldata
+
+For new integrations, use `POST /v2/swap/calldata`. It supports both
+output-targeted swaps and spend-mode swaps. `POST /v1/swap/calldata` remains
+available for existing output-targeted clients.
+
+### Recommended: V2 Mode-Based Calldata
+
+```
+POST /v2/swap/calldata
+```
+
+#### Request
+
+```bash
+curl -X POST https://api.st0x.io/v2/swap/calldata \
+  -H "Authorization: Basic <credentials>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "taker": "0xYourWalletAddress",
+    "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "outputToken": "0x4200000000000000000000000000000000000006",
+    "mode": "spendExact",
+    "amount": "2500.0",
+    "priceCap": "2600.0",
+    "denomination": "wrapped"
+  }'
+```
+
+| Field          | Type   | Description                                                                                                                                                         |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `taker`        | string | Your wallet address that will execute the transaction                                                                                                               |
+| `inputToken`   | string | Wrapped/orderbook token address you are selling                                                                                                                     |
+| `outputToken`  | string | Wrapped/orderbook token address you want to receive                                                                                                                 |
+| `mode`         | string | Swap mode. One of `"buyUpTo"`, `"spendExact"`, or `"spendUpTo"`                                                                                                     |
+| `amount`       | string | Target amount in the selected `denomination`. For `buyUpTo`, this is output amount. For `spendExact` and `spendUpTo`, this is input amount                          |
+| `priceCap`     | string | Maximum input-token amount you are willing to spend per 1 output token, in the selected `denomination`                                                              |
+| `denomination` | string | Optional. `"wrapped"` (default) uses orderbook units. `"unwrapped"` interprets `amount` and `priceCap` as unwrapped display values for wrapped ST0x/ERC4626 tokens. |
+
+Mode behavior:
+
+| Mode         | Amount Means                 | Fill Behavior                                   |
+| ------------ | ---------------------------- | ----------------------------------------------- |
+| `buyUpTo`    | Output-token amount to buy   | Buy up to `amount`; partial fills are allowed   |
+| `spendExact` | Input-token amount to spend  | Spend exactly `amount`; fails if not fillable   |
+| `spendUpTo`  | Maximum input-token to spend | Spend up to `amount`; partial fills are allowed |
+
+Set `priceCap` slightly above the quote price to allow for price movement. For
+example, when selling USDC for WETH, `"priceCap": "2600"` means the swap will
+not pay more than 2600 USDC per 1 WETH.
+
+### Legacy: V1 Output-Targeted Calldata
 
 ```
 POST /v1/swap/calldata
 ```
 
-### Request
+#### Request
 
 ```bash
 curl -X POST https://api.st0x.io/v1/swap/calldata \
@@ -98,13 +149,16 @@ curl -X POST https://api.st0x.io/v1/swap/calldata \
 | `maximumIoRatio` | string | Maximum acceptable IO ratio in the selected `denomination`                                                                                                                      |
 | `denomination`   | string | Optional. `"wrapped"` (default) uses orderbook units. `"unwrapped"` interprets `outputAmount` and `maximumIoRatio` as unwrapped display values for wrapped ST0x/ERC4626 tokens. |
 
+V1 is equivalent to v2 with `"mode": "buyUpTo"`. It cannot express spend-based
+intent.
+
 Set `maximumIoRatio` slightly above the `estimatedIoRatio` from the quote to
 allow for price movement.
 
 For calldata, `denomination=unwrapped` only changes how numeric fields are
-interpreted and displayed. The API converts `outputAmount` and `maximumIoRatio`
-to wrapped/orderbook units before generating calldata. Clients must still pass
-the wrapped/orderbook token addresses for `inputToken` and `outputToken`; the
+interpreted and displayed. The API converts request amounts and price limits to
+wrapped/orderbook units before generating calldata. Clients must still pass the
+wrapped/orderbook token addresses for `inputToken` and `outputToken`; the
 endpoint does not translate unwrapped asset addresses.
 
 ### Response
@@ -148,18 +202,21 @@ the swap calldata:
 }
 ```
 
-| Field            | Type   | Description                                                                        |
-| ---------------- | ------ | ---------------------------------------------------------------------------------- |
-| `to`             | string | Contract address to send the transaction to                                        |
-| `data`           | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed            |
-| `value`          | string | Native token value to send (usually `"0x0"`)                                       |
-| `estimatedInput` | string | Expected input amount in the requested `denomination`                              |
-| `denomination`   | string | Denomination used for `estimatedInput`                                             |
-| `approvals`      | array  | Token approvals needed — if non-empty, approve first then call this endpoint again |
+| Field            | Type   | Description                                                                                                                                                                                    |
+| ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `to`             | string | Contract address to send the transaction to                                                                                                                                                    |
+| `data`           | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed                                                                                                                        |
+| `value`          | string | Native token value to send (usually `"0x0"`)                                                                                                                                                   |
+| `estimatedInput` | string | Expected input amount in the requested `denomination` when calldata is ready. When approvals are needed, this is the input-token approval amount/cap required before calldata can be generated |
+| `denomination`   | string | Denomination used for `estimatedInput`                                                                                                                                                         |
+| `approvals`      | array  | Token approvals needed — if non-empty, approve first then call this endpoint again                                                                                                             |
 
 Approval entries always describe the actual on-chain approval requirements in
 wrapped/orderbook token units. They are not converted or relabeled when
-`denomination=unwrapped`.
+`denomination=unwrapped`. For approval-required responses, `estimatedInput`
+matches the approval requirement expressed in the requested `denomination`, not
+the final simulated spend. Call the calldata endpoint again after approving to
+receive the ready calldata response with the expected input amount.
 
 ## Step 3: Handle Approvals
 
@@ -191,16 +248,17 @@ QUOTE=$(curl -s -X POST https://api.st0x.io/v1/swap/quote \
 
 echo "$QUOTE" | jq .estimatedIoRatio
 
-# 2. Get calldata (add some slippage to the IO ratio)
-CALLDATA=$(curl -s -X POST https://api.st0x.io/v1/swap/calldata \
+# 2. Get calldata (add some slippage to the quoted price)
+CALLDATA=$(curl -s -X POST https://api.st0x.io/v2/swap/calldata \
   -H "Authorization: Basic <credentials>" \
   -H "Content-Type: application/json" \
   -d '{
     "taker": "0xYourWalletAddress",
     "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "outputToken": "0x4200000000000000000000000000000000000006",
-    "outputAmount": "1.0",
-    "maximumIoRatio": "2600.0"
+    "mode": "buyUpTo",
+    "amount": "1.0",
+    "priceCap": "2600.0"
   }')
 
 # 3. Check if approvals are needed
@@ -214,15 +272,16 @@ if [ "$APPROVALS" != "[]" ]; then
 
   # Now call the calldata endpoint again — this time approvals are in place
   # and the response will contain the swap calldata in "data"
-  CALLDATA=$(curl -s -X POST https://api.st0x.io/v1/swap/calldata \
+  CALLDATA=$(curl -s -X POST https://api.st0x.io/v2/swap/calldata \
     -H "Authorization: Basic <credentials>" \
     -H "Content-Type: application/json" \
     -d '{
       "taker": "0xYourWalletAddress",
       "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
       "outputToken": "0x4200000000000000000000000000000000000006",
-      "outputAmount": "1.0",
-      "maximumIoRatio": "2600.0"
+      "mode": "buyUpTo",
+      "amount": "1.0",
+      "priceCap": "2600.0"
     }')
 fi
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,6 +89,7 @@ enum StartupRegistryError {
         routes::tokens::get_token_proofs,
         routes::swap::post_swap_quote,
         routes::swap::post_swap_calldata,
+        routes::swap::post_swap_calldata_v2,
         routes::order::post_order_dca,
         routes::order::post_order_solver,
         routes::order::get_order,
@@ -175,6 +176,7 @@ pub(crate) fn rocket(
         .mount("/", routes::health::routes())
         .mount("/v1/tokens", routes::tokens::routes())
         .mount("/v1/swap", routes::swap::routes())
+        .mount("/v2/swap", routes::swap::routes_v2())
         .mount("/v1/order", routes::order::routes())
         .mount("/v1/orders", routes::orders::routes())
         .mount("/v1/vaults", routes::vaults::routes())
@@ -453,6 +455,7 @@ mod tests {
     fn test_openapi_includes_token_proofs_schema() {
         let openapi = serde_json::to_value(super::ApiDoc::openapi()).expect("serialize openapi");
         let proofs_path = &openapi["paths"]["/v1/tokens/{address}/proofs"]["get"];
+        let swap_calldata_v2_path = &openapi["paths"]["/v2/swap/calldata"]["post"];
 
         assert_eq!(proofs_path["tags"][0], "Tokens");
         assert_eq!(
@@ -474,6 +477,15 @@ mod tests {
         assert!(schemas["TokenProofReceipt"]["properties"]["receiptId"].is_object());
         assert!(schemas["TokenProofReceipt"]["properties"]["txHash"].is_object());
         assert!(schemas["TokenProofReceipt"]["properties"]["type"].is_object());
+        assert_eq!(swap_calldata_v2_path["tags"][0], "Swap");
+        assert_eq!(
+            swap_calldata_v2_path["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/SwapCalldataV2Request"
+        );
+        assert_eq!(
+            schemas["SwapCalldataMode"]["enum"],
+            serde_json::json!(["buyUpTo", "spendExact", "spendUpTo"])
+        );
     }
 
     #[test]

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -5,9 +5,12 @@ use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::{
-    normalize_calldata_request_values, normalize_calldata_response,
+    normalize_calldata_request_values, normalize_calldata_response, CalldataRequestNormalization,
 };
-use crate::types::swap::{SwapCalldataRequest, SwapCalldataResponse};
+use crate::types::swap::{
+    SwapCalldataMode, SwapCalldataRequest, SwapCalldataResponse, SwapCalldataV2Request,
+};
+use alloy::primitives::Address;
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::take_orders::TakeOrdersMode;
 use rocket::serde::json::Json;
@@ -56,20 +59,140 @@ pub async fn post_swap_calldata(
     .await
 }
 
+#[utoipa::path(
+    post,
+    path = "/v2/swap/calldata",
+    tag = "Swap",
+    security(("basicAuth" = [])),
+    request_body = SwapCalldataV2Request,
+    responses(
+        (status = 200, description = "Swap calldata", body = SwapCalldataResponse),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 404, description = "No liquidity found", body = ApiErrorResponse),
+        (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[post("/calldata", data = "<request>")]
+pub async fn post_swap_calldata_v2(
+    _global: GlobalRateLimit,
+    _key: AuthenticatedKey,
+    shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
+    span: TracingSpan,
+    request: Json<SwapCalldataV2Request>,
+) -> Result<Json<SwapCalldataResponse>, ApiError> {
+    let req = request.into_inner();
+    async move {
+        tracing::info!(
+            mode = ?req.mode,
+            denomination = ?req.denomination,
+            "request received"
+        );
+        let raindex = shared_raindex.read().await;
+        let ds = RaindexSwapDataSource {
+            client: raindex.client(),
+            caches: &app_state.response_caches,
+            pool: pool.inner(),
+        };
+        let response = process_swap_calldata_v2(&ds, req).await?;
+        Ok(Json(response))
+    }
+    .instrument(span.0)
+    .await
+}
+
+#[derive(Debug)]
+struct SwapCalldataBuildRequest {
+    taker: Address,
+    input_token: Address,
+    output_token: Address,
+    mode: TakeOrdersMode,
+    amount: String,
+    amount_field: &'static str,
+    price_cap: String,
+    price_cap_field: &'static str,
+    denomination: crate::types::swap::SwapDenomination,
+}
+
+impl From<SwapCalldataRequest> for SwapCalldataBuildRequest {
+    fn from(req: SwapCalldataRequest) -> Self {
+        Self {
+            taker: req.taker,
+            input_token: req.input_token,
+            output_token: req.output_token,
+            mode: TakeOrdersMode::BuyUpTo,
+            amount: req.output_amount,
+            amount_field: "output_amount",
+            price_cap: req.maximum_io_ratio,
+            price_cap_field: "maximum_io_ratio",
+            denomination: req.denomination,
+        }
+    }
+}
+
+impl From<SwapCalldataV2Request> for SwapCalldataBuildRequest {
+    fn from(req: SwapCalldataV2Request) -> Self {
+        Self {
+            taker: req.taker,
+            input_token: req.input_token,
+            output_token: req.output_token,
+            mode: req.mode.into(),
+            amount: req.amount,
+            amount_field: "amount",
+            price_cap: req.price_cap,
+            price_cap_field: "price_cap",
+            denomination: req.denomination,
+        }
+    }
+}
+
+impl From<SwapCalldataMode> for TakeOrdersMode {
+    fn from(mode: SwapCalldataMode) -> Self {
+        match mode {
+            SwapCalldataMode::BuyUpTo => TakeOrdersMode::BuyUpTo,
+            SwapCalldataMode::SpendExact => TakeOrdersMode::SpendExact,
+            SwapCalldataMode::SpendUpTo => TakeOrdersMode::SpendUpTo,
+        }
+    }
+}
+
 async fn process_swap_calldata(
     ds: &dyn SwapDataSource,
     req: SwapCalldataRequest,
 ) -> Result<SwapCalldataResponse, ApiError> {
+    process_swap_calldata_build(ds, req.into()).await
+}
+
+async fn process_swap_calldata_v2(
+    ds: &dyn SwapDataSource,
+    req: SwapCalldataV2Request,
+) -> Result<SwapCalldataResponse, ApiError> {
+    process_swap_calldata_build(ds, req.into()).await
+}
+
+async fn process_swap_calldata_build(
+    ds: &dyn SwapDataSource,
+    req: SwapCalldataBuildRequest,
+) -> Result<SwapCalldataResponse, ApiError> {
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await?;
 
-    let (output_amount, maximum_io_ratio, wrap_ratios) = normalize_calldata_request_values(
+    let (amount, price_cap, wrap_ratios) = normalize_calldata_request_values(
         ds,
-        req.denomination,
-        req.input_token,
-        req.output_token,
-        req.output_amount,
-        req.maximum_io_ratio,
+        CalldataRequestNormalization {
+            denomination: req.denomination,
+            input_token: req.input_token,
+            output_token: req.output_token,
+            mode: req.mode,
+            amount: req.amount,
+            amount_field: req.amount_field,
+            price_cap: req.price_cap,
+            price_cap_field: req.price_cap_field,
+        },
     )
     .await?;
 
@@ -78,9 +201,9 @@ async fn process_swap_calldata(
         chain_id: crate::CHAIN_ID,
         sell_token: req.input_token.to_string(),
         buy_token: req.output_token.to_string(),
-        mode: TakeOrdersMode::BuyUpTo,
-        amount: output_amount,
-        price_cap: maximum_io_ratio,
+        mode: req.mode,
+        amount,
+        price_cap,
     };
 
     let response = ds.get_calldata(take_req).await?;
@@ -93,7 +216,7 @@ mod tests {
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::TestClientBuilder;
     use crate::types::common::Approval;
-    use crate::types::swap::SwapDenomination;
+    use crate::types::swap::{SwapCalldataMode, SwapDenomination};
     use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::{address, Address, Bytes, U256};
     use async_trait::async_trait;
@@ -119,6 +242,22 @@ mod tests {
         }
     }
 
+    fn calldata_v2_request(
+        mode: SwapCalldataMode,
+        amount: &str,
+        price_cap: &str,
+    ) -> SwapCalldataV2Request {
+        SwapCalldataV2Request {
+            taker: TAKER,
+            input_token: USDC,
+            output_token: WETH,
+            mode,
+            amount: amount.to_string(),
+            price_cap: price_cap.to_string(),
+            denomination: SwapDenomination::Wrapped,
+        }
+    }
+
     fn unwrapped_calldata_request(
         input_token: Address,
         output_token: Address,
@@ -131,6 +270,24 @@ mod tests {
             output_token,
             output_amount: output_amount.to_string(),
             maximum_io_ratio: max_ratio.to_string(),
+            denomination: SwapDenomination::Unwrapped,
+        }
+    }
+
+    fn unwrapped_calldata_v2_request(
+        input_token: Address,
+        output_token: Address,
+        mode: SwapCalldataMode,
+        amount: &str,
+        price_cap: &str,
+    ) -> SwapCalldataV2Request {
+        SwapCalldataV2Request {
+            taker: TAKER,
+            input_token,
+            output_token,
+            mode,
+            amount: amount.to_string(),
+            price_cap: price_cap.to_string(),
             denomination: SwapDenomination::Unwrapped,
         }
     }
@@ -327,9 +484,64 @@ mod tests {
 
         assert_eq!(request.sell_token, USDC.to_string());
         assert_eq!(request.buy_token, WETH.to_string());
+        assert_eq!(request.mode, TakeOrdersMode::BuyUpTo);
         assert_eq!(request.amount, "100");
         assert_eq!(request.price_cap, "2.5");
         assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_spend_exact_preserves_request() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result = process_swap_calldata_v2(
+            &ds,
+            calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2.5"),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.sell_token, USDC.to_string());
+        assert_eq!(request.buy_token, WETH.to_string());
+        assert_eq!(request.mode, TakeOrdersMode::SpendExact);
+        assert_eq!(request.amount, "100");
+        assert_eq!(request.price_cap, "2.5");
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_spend_up_to_preserves_request() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result = process_swap_calldata_v2(
+            &ds,
+            calldata_v2_request(SwapCalldataMode::SpendUpTo, "75", "3"),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.mode, TakeOrdersMode::SpendUpTo);
+        assert_eq!(request.amount, "75");
+        assert_eq!(request.price_cap, "3");
+        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_buy_up_to_preserves_request() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result = process_swap_calldata_v2(
+            &ds,
+            calldata_v2_request(SwapCalldataMode::BuyUpTo, "50", "2"),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.mode, TakeOrdersMode::BuyUpTo);
+        assert_eq!(request.amount, "50");
+        assert_eq!(request.price_cap, "2");
         assert_eq!(result.denomination, SwapDenomination::Wrapped);
     }
 
@@ -383,6 +595,56 @@ mod tests {
         assert_eq!(request.amount, "100");
         assert_eq!(request.price_cap, "1.25");
         assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_unwrapped_spend_converts_wrapped_input_amount() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result = process_swap_calldata_v2(
+            &ds,
+            unwrapped_calldata_v2_request(
+                WT_MSTR,
+                WETH,
+                SwapCalldataMode::SpendExact,
+                "100",
+                "2.5",
+            ),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.sell_token, WT_MSTR.to_string());
+        assert_eq!(request.buy_token, WETH.to_string());
+        assert_eq!(request.mode, TakeOrdersMode::SpendExact);
+        assert_eq!(request.amount, "50");
+        assert_eq!(request.price_cap, "1.25");
+        assert_eq!(result.estimated_input, "300");
+        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_unwrapped_buy_converts_wrapped_output_amount() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_COIN, wrap_ratio(WT_COIN, "4"))]),
+        );
+        let result = process_swap_calldata_v2(
+            &ds,
+            unwrapped_calldata_v2_request(USDC, WT_COIN, SwapCalldataMode::BuyUpTo, "100", "2.5"),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.mode, TakeOrdersMode::BuyUpTo);
+        assert_eq!(request.amount, "25");
+        assert_eq!(request.price_cap, "10");
+        assert_eq!(result.estimated_input, "150");
         assert_eq!(result.denomination, SwapDenomination::Unwrapped);
     }
 
@@ -490,6 +752,50 @@ mod tests {
     }
 
     #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_unwrapped_invalid_amount_is_bad_request() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result = process_swap_calldata_v2(
+            &ds,
+            unwrapped_calldata_v2_request(
+                WT_MSTR,
+                WETH,
+                SwapCalldataMode::SpendUpTo,
+                "not-a-number",
+                "2.5",
+            ),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ApiError::BadRequest(msg)) if msg == "invalid amount"));
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_unwrapped_invalid_price_cap_is_bad_request() {
+        let (ds, captured_request) = capture_ds(
+            ready_response(),
+            HashMap::from([(WT_MSTR, wrap_ratio(WT_MSTR, "2"))]),
+        );
+        let result = process_swap_calldata_v2(
+            &ds,
+            unwrapped_calldata_v2_request(
+                WT_MSTR,
+                WETH,
+                SwapCalldataMode::SpendUpTo,
+                "100",
+                "not-a-number",
+            ),
+        )
+        .await;
+
+        assert!(matches!(result, Err(ApiError::BadRequest(msg)) if msg == "invalid price_cap"));
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
     async fn test_process_swap_calldata_unwrapped_wrap_ratio_lookup_failure() {
         let (ds, captured_request) = capture_ds_with_wrap_result(
             ready_response(),
@@ -548,6 +854,17 @@ mod tests {
         )
         .unwrap();
 
+        assert_eq!(request.denomination, SwapDenomination::Wrapped);
+    }
+
+    #[test]
+    fn test_swap_calldata_v2_request_defaults_to_wrapped_denomination() {
+        let request: SwapCalldataV2Request = serde_json::from_str(
+            r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","mode":"spendExact","amount":"100","priceCap":"2.5"}"#,
+        )
+        .unwrap();
+
+        assert_eq!(request.mode, SwapCalldataMode::SpendExact);
         assert_eq!(request.denomination, SwapDenomination::Wrapped);
     }
 
@@ -618,6 +935,18 @@ mod tests {
     }
 
     #[rocket::async_test]
+    async fn test_swap_calldata_v2_401_without_auth() {
+        let client = TestClientBuilder::new().build().await;
+        let response = client
+            .post("/v2/swap/calldata")
+            .header(ContentType::JSON)
+            .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","mode":"spendExact","amount":"100","priceCap":"2.5"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[rocket::async_test]
     async fn test_swap_calldata_400_for_unsupported_tokens() {
         let client = TestClientBuilder::new().build().await;
         let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
@@ -633,6 +962,21 @@ mod tests {
     }
 
     #[rocket::async_test]
+    async fn test_swap_calldata_v2_400_for_unsupported_tokens() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v2/swap/calldata")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","mode":"spendExact","amount":"100","priceCap":"2.5"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::BadRequest);
+    }
+
+    #[rocket::async_test]
     async fn test_swap_calldata_422_for_invalid_denomination() {
         let client = TestClientBuilder::new().build().await;
         let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
@@ -642,6 +986,21 @@ mod tests {
             .header(ContentType::JSON)
             .header(rocket::http::Header::new("Authorization", header))
             .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","outputAmount":"100","maximumIoRatio":"2.5","denomination":"invalid"}"#)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    #[rocket::async_test]
+    async fn test_swap_calldata_v2_422_for_buy_exact_mode() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = crate::test_helpers::seed_api_key(&client).await;
+        let header = crate::test_helpers::basic_auth_header(&key_id, &secret);
+        let response = client
+            .post("/v2/swap/calldata")
+            .header(ContentType::JSON)
+            .header(rocket::http::Header::new("Authorization", header))
+            .body(r#"{"taker":"0x1111111111111111111111111111111111111111","inputToken":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913","outputToken":"0x4200000000000000000000000000000000000006","mode":"buyExact","amount":"100","priceCap":"2.5"}"#)
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::UnprocessableEntity);

--- a/src/routes/swap/denomination.rs
+++ b/src/routes/swap/denomination.rs
@@ -4,8 +4,20 @@ use crate::types::swap::{SwapCalldataResponse, SwapDenomination};
 use crate::wrap_ratio::WrapRatioValue;
 use alloy::primitives::Address;
 use rain_math_float::Float;
+use rain_orderbook_common::take_orders::TakeOrdersMode;
 use std::collections::HashMap;
 use std::ops::{Div, Mul};
+
+pub(crate) struct CalldataRequestNormalization {
+    pub denomination: SwapDenomination,
+    pub input_token: Address,
+    pub output_token: Address,
+    pub mode: TakeOrdersMode,
+    pub amount: String,
+    pub amount_field: &'static str,
+    pub price_cap: String,
+    pub price_cap_field: &'static str,
+}
 
 pub(crate) async fn normalize_quote_amounts(
     ds: &dyn SwapDataSource,
@@ -35,44 +47,44 @@ pub(crate) async fn normalize_quote_amounts(
 
 pub(crate) async fn normalize_calldata_request_values(
     ds: &dyn SwapDataSource,
-    denomination: SwapDenomination,
-    input_token: Address,
-    output_token: Address,
-    output_amount: String,
-    maximum_io_ratio: String,
+    req: CalldataRequestNormalization,
 ) -> Result<(String, String, HashMap<Address, WrapRatioValue>), ApiError> {
-    match denomination {
-        SwapDenomination::Wrapped => Ok((output_amount, maximum_io_ratio, HashMap::new())),
+    match req.denomination {
+        SwapDenomination::Wrapped => Ok((req.amount, req.price_cap, HashMap::new())),
         SwapDenomination::Unwrapped => {
             tracing::info!("normalizing swap calldata request to wrapped denomination");
             let ratios = ds
-                .get_wrap_ratios_for_tokens(&[input_token, output_token])
+                .get_wrap_ratios_for_tokens(&[req.input_token, req.output_token])
                 .await?;
-            let input_is_wrapped = ratios.contains_key(&input_token);
-            let output_is_wrapped = ratios.contains_key(&output_token);
+            let input_is_wrapped = ratios.contains_key(&req.input_token);
+            let output_is_wrapped = ratios.contains_key(&req.output_token);
 
             if !input_is_wrapped && !output_is_wrapped {
-                return Ok((output_amount, maximum_io_ratio, ratios));
+                return Ok((req.amount, req.price_cap, ratios));
             }
 
-            let input_assets_per_share = ratio_for_token(input_token, &ratios)?;
-            let output_assets_per_share = ratio_for_token(output_token, &ratios)?;
+            let input_assets_per_share = ratio_for_token(req.input_token, &ratios)?;
+            let output_assets_per_share = ratio_for_token(req.output_token, &ratios)?;
 
-            let maximum_io_ratio = parse_user_float(maximum_io_ratio, "maximum_io_ratio")?;
+            let price_cap = parse_user_float(req.price_cap, req.price_cap_field)?;
 
-            let normalized_output_amount = if output_is_wrapped {
-                let output_amount = parse_user_float(output_amount, "output_amount")?;
-                let wrapped_output_amount =
-                    output_amount.div(output_assets_per_share).map_err(|e| {
-                        tracing::error!(error = %e, "failed to normalize calldata output amount");
-                        ApiError::Internal("failed to normalize output amount".into())
-                    })?;
-                format_float(wrapped_output_amount, "output amount")?
+            let normalized_amount = if amount_needs_wrapped_normalization(
+                req.mode,
+                input_is_wrapped,
+                output_is_wrapped,
+            ) {
+                let amount = parse_user_float(req.amount, req.amount_field)?;
+                let ratio = amount_ratio(req.mode, input_assets_per_share, output_assets_per_share);
+                let wrapped_amount = amount.div(ratio).map_err(|e| {
+                    tracing::error!(error = %e, "failed to normalize calldata amount");
+                    ApiError::Internal("failed to normalize amount".into())
+                })?;
+                format_float(wrapped_amount, "amount")?
             } else {
-                output_amount
+                req.amount
             };
 
-            let normalized_io_ratio = maximum_io_ratio
+            let normalized_io_ratio = price_cap
                 .mul(output_assets_per_share)
                 .and_then(|ratio| ratio.div(input_assets_per_share))
                 .map_err(|e| {
@@ -81,11 +93,33 @@ pub(crate) async fn normalize_calldata_request_values(
                 })?;
 
             Ok((
-                normalized_output_amount,
+                normalized_amount,
                 format_float(normalized_io_ratio, "IO ratio")?,
                 ratios,
             ))
         }
+    }
+}
+
+fn amount_needs_wrapped_normalization(
+    mode: TakeOrdersMode,
+    input_is_wrapped: bool,
+    output_is_wrapped: bool,
+) -> bool {
+    match mode {
+        TakeOrdersMode::BuyExact | TakeOrdersMode::BuyUpTo => output_is_wrapped,
+        TakeOrdersMode::SpendExact | TakeOrdersMode::SpendUpTo => input_is_wrapped,
+    }
+}
+
+fn amount_ratio(
+    mode: TakeOrdersMode,
+    input_assets_per_share: Float,
+    output_assets_per_share: Float,
+) -> Float {
+    match mode {
+        TakeOrdersMode::BuyExact | TakeOrdersMode::BuyUpTo => output_assets_per_share,
+        TakeOrdersMode::SpendExact | TakeOrdersMode::SpendUpTo => input_assets_per_share,
     }
 }
 

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -276,6 +276,10 @@ pub fn routes() -> Vec<Route> {
     rocket::routes![quote::post_swap_quote, calldata::post_swap_calldata]
 }
 
+pub fn routes_v2() -> Vec<Route> {
+    rocket::routes![calldata::post_swap_calldata_v2]
+}
+
 #[cfg(test)]
 mod tests {
     use super::swap_candidates_cache_key;

--- a/src/types/swap.rs
+++ b/src/types/swap.rs
@@ -62,6 +62,34 @@ pub struct SwapCalldataRequest {
     pub denomination: SwapDenomination,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum SwapCalldataMode {
+    BuyUpTo,
+    SpendExact,
+    SpendUpTo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapCalldataV2Request {
+    #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
+    pub taker: Address,
+    #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
+    pub input_token: Address,
+    #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
+    pub output_token: Address,
+    #[schema(example = "spendExact")]
+    pub mode: SwapCalldataMode,
+    #[schema(example = "100")]
+    pub amount: String,
+    #[schema(example = "2600")]
+    pub price_cap: String,
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapDenomination,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapCalldataResponse {


### PR DESCRIPTION
## Why

RAI-739 needs the REST API to support spend-mode swap calldata so clients can express "spend this input amount" intents through the API instead of walking orders locally. The existing `/v1/swap/calldata` contract only supports output-targeted `buyUpTo` requests through `outputAmount` and `maximumIoRatio`.

## What Changed

- Added `POST /v2/swap/calldata` with a mode-based request shape: `mode`, `amount`, and `priceCap`.
- Exposed `buyUpTo`, `spendExact`, and `spendUpTo`, mapped into the existing engine `TakeOrdersMode` values.
- Kept `/v1/swap/calldata` unchanged and adapted it into the same internal calldata build path as v2.
- Made calldata denomination normalization mode-aware so buy modes normalize output-side amounts and spend modes normalize input-side amounts.
- Mounted the v2 swap route and added OpenAPI coverage for the v2 request schema and mode enum.
- Updated swap docs and getting-started docs to recommend v2, explain mode semantics, and clarify approval-required `estimatedInput` behavior.

## What Did Not Change

- `/v1/swap/calldata` request and response behavior remain unchanged.
- Response shape remains the same for v1 and v2.
- `buyExact` is intentionally not exposed in the REST v2 request.
- No submodule code was changed.

## Verification

- `nix develop -c cargo fmt`
- `nix develop -c cargo check`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test routes::swap::calldata`
- `nix develop -c cargo test test_openapi_includes_token_proofs_schema`
- `nix develop -c cargo nextest run --workspace` - 287 passed
- `nix build .#st0x-docs`
- Staged local review round 1: 2 read-only reviewers, 1 docs/contract finding fixed
- Staged local review round 2: 1 read-only reviewer, no actionable findings

## Reviewer Notes

Please pay close attention to the mode-aware unwrapped denomination math in `src/routes/swap/denomination.rs` and the v1/v2 adapters in `src/routes/swap/calldata.rs`. The intended contract is that `priceCap` is still input per output for all modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /v2/swap/calldata` with `mode` support for `buyUpTo`, `spendExact`, and `spendUpTo`, plus `amount` and `priceCap` fields and `wrapped`/`unwrapped` denomination handling.
* **Bug Fixes**
  * Improved v2 calldata normalization and validation for `unwrapped` requests, including correct mode-specific behavior and clearer handling of invalid inputs.
* **Documentation**
  * Updated getting-started and swap-flow guides with v2 endpoint changes, revised request/step formatting, and refreshed end-to-end v2 example payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->