### PR TITLE
test: isolate token details cache tests

### DIFF
--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -1215,6 +1215,7 @@ mod tests {
     use serde_json::json;
     use std::collections::VecDeque;
     use std::sync::{Arc as StdArc, Mutex};
+    use tokio::sync::Mutex as AsyncMutex;
 
     const WT_MSTR: Address = address!("ff05e1bd696900dc6a52ca35ca61bb1024eda8e2");
     const T_MSTR: Address = address!("013b782f402d61aa1004cca95b9f5bb402c9d5fe");
@@ -1223,6 +1224,7 @@ mod tests {
     const WT_BAD: Address = address!("1111111111111111111111111111111111111111");
     const T_BAD: Address = address!("2222222222222222222222222222222222222222");
     const WT_LEGACY: Address = address!("5555555555555555555555555555555555555555");
+    static TOKEN_DETAILS_CACHE_TEST_LOCK: AsyncMutex<()> = AsyncMutex::const_new(());
 
     #[derive(Debug, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -2331,6 +2333,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_by_address_returns_aggregates_and_recent_activity() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, _) = mock_token_details_subgraph().await;
         let client = token_details_client(&sft_url).await;
@@ -2368,6 +2371,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_by_address_resolves_unwrapped_and_legacy_addresses() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, requests) = mock_token_details_subgraph().await;
         let client = token_details_client(&sft_url).await;
@@ -2395,6 +2399,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_uses_cached_aggregates() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, requests) = mock_token_details_subgraph().await;
         let client = token_details_client(&sft_url).await;
@@ -2506,6 +2511,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_by_address_returns_not_found_for_missing_vault() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, _) = mock_token_details_subgraph().await;
         let client = token_details_multi_client(&sft_url).await;
@@ -2517,6 +2523,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_returns_data_and_per_token_errors() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, _) = mock_token_details_subgraph().await;
         let client = token_details_multi_client(&sft_url).await;
@@ -2540,6 +2547,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_uses_cached_list_response() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, requests) = mock_token_details_subgraph().await;
         let client = token_details_client(&sft_url).await;
@@ -2565,6 +2573,7 @@ using-tokens-from:
 
     #[rocket::async_test]
     async fn test_get_token_details_does_not_cache_partial_list_response() {
+        let _cache_guard = TOKEN_DETAILS_CACHE_TEST_LOCK.lock().await;
         clear_token_details_aggregate_cache();
         let (sft_url, requests) = mock_token_details_subgraph().await;
         let client = token_details_multi_client(&sft_url).await;


### PR DESCRIPTION
## Summary
- serialize token-details cache-sensitive tests around the shared global aggregate/list caches
- keep the prod deploy check path deterministic under normal `cargo test`

## Testing
- nix develop -c cargo test --workspace
- nix develop -c cargo fmt
- nix develop -c rainix-rs-static

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785318029&installation_id=125569124&pr_number=147&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F147&signature=5f7b7d75bd81c5fbf222ea2742a600eeee507292558cdcc81fa6cb62c02421dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of token details cache-related tests by preventing concurrent access to shared cached state, ensuring consistent outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->