### PR TITLE
feat(errors): define typed API error contract

### DIFF
--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -6,6 +6,7 @@ All error responses follow a consistent format.
 
 ```json
 {
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
   "error": {
     "code": "ERROR_CODE",
     "message": "Human-readable description of what went wrong"
@@ -13,15 +14,48 @@ All error responses follow a consistent format.
 }
 ```
 
+`code` is a stable machine-readable identifier. Once published, a code is never
+reused for another meaning. `request_id` identifies one concrete request and is
+also returned in the `X-Request-Id` response header and included in structured
+request logs.
+
+API consumers should branch on `code`, not `message`. Messages may be reworded
+without changing the code's meaning and should not be displayed directly to end
+users. Domain-coded server failures use static public summaries; detailed
+dependency errors remain in structured logs.
+
 ## Error Codes
 
-| HTTP Status | Code | Description |
-|-------------|------|-------------|
-| 400 | `BAD_REQUEST` | Invalid request body, missing fields, or malformed parameters |
-| 401 | `UNAUTHORIZED` | Missing or invalid authentication credentials |
-| 404 | `NOT_FOUND` | Requested resource does not exist |
-| 429 | `RATE_LIMITED` | Too many requests — see [Rate Limiting](./rate-limiting.md) |
-| 500 | `INTERNAL_ERROR` | Unexpected server error |
+| HTTP Status | Code                   | Description                                                   |
+| ----------- | ---------------------- | ------------------------------------------------------------- |
+| 202         | `NOT_YET_INDEXED`      | The requested transaction has not been indexed yet            |
+| 400         | `BAD_REQUEST`          | Invalid request body, missing fields, or malformed parameters |
+| 401         | `UNAUTHORIZED`         | Missing or invalid authentication credentials                 |
+| 403         | `FORBIDDEN`            | Authenticated caller does not have permission                 |
+| 404         | `NOT_FOUND`            | Requested resource does not exist                             |
+| 422         | `UNPROCESSABLE_ENTITY` | Request body could not be parsed                              |
+| 429         | `RATE_LIMITED`         | Too many requests — see [Rate Limiting](./rate-limiting.md)   |
+| 500         | `INTERNAL_ERROR`       | Unexpected server error                                       |
+
+### Reserved trade-flow codes
+
+The following stable codes are reserved by the error contract. Individual trade
+endpoints begin emitting them as their failure boundaries are migrated;
+consumers must continue to handle the generic fallback codes during rollout.
+
+| HTTP Status | Code                     | Description                                    |
+| ----------- | ------------------------ | ---------------------------------------------- |
+| 400         | `SWAP_UNSUPPORTED_TOKEN` | One or both swap tokens are unsupported        |
+| 400         | `SWAP_PREFLIGHT_FAILED`  | Swap preflight rejected the proposed execution |
+| 404         | `SWAP_NO_LIQUIDITY`      | No executable liquidity is available           |
+| 500         | `SWAP_QUOTE_FAILED`      | Quote generation failed unexpectedly           |
+| 500         | `SWAP_CALLDATA_FAILED`   | Calldata generation failed unexpectedly        |
+| 502         | `ORDERS_QUERY_FAILED`    | The order source could not serve the request   |
+| 503         | `UPSTREAM_UNAVAILABLE`   | A required upstream dependency is unavailable  |
+
+Domain codes are assigned at the boundary where the failure is understood.
+Internal dependency errors are logged with the same code and `request_id`; raw
+dependency details are not returned in domain-coded response bodies.
 
 ## Examples
 
@@ -36,6 +70,7 @@ curl -X POST https://api.st0x.io/v1/swap/quote \
 
 ```json
 {
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
   "error": {
     "code": "BAD_REQUEST",
     "message": "Missing required field: inputToken"
@@ -52,6 +87,7 @@ curl https://api.st0x.io/v1/order/0xinvalidhash \
 
 ```json
 {
+  "request_id": "550e8400-e29b-41d4-a716-446655440001",
   "error": {
     "code": "NOT_FOUND",
     "message": "Order not found"
@@ -63,6 +99,7 @@ curl https://api.st0x.io/v1/order/0xinvalidhash \
 
 ```json
 {
+  "request_id": "550e8400-e29b-41d4-a716-446655440002",
   "error": {
     "code": "RATE_LIMITED",
     "message": "Rate limit exceeded"
@@ -70,4 +107,5 @@ curl https://api.st0x.io/v1/order/0xinvalidhash \
 }
 ```
 
-Rate-limited responses include a `Retry-After: 60` header indicating how many seconds to wait.
+Rate-limited responses include a `Retry-After: 60` header indicating how many
+seconds to wait.

--- a/src/catchers.rs
+++ b/src/catchers.rs
@@ -1,4 +1,4 @@
-use crate::error::{ApiErrorDetail, ApiErrorResponse};
+use crate::error::{ApiErrorCode, ApiErrorDetail, ApiErrorResponse};
 use crate::fairings::{request_id_for, request_span_for};
 use rocket::http::Header;
 use rocket::response::Responder;
@@ -16,7 +16,7 @@ pub fn bad_request(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "BAD_REQUEST".to_string(),
+            code: ApiErrorCode::BadRequest,
             message: "The request was invalid or malformed".to_string(),
         },
     })
@@ -30,7 +30,7 @@ pub fn unauthorized(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "UNAUTHORIZED".to_string(),
+            code: ApiErrorCode::Unauthorized,
             message: "Missing or invalid credentials".to_string(),
         },
     })
@@ -44,7 +44,7 @@ pub fn forbidden(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "FORBIDDEN".to_string(),
+            code: ApiErrorCode::Forbidden,
             message: "Insufficient permissions".to_string(),
         },
     })
@@ -58,7 +58,7 @@ pub fn not_found(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "NOT_FOUND".to_string(),
+            code: ApiErrorCode::NotFound,
             message: "The requested resource was not found".to_string(),
         },
     })
@@ -72,7 +72,7 @@ pub fn unprocessable_entity(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "UNPROCESSABLE_ENTITY".to_string(),
+            code: ApiErrorCode::UnprocessableEntity,
             message: "Request body could not be parsed".to_string(),
         },
     })
@@ -96,7 +96,7 @@ pub fn too_many_requests(req: &Request<'_>) -> RateLimitedResponse {
     RateLimitedResponse(Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "RATE_LIMITED".to_string(),
+            code: ApiErrorCode::RateLimited,
             message: "Too many requests, please try again later".to_string(),
         },
     }))
@@ -110,7 +110,7 @@ pub fn internal_server_error(req: &Request<'_>) -> Json<ApiErrorResponse> {
     Json(ApiErrorResponse {
         request_id: request_id_for(req),
         error: ApiErrorDetail {
-            code: "INTERNAL_ERROR".to_string(),
+            code: ApiErrorCode::InternalError,
             message: "Internal server error".to_string(),
         },
     })

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,12 +4,80 @@ use rocket::response::Responder;
 use rocket::serde::json::Json;
 use rocket::{Request, Response};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ApiErrorCode {
+    BadRequest,
+    UnprocessableEntity,
+    Unauthorized,
+    Forbidden,
+    NotFound,
+    InternalError,
+    RateLimited,
+    NotYetIndexed,
+    SwapUnsupportedToken,
+    SwapNoLiquidity,
+    SwapQuoteFailed,
+    SwapPreflightFailed,
+    SwapCalldataFailed,
+    OrdersQueryFailed,
+    UpstreamUnavailable,
+}
+
+impl ApiErrorCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BadRequest => "BAD_REQUEST",
+            Self::UnprocessableEntity => "UNPROCESSABLE_ENTITY",
+            Self::Unauthorized => "UNAUTHORIZED",
+            Self::Forbidden => "FORBIDDEN",
+            Self::NotFound => "NOT_FOUND",
+            Self::InternalError => "INTERNAL_ERROR",
+            Self::RateLimited => "RATE_LIMITED",
+            Self::NotYetIndexed => "NOT_YET_INDEXED",
+            Self::SwapUnsupportedToken => "SWAP_UNSUPPORTED_TOKEN",
+            Self::SwapNoLiquidity => "SWAP_NO_LIQUIDITY",
+            Self::SwapQuoteFailed => "SWAP_QUOTE_FAILED",
+            Self::SwapPreflightFailed => "SWAP_PREFLIGHT_FAILED",
+            Self::SwapCalldataFailed => "SWAP_CALLDATA_FAILED",
+            Self::OrdersQueryFailed => "ORDERS_QUERY_FAILED",
+            Self::UpstreamUnavailable => "UPSTREAM_UNAVAILABLE",
+        }
+    }
+
+    pub const fn status(self) -> Status {
+        match self {
+            Self::BadRequest | Self::SwapUnsupportedToken | Self::SwapPreflightFailed => {
+                Status::BadRequest
+            }
+            Self::UnprocessableEntity => Status::UnprocessableEntity,
+            Self::Unauthorized => Status::Unauthorized,
+            Self::Forbidden => Status::Forbidden,
+            Self::NotFound | Self::SwapNoLiquidity => Status::NotFound,
+            Self::RateLimited => Status::TooManyRequests,
+            Self::NotYetIndexed => Status::Accepted,
+            Self::OrdersQueryFailed => Status::BadGateway,
+            Self::UpstreamUnavailable => Status::ServiceUnavailable,
+            Self::InternalError | Self::SwapQuoteFailed | Self::SwapCalldataFailed => {
+                Status::InternalServerError
+            }
+        }
+    }
+}
+
+impl fmt::Display for ApiErrorCode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ApiErrorDetail {
     #[schema(example = "BAD_REQUEST")]
-    pub code: String,
+    pub code: ApiErrorCode,
     #[schema(example = "Something went wrong")]
     pub message: String,
 }
@@ -41,15 +109,16 @@ pub enum ApiError {
 
 impl<'r> Responder<'r, 'static> for ApiError {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
-        let (status, code, message) = match &self {
-            ApiError::BadRequest(msg) => (Status::BadRequest, "BAD_REQUEST", msg.clone()),
-            ApiError::Unauthorized(msg) => (Status::Unauthorized, "UNAUTHORIZED", msg.clone()),
-            ApiError::Forbidden(msg) => (Status::Forbidden, "FORBIDDEN", msg.clone()),
-            ApiError::NotFound(msg) => (Status::NotFound, "NOT_FOUND", msg.clone()),
-            ApiError::Internal(msg) => (Status::InternalServerError, "INTERNAL_ERROR", msg.clone()),
-            ApiError::RateLimited(msg) => (Status::TooManyRequests, "RATE_LIMITED", msg.clone()),
-            ApiError::NotYetIndexed(msg) => (Status::Accepted, "NOT_YET_INDEXED", msg.clone()),
+        let (code, message) = match &self {
+            ApiError::BadRequest(msg) => (ApiErrorCode::BadRequest, msg.clone()),
+            ApiError::Unauthorized(msg) => (ApiErrorCode::Unauthorized, msg.clone()),
+            ApiError::Forbidden(msg) => (ApiErrorCode::Forbidden, msg.clone()),
+            ApiError::NotFound(msg) => (ApiErrorCode::NotFound, msg.clone()),
+            ApiError::Internal(msg) => (ApiErrorCode::InternalError, msg.clone()),
+            ApiError::RateLimited(msg) => (ApiErrorCode::RateLimited, msg.clone()),
+            ApiError::NotYetIndexed(msg) => (ApiErrorCode::NotYetIndexed, msg.clone()),
         };
+        let status = code.status();
         let span = request_span_for(req);
         span.in_scope(|| {
             if status.code >= 500 {
@@ -59,7 +128,7 @@ impl<'r> Responder<'r, 'static> for ApiError {
                     error_message = %message,
                     "request failed"
                 );
-            } else if matches!(self, ApiError::NotYetIndexed(_)) {
+            } else if code == ApiErrorCode::NotYetIndexed {
                 tracing::info!(
                     status = status.code,
                     code = %code,
@@ -79,10 +148,7 @@ impl<'r> Responder<'r, 'static> for ApiError {
         let request_id = request_id_for(req);
         let body = ApiErrorResponse {
             request_id,
-            error: ApiErrorDetail {
-                code: code.to_string(),
-                message,
-            },
+            error: ApiErrorDetail { code, message },
         };
         let json_response = match Json(body).respond_to(req) {
             Ok(r) => r,
@@ -94,7 +160,7 @@ impl<'r> Responder<'r, 'static> for ApiError {
         let mut response = Response::build_from(json_response)
             .status(status)
             .finalize();
-        if matches!(self, ApiError::RateLimited(_)) {
+        if code == ApiErrorCode::RateLimited {
             response.set_header(Header::new("Retry-After", "60"));
         }
         Ok(response)
@@ -104,6 +170,7 @@ impl<'r> Responder<'r, 'static> for ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::fairings::RequestLogger;
     use rocket::local::blocking::Client;
 
     #[get("/bad-request")]
@@ -122,12 +189,13 @@ mod tests {
     fn internal() -> Result<(), ApiError> {
         Err(ApiError::Internal("something broke".into()))
     }
-
     fn error_client() -> Client {
-        let rocket = rocket::build().mount(
-            "/",
-            rocket::routes![bad_request, unauthorized, not_found, internal],
-        );
+        let rocket = rocket::build()
+            .mount(
+                "/",
+                rocket::routes![bad_request, unauthorized, not_found, internal],
+            )
+            .attach(RequestLogger);
         Client::tracked(rocket).expect("valid rocket instance")
     }
 
@@ -140,9 +208,14 @@ mod tests {
     ) {
         let response = client.get(path).dispatch();
         assert_eq!(response.status().code, expected_status);
+        let request_id = response
+            .headers()
+            .get_one("X-Request-Id")
+            .expect("request id response header")
+            .to_string();
         let body: serde_json::Value =
             serde_json::from_str(&response.into_string().unwrap()).unwrap();
-        assert!(body["request_id"].is_string());
+        assert_eq!(body["request_id"], request_id);
         assert_eq!(body["error"]["code"], expected_code);
         assert_eq!(body["error"]["message"], expected_message);
     }
@@ -175,5 +248,21 @@ mod tests {
             "INTERNAL_ERROR",
             "something broke",
         );
+    }
+
+    #[test]
+    fn test_catalog_serializes_stable_codes() {
+        let cases = [
+            (ApiErrorCode::BadRequest, "\"BAD_REQUEST\""),
+            (ApiErrorCode::SwapQuoteFailed, "\"SWAP_QUOTE_FAILED\""),
+            (
+                ApiErrorCode::UpstreamUnavailable,
+                "\"UPSTREAM_UNAVAILABLE\"",
+            ),
+        ];
+
+        for (code, expected) in cases {
+            assert_eq!(serde_json::to_string(&code).unwrap(), expected);
+        }
     }
 }


### PR DESCRIPTION
## Chained PRs

- Stack 1 of 2
- Child: [#156](https://github.com/ST0x-Technology/st0x.rest.api/pull/156)
- Companion website stack: [SARKEX/st0x#224](https://github.com/SARKEX/st0x/pull/224) → [#225](https://github.com/SARKEX/st0x/pull/225) → [#226](https://github.com/SARKEX/st0x/pull/226)

## Motivation

API errors exposed HTTP status and ad hoc messages but no stable support code or request correlation value that a user could report from the website.

## Solution

- Add a typed `ApiErrorCode` catalog with stable serialized codes and canonical HTTP status mappings.
- Return `{ request_id, error: { code, message } }` from responders and catchers.
- Validate and echo safe incoming request IDs or generate a new ID consistently for logs, headers, and bodies.
- Log code and request ID as structured fields while keeping public messages static.
- Document the canonical envelope, active generic codes, and reserved trade-domain codes.

## Checks

- [x] `nix develop -c cargo test` — 308 passed
- [x] `nix develop -c cargo check`
- [x] `nix develop -c rainix-rs-static`
- [x] Request ID, catcher, response, and catalog tests
- [x] Staged local review completed clean after fixes

## Linear

Fixes RAI-333

- [RAI-333 — Surface user-facing error codes for support and debugging](https://linear.app/makeitrain/issue/RAI-333/surface-user-facing-error-codes-for-support-and-debugging)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Formalized the structured error response contract, including `request_id`, stable machine-readable `code`, and consumer guidance to branch on `code`.
  * Expanded and clarified documented HTTP/code mappings, including a dedicated section for reserved trade-flow codes, with updated JSON examples.

* **Bug Fixes**
  * Rate-limit (429) responses now consistently include a `Retry-After: 60` header.
  * Error responses now align `X-Request-Id` with the JSON `request_id` and return codes/statuses derived from the same stable set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->