### PR TITLE
feat(swap): map trade failures to stable codes

### DIFF
--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -37,25 +37,30 @@ dependency errors remain in structured logs.
 | 429         | `RATE_LIMITED`         | Too many requests — see [Rate Limiting](./rate-limiting.md)   |
 | 500         | `INTERNAL_ERROR`       | Unexpected server error                                       |
 
-### Reserved trade-flow codes
+### Trade-flow codes
 
-The following stable codes are reserved by the error contract. Individual trade
-endpoints begin emitting them as their failure boundaries are migrated;
-consumers must continue to handle the generic fallback codes during rollout.
+Swap and token-order endpoints emit the following stable codes at understood
+failure boundaries. Consumers should still handle generic fallback codes for
+unexpected failures outside those boundaries.
 
-| HTTP Status | Code                     | Description                                    |
-| ----------- | ------------------------ | ---------------------------------------------- |
-| 400         | `SWAP_UNSUPPORTED_TOKEN` | One or both swap tokens are unsupported        |
-| 400         | `SWAP_PREFLIGHT_FAILED`  | Swap preflight rejected the proposed execution |
-| 404         | `SWAP_NO_LIQUIDITY`      | No executable liquidity is available           |
-| 500         | `SWAP_QUOTE_FAILED`      | Quote generation failed unexpectedly           |
-| 500         | `SWAP_CALLDATA_FAILED`   | Calldata generation failed unexpectedly        |
-| 502         | `ORDERS_QUERY_FAILED`    | The order source could not serve the request   |
-| 503         | `UPSTREAM_UNAVAILABLE`   | A required upstream dependency is unavailable  |
+| HTTP Status | Code                     | Description                                   |
+| ----------- | ------------------------ | --------------------------------------------- |
+| 400         | `SWAP_UNSUPPORTED_TOKEN` | One or both swap tokens are unsupported       |
+| 404         | `SWAP_NO_LIQUIDITY`      | No executable liquidity is available          |
+| 500         | `SWAP_QUOTE_FAILED`      | Quote generation failed unexpectedly          |
+| 500         | `SWAP_CALLDATA_FAILED`   | Calldata generation failed unexpectedly       |
+| 502         | `ORDERS_QUERY_FAILED`    | The order source could not serve the request  |
+| 503         | `UPSTREAM_UNAVAILABLE`   | A required upstream dependency is unavailable |
+
+`SWAP_PREFLIGHT_FAILED` is reserved for a future typed preflight rejection
+boundary. The current Raindex dependency combines execution rejections with
+provider failures in one error variant, so the API conservatively emits
+`SWAP_CALLDATA_FAILED` instead of presenting ambiguous failures as HTTP 400.
 
 Domain codes are assigned at the boundary where the failure is understood.
-Internal dependency errors are logged with the same code and `request_id`; raw
-dependency details are not returned in domain-coded response bodies.
+Detailed dependency logs and the coded response event share the same
+`request_id`; raw dependency details are not returned in domain-coded response
+bodies.
 
 ## Examples
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,6 +105,20 @@ pub enum ApiError {
     RateLimited(String),
     #[error("Not yet indexed: {0}")]
     NotYetIndexed(String),
+    #[error("{code}: {public_message}")]
+    Coded {
+        code: ApiErrorCode,
+        public_message: &'static str,
+    },
+}
+
+impl ApiError {
+    pub fn coded(code: ApiErrorCode, public_message: &'static str) -> Self {
+        Self::Coded {
+            code,
+            public_message,
+        }
+    }
 }
 
 impl<'r> Responder<'r, 'static> for ApiError {
@@ -117,6 +131,10 @@ impl<'r> Responder<'r, 'static> for ApiError {
             ApiError::Internal(msg) => (ApiErrorCode::InternalError, msg.clone()),
             ApiError::RateLimited(msg) => (ApiErrorCode::RateLimited, msg.clone()),
             ApiError::NotYetIndexed(msg) => (ApiErrorCode::NotYetIndexed, msg.clone()),
+            ApiError::Coded {
+                code,
+                public_message,
+            } => (*code, (*public_message).to_string()),
         };
         let status = code.status();
         let span = request_span_for(req);
@@ -172,6 +190,7 @@ mod tests {
     use super::*;
     use crate::fairings::RequestLogger;
     use rocket::local::blocking::Client;
+    use tracing_test::traced_test;
 
     #[get("/bad-request")]
     fn bad_request() -> Result<(), ApiError> {
@@ -189,11 +208,19 @@ mod tests {
     fn internal() -> Result<(), ApiError> {
         Err(ApiError::Internal("something broke".into()))
     }
+    #[get("/coded")]
+    fn coded() -> Result<(), ApiError> {
+        Err(ApiError::coded(
+            ApiErrorCode::SwapNoLiquidity,
+            "no executable liquidity",
+        ))
+    }
+
     fn error_client() -> Client {
         let rocket = rocket::build()
             .mount(
                 "/",
-                rocket::routes![bad_request, unauthorized, not_found, internal],
+                rocket::routes![bad_request, unauthorized, not_found, internal, coded],
             )
             .attach(RequestLogger);
         Client::tracked(rocket).expect("valid rocket instance")
@@ -250,6 +277,20 @@ mod tests {
         );
     }
 
+    #[traced_test]
+    #[test]
+    fn test_coded_error_uses_catalog_status_and_code() {
+        let client = error_client();
+        assert_error_response(
+            &client,
+            "/coded",
+            404,
+            "SWAP_NO_LIQUIDITY",
+            "no executable liquidity",
+        );
+        assert!(logs_contain("SWAP_NO_LIQUIDITY"));
+    }
+
     #[test]
     fn test_catalog_serializes_stable_codes() {
         let cases = [
@@ -263,6 +304,29 @@ mod tests {
 
         for (code, expected) in cases {
             assert_eq!(serde_json::to_string(&code).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_trade_catalog_uses_expected_http_statuses() {
+        let cases = [
+            (ApiErrorCode::SwapUnsupportedToken, Status::BadRequest),
+            (ApiErrorCode::SwapPreflightFailed, Status::BadRequest),
+            (ApiErrorCode::SwapNoLiquidity, Status::NotFound),
+            (ApiErrorCode::SwapQuoteFailed, Status::InternalServerError),
+            (
+                ApiErrorCode::SwapCalldataFailed,
+                Status::InternalServerError,
+            ),
+            (ApiErrorCode::OrdersQueryFailed, Status::BadGateway),
+            (
+                ApiErrorCode::UpstreamUnavailable,
+                Status::ServiceUnavailable,
+            ),
+        ];
+
+        for (code, expected_status) in cases {
+            assert_eq!(code.status(), expected_status);
         }
     }
 }

--- a/src/routes/orders/get_by_token.rs
+++ b/src/routes/orders/get_by_token.rs
@@ -6,7 +6,7 @@ use super::{
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
-use crate::error::{ApiError, ApiErrorResponse};
+use crate::error::{ApiError, ApiErrorCode, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::types::common::{Denomination, ValidatedAddress};
 use crate::types::orders::{OrderSide, OrderState, OrdersByTokenParams, OrdersListResponse};
@@ -55,7 +55,14 @@ pub(crate) async fn process_get_orders_by_token(
         .min(MAX_PAGE_SIZE);
     let (orders, total_count) = ds
         .get_orders_list(filters, Some(page_num), Some(effective_page_size))
-        .await?;
+        .await
+        .map_err(|error| {
+            tracing::error!(%error, code = %ApiErrorCode::OrdersQueryFailed, "orders-by-token query failed");
+            ApiError::coded(
+                ApiErrorCode::OrdersQueryFailed,
+                "the order source could not serve this request",
+            )
+        })?;
 
     tracing::info!(
         quoted_orders = orders.len(),
@@ -91,6 +98,7 @@ pub(crate) async fn process_get_orders_by_token(
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
+        (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
     )
 )]
 #[allow(clippy::too_many_arguments)]
@@ -279,7 +287,13 @@ mod tests {
         let result =
             process_get_orders_by_token(&ds, addr, None, None, None, None, Denomination::Wrapped)
                 .await;
-        assert!(matches!(result, Err(ApiError::Internal(_))));
+        assert!(matches!(
+            result,
+            Err(ApiError::Coded {
+                code: ApiErrorCode::OrdersQueryFailed,
+                ..
+            })
+        ));
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -4,7 +4,7 @@ use crate::app_state::ApplicationState;
 use crate::attribution::{attribution_message_hash, Attribution, AttributionSigner};
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
-use crate::error::{ApiError, ApiErrorResponse};
+use crate::error::{ApiError, ApiErrorCode, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::{
     denormalize_calldata_price_cap, normalize_calldata_price_cap,
@@ -39,6 +39,8 @@ use tracing::Instrument;
         (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
+        (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required upstream unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/calldata", data = "<request>")]
@@ -95,6 +97,8 @@ pub async fn post_swap_calldata(
         (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
+        (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required upstream unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/calldata", data = "<request>")]
@@ -454,7 +458,8 @@ async fn process_swap_calldata_build(
     req: SwapCalldataBuildRequest,
 ) -> Result<SwapCalldataBuildResult, ApiError> {
     ds.validate_supported_tokens(req.input_token, req.output_token)
-        .await?;
+        .await
+        .map_err(map_calldata_boundary_error)?;
 
     let (amount, price_cap, resolved_price_cap, wrap_ratios) = match req.price_limit {
         SwapCalldataPriceLimit::Explicit { value, field } => {
@@ -472,7 +477,8 @@ async fn process_swap_calldata_build(
                     price_cap_field: field,
                 },
             )
-            .await?;
+            .await
+            .map_err(map_calldata_boundary_error)?;
             (amount, price_cap, resolved_price_cap, wrap_ratios)
         }
         SwapCalldataPriceLimit::SlippageBps {
@@ -490,7 +496,8 @@ async fn process_swap_calldata_build(
                     amount_field: req.amount_field,
                 },
             )
-            .await?;
+            .await
+            .map_err(map_calldata_boundary_error)?;
             let reference_io_ratio = reference_io_ratio
                 .map(|reference_io_ratio| {
                     normalize_calldata_price_cap(
@@ -514,29 +521,34 @@ async fn process_swap_calldata_build(
                 .transpose()?;
             let orders = ds
                 .get_orders_for_pair(req.input_token, req.output_token)
-                .await?;
+                .await
+                .map_err(map_calldata_boundary_error)?;
             if orders.is_empty() {
-                return Err(ApiError::NotFound(
-                    "no liquidity found for this pair".into(),
+                return Err(ApiError::coded(
+                    ApiErrorCode::SwapNoLiquidity,
+                    "no executable liquidity is available for this pair",
                 ));
             }
             let candidates = ds
                 .build_candidates_for_pair(&orders, req.input_token, req.output_token, req.taker)
-                .await?;
+                .await
+                .map_err(map_calldata_boundary_error)?;
             let price_cap = super::slippage::resolve_slippage_price_cap(
                 candidates,
                 req.mode,
                 &amount,
                 slippage_bps,
                 reference_io_ratio,
-            )?;
+            )
+            .map_err(map_calldata_boundary_error)?;
             let resolved_price_cap = denormalize_calldata_price_cap(
                 price_cap,
                 req.denomination,
                 req.input_token,
                 req.output_token,
                 &wrap_ratios,
-            )?;
+            )
+            .map_err(map_calldata_boundary_error)?;
             tracing::info!(
                 slippage_bps,
                 resolved_price_cap = %resolved_price_cap,
@@ -545,7 +557,10 @@ async fn process_swap_calldata_build(
             );
             let price_cap = price_cap.format().map_err(|error| {
                 tracing::error!(%error, "failed to format resolved slippage price cap");
-                ApiError::Internal("failed to resolve slippage".into())
+                ApiError::coded(
+                    ApiErrorCode::SwapCalldataFailed,
+                    "swap calldata could not be generated",
+                )
             })?;
             (amount, price_cap, resolved_price_cap, wrap_ratios)
         }
@@ -561,13 +576,35 @@ async fn process_swap_calldata_build(
         price_cap,
     };
 
-    let response = ds.get_calldata(take_req).await?;
+    let response = ds
+        .get_calldata(take_req)
+        .await
+        .map_err(map_calldata_boundary_error)?;
     let calldata =
-        normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)?;
+        normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)
+            .map_err(map_calldata_boundary_error)?;
     Ok(SwapCalldataBuildResult {
         calldata,
         resolved_price_cap,
     })
+}
+
+fn map_calldata_boundary_error(error: ApiError) -> ApiError {
+    if matches!(error, ApiError::Coded { .. } | ApiError::BadRequest(_)) {
+        return error;
+    }
+    if matches!(error, ApiError::NotFound(_)) {
+        tracing::warn!(%error, code = %ApiErrorCode::SwapNoLiquidity, "swap calldata found no executable liquidity");
+        return ApiError::coded(
+            ApiErrorCode::SwapNoLiquidity,
+            "no executable liquidity is available for this pair",
+        );
+    }
+    tracing::error!(%error, code = %ApiErrorCode::SwapCalldataFailed, "swap calldata boundary failed");
+    ApiError::coded(
+        ApiErrorCode::SwapCalldataFailed,
+        "swap calldata could not be generated",
+    )
 }
 
 #[cfg(all(test, feature = "oracle-integration-tests"))]
@@ -626,6 +663,13 @@ mod tests {
             maximum_io_ratio: max_ratio.to_string(),
             denomination: SwapDenomination::Wrapped,
         }
+    }
+
+    fn assert_error_code<T>(result: Result<T, ApiError>, expected: ApiErrorCode) {
+        assert!(matches!(
+            result,
+            Err(ApiError::Coded { code, .. }) if code == expected
+        ));
     }
 
     fn calldata_v2_request(
@@ -1084,9 +1128,7 @@ mod tests {
 
         let result = process_swap_calldata_v2(&ds, request).await;
 
-        assert!(
-            matches!(result, Err(ApiError::NotFound(message)) if message == "no liquidity found for this pair")
-        );
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
         no_take_orders_request_was_made(&captured_request);
     }
 
@@ -1433,9 +1475,7 @@ mod tests {
             process_swap_calldata(&ds, unwrapped_calldata_request(WT_MSTR, WETH, "100", "2.5"))
                 .await;
 
-        assert!(
-            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read wrap ratios")
-        );
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
         no_take_orders_request_was_made(&captured_request);
     }
 
@@ -1449,9 +1489,7 @@ mod tests {
             process_swap_calldata(&ds, unwrapped_calldata_request(USDC, WT_MSTR, "100", "2.5"))
                 .await;
 
-        assert!(
-            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read wrapped token ratio")
-        );
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
         no_take_orders_request_was_made(&captured_request);
     }
 
@@ -1470,9 +1508,7 @@ mod tests {
 
         let request = captured_take_orders_request(&captured_request);
         assert_eq!(request.price_cap, "1.25");
-        assert!(
-            matches!(result, Err(ApiError::Internal(msg)) if msg == "failed to read estimated_input")
-        );
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
     }
 
     #[test]
@@ -1502,12 +1538,13 @@ mod tests {
             supported_tokens: Ok(()),
             orders: Ok(vec![]),
             candidates: vec![],
-            calldata_result: Err(ApiError::NotFound(
-                "no liquidity found for this pair".into(),
+            calldata_result: Err(ApiError::coded(
+                ApiErrorCode::SwapNoLiquidity,
+                "no executable liquidity is available for this pair",
             )),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
-        assert!(matches!(result, Err(ApiError::NotFound(msg)) if msg.contains("no liquidity")));
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
     }
 
     #[rocket::async_test]
@@ -1531,23 +1568,34 @@ mod tests {
             calldata_result: Err(ApiError::Internal("failed to generate calldata".into())),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
-        assert!(matches!(result, Err(ApiError::Internal(_))));
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
     }
 
     #[rocket::async_test]
     async fn test_process_swap_calldata_rejects_unsupported_tokens() {
         let ds = MockSwapDataSource {
-            supported_tokens: Err(ApiError::BadRequest(
-                "unsupported token for this API".into(),
+            supported_tokens: Err(ApiError::coded(
+                ApiErrorCode::SwapUnsupportedToken,
+                "one or both swap tokens are unsupported",
             )),
             orders: Ok(vec![]),
             candidates: vec![],
             calldata_result: Ok(ready_response()),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
-        assert!(
-            matches!(result, Err(ApiError::BadRequest(msg)) if msg.contains("unsupported token"))
-        );
+        assert_error_code(result, ApiErrorCode::SwapUnsupportedToken);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_registry_failure_is_not_retryable() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::Internal("invalid local registry".into())),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+        let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
     }
 
     #[rocket::async_test]
@@ -1587,6 +1635,9 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::BadRequest);
+        let body = response.into_json::<ApiErrorResponse>().await.unwrap();
+        assert_eq!(body.error.code, ApiErrorCode::SwapUnsupportedToken);
+        assert!(!body.request_id.is_empty());
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -533,7 +533,11 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
     let error = process_swap_calldata(&data_source, request)
         .await
         .unwrap_err();
-    assert!(
-        matches!(error, ApiError::NotFound(message) if message == "no liquidity found for this pair")
-    );
+    assert!(matches!(
+        error,
+        ApiError::Coded {
+            code: ApiErrorCode::SwapNoLiquidity,
+            ..
+        }
+    ));
 }

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -5,7 +5,7 @@ mod slippage;
 
 use crate::cache::RouteResponseCaches;
 use crate::db::DbPool;
-use crate::error::ApiError;
+use crate::error::{ApiError, ApiErrorCode};
 use crate::types::swap::{SwapCalldataMode, SwapCalldataResponse, SwapDenomination};
 use crate::wrap_ratio::{
     persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
@@ -20,6 +20,7 @@ use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::raindex_client::types::ChainIds;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_common::raindex_client::RaindexError;
+use rain_orderbook_common::rpc_client::RpcClientError;
 use rain_orderbook_common::take_orders::{
     build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate, TakeOrdersMode,
 };
@@ -101,7 +102,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
     ) -> Result<(), ApiError> {
         let tokens = self.client.get_all_tokens().map_err(|e| {
             tracing::error!(error = %e, "failed to retrieve curated tokens");
-            ApiError::Internal("failed to retrieve curated tokens".into())
+            ApiError::Internal("failed to read the token registry".into())
         })?;
 
         let input_supported = tokens.values().any(|token| token.address == input_token);
@@ -119,8 +120,9 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             output_supported,
             "swap request rejected for unsupported curated tokens"
         );
-        Err(ApiError::BadRequest(
-            "unsupported token for this API".into(),
+        Err(ApiError::coded(
+            ApiErrorCode::SwapUnsupportedToken,
+            "one or both swap tokens are unsupported",
         ))
     }
 
@@ -144,7 +146,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             .map(|r| r.orders().to_vec())
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to query orders for pair");
-                ApiError::Internal("failed to query orders".into())
+                ApiError::coded(
+                    ApiErrorCode::OrdersQueryFailed,
+                    "the order source could not serve this request",
+                )
             })
     }
 
@@ -168,7 +173,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             .await
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to build order candidates");
-                ApiError::Internal("failed to build order candidates".into())
+                ApiError::coded(
+                    ApiErrorCode::SwapQuoteFailed,
+                    "the swap quote could not be generated",
+                )
             })
         };
 
@@ -215,7 +223,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         } else if let Some(take_orders_info) = result.take_orders_info() {
             let expected_sell = take_orders_info.expected_sell().format().map_err(|e| {
                 tracing::error!(error = %e, "failed to format expected sell");
-                ApiError::Internal("failed to format expected sell".into())
+                ApiError::coded(
+                    ApiErrorCode::SwapCalldataFailed,
+                    "swap calldata could not be generated",
+                )
             })?;
             Ok(SwapCalldataResponse {
                 to: take_orders_info.raindex(),
@@ -226,8 +237,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 approvals: vec![],
             })
         } else {
-            Err(ApiError::Internal(
-                "unexpected calldata result state".into(),
+            tracing::error!("calldata provider returned an unexpected result state");
+            Err(ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
             ))
         }
     }
@@ -241,7 +254,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             .get_all_tokens()
             .map_err(|e| {
                 tracing::error!(error = %e, "failed to retrieve curated tokens");
-                ApiError::Internal("failed to retrieve curated tokens".into())
+                ApiError::Internal("failed to read the token registry".into())
             })?
             .into_values()
             .collect();
@@ -256,7 +269,10 @@ fn map_raindex_error(e: RaindexError) -> ApiError {
     match &e {
         RaindexError::NoLiquidity | RaindexError::InsufficientLiquidity { .. } => {
             tracing::warn!(error = %e, "no liquidity found");
-            ApiError::NotFound("no liquidity found for this pair".into())
+            ApiError::coded(
+                ApiErrorCode::SwapNoLiquidity,
+                "no executable liquidity is available for this pair",
+            )
         }
         RaindexError::SameTokenPair
         | RaindexError::NonPositiveAmount
@@ -264,15 +280,39 @@ fn map_raindex_error(e: RaindexError) -> ApiError {
         | RaindexError::FromHexError(_)
         | RaindexError::Float(_) => {
             tracing::warn!(error = %e, "invalid request parameters");
-            ApiError::BadRequest(e.to_string())
+            ApiError::BadRequest("invalid swap parameters".into())
+        }
+        RaindexError::RaindexSubgraphClientError(_) => {
+            tracing::error!(error = %e, "order source failed during calldata generation");
+            ApiError::coded(
+                ApiErrorCode::OrdersQueryFailed,
+                "the order source could not serve this request",
+            )
+        }
+        RaindexError::RpcClientError(
+            RpcClientError::Transport(_)
+            | RpcClientError::RpcError { .. }
+            | RpcClientError::RateLimited { .. },
+        ) => {
+            tracing::error!(error = %e, "RPC unavailable during calldata generation");
+            ApiError::coded(
+                ApiErrorCode::UpstreamUnavailable,
+                "a required chain data provider is temporarily unavailable",
+            )
         }
         RaindexError::PreflightError(_) => {
-            tracing::warn!(error = %e, "preflight simulation failed");
-            ApiError::BadRequest(e.to_readable_msg())
+            tracing::error!(error = %e, "preflight failed without a typed failure category");
+            ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            )
         }
         _ => {
             tracing::error!(error = %e, "calldata generation failed");
-            ApiError::Internal("failed to generate calldata".into())
+            ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            )
         }
     }
 }
@@ -300,9 +340,12 @@ pub fn routes_v2() -> Vec<Route> {
 
 #[cfg(test)]
 mod tests {
-    use super::{swap_candidates_cache_key, swap_chain_ids};
+    use super::{map_raindex_error, swap_candidates_cache_key, swap_chain_ids};
+    use crate::error::{ApiError, ApiErrorCode};
     use alloy::primitives::address;
     use rain_orderbook_common::raindex_client::orders::RaindexOrder;
+    use rain_orderbook_common::raindex_client::RaindexError;
+    use rain_orderbook_common::rpc_client::RpcClientError;
     use serde_json::json;
 
     fn mock_order(chain_id: u32, order_hash: &str) -> RaindexOrder {
@@ -338,6 +381,59 @@ mod tests {
     #[test]
     fn test_swap_orders_are_scoped_to_calldata_chain() {
         assert_eq!(swap_chain_ids().0, vec![crate::CHAIN_ID]);
+    }
+
+    #[test]
+    fn test_raindex_no_liquidity_maps_to_stable_code() {
+        assert!(matches!(
+            map_raindex_error(RaindexError::NoLiquidity),
+            ApiError::Coded {
+                code: ApiErrorCode::SwapNoLiquidity,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_ambiguous_raindex_preflight_maps_to_server_failure() {
+        let error = map_raindex_error(RaindexError::PreflightError(
+            "sensitive rpc detail".to_string(),
+        ));
+        assert!(matches!(
+            error,
+            ApiError::Coded {
+                code: ApiErrorCode::SwapCalldataFailed,
+                public_message: "swap calldata could not be generated",
+            }
+        ));
+    }
+
+    #[test]
+    fn test_typed_rpc_failure_maps_to_upstream_unavailable() {
+        let error = map_raindex_error(RaindexError::RpcClientError(RpcClientError::RpcError {
+            message: "sensitive rpc detail".to_string(),
+        }));
+        assert!(matches!(
+            error,
+            ApiError::Coded {
+                code: ApiErrorCode::UpstreamUnavailable,
+                public_message: "a required chain data provider is temporarily unavailable",
+            }
+        ));
+    }
+
+    #[test]
+    fn test_rpc_configuration_failure_is_not_retryable() {
+        let error = map_raindex_error(RaindexError::RpcClientError(RpcClientError::Config {
+            message: "bad local config".to_string(),
+        }));
+        assert!(matches!(
+            error,
+            ApiError::Coded {
+                code: ApiErrorCode::SwapCalldataFailed,
+                ..
+            }
+        ));
     }
 }
 

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -3,7 +3,7 @@ use crate::analytics::{swap_quoted_event, swap_quoted_v2_event, Analytics};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
-use crate::error::{ApiError, ApiErrorResponse};
+use crate::error::{ApiError, ApiErrorCode, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::{
     denormalize_calldata_price_cap, normalize_calldata_price_cap,
@@ -37,6 +37,7 @@ use tracing::Instrument;
         (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
+        (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/quote", data = "<request>")]
@@ -159,24 +160,25 @@ async fn process_swap_quote(
     req: SwapQuoteRequest,
 ) -> Result<SwapQuoteResponse, ApiError> {
     ds.validate_supported_tokens(req.input_token, req.output_token)
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     let orders = ds
         .get_orders_for_pair(req.input_token, req.output_token)
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::OrdersQueryFailed))?;
 
     if orders.is_empty() {
-        return Err(ApiError::NotFound(
-            "no liquidity found for this pair".into(),
-        ));
+        return Err(no_liquidity_error());
     }
 
     let candidates = ds
         .build_candidates_for_pair(&orders, req.input_token, req.output_token, Address::ZERO)
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     if candidates.is_empty() {
-        return Err(ApiError::NotFound("no valid quotes available".into()));
+        return Err(no_liquidity_error());
     }
 
     let buy_target = Float::parse(req.output_amount.clone()).map_err(|e| {
@@ -186,16 +188,16 @@ async fn process_swap_quote(
 
     let price_cap = Float::max_positive_value().map_err(|e| {
         tracing::error!(error = %e, "failed to create price cap");
-        ApiError::Internal("failed to create price cap".into())
+        quote_failed_error()
     })?;
 
     let sim = simulate_buy_over_candidates(candidates, buy_target, price_cap).map_err(|e| {
         tracing::error!(error = %e, "failed to simulate swap");
-        ApiError::Internal("failed to simulate swap".into())
+        quote_failed_error()
     })?;
 
     if sim.legs.is_empty() {
-        return Err(ApiError::NotFound("no valid quotes available".into()));
+        return Err(no_liquidity_error());
     }
 
     let (estimated_input, estimated_output) = normalize_quote_amounts(
@@ -206,26 +208,27 @@ async fn process_swap_quote(
         sim.total_input,
         sim.total_output,
     )
-    .await?;
+    .await
+    .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     let blended_ratio = estimated_input.div(estimated_output).map_err(|e| {
         tracing::error!(error = %e, "failed to compute blended ratio");
-        ApiError::Internal("failed to compute ratio".into())
+        quote_failed_error()
     })?;
 
     let formatted_output = estimated_output.format().map_err(|e| {
         tracing::error!(error = %e, "failed to format estimated output");
-        ApiError::Internal("failed to format estimated output".into())
+        quote_failed_error()
     })?;
 
     let formatted_input = estimated_input.format().map_err(|e| {
         tracing::error!(error = %e, "failed to format estimated input");
-        ApiError::Internal("failed to format estimated input".into())
+        quote_failed_error()
     })?;
 
     let formatted_ratio = blended_ratio.format().map_err(|e| {
         tracing::error!(error = %e, "failed to format ratio");
-        ApiError::Internal("failed to format ratio".into())
+        quote_failed_error()
     })?;
 
     Ok(SwapQuoteResponse {
@@ -244,7 +247,8 @@ async fn process_swap_quote_v2(
     req: SwapQuoteV2Request,
 ) -> Result<SwapQuoteV2Response, ApiError> {
     ds.validate_supported_tokens(req.input_token, req.output_token)
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     let mode: TakeOrdersMode = req.mode.into();
     let (amount, wrap_ratios) = normalize_calldata_request_amount(
@@ -258,17 +262,17 @@ async fn process_swap_quote_v2(
             amount_field: "amount",
         },
     )
-    .await?;
+    .await
+    .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
     let parsed_mode =
         ParsedTakeOrdersMode::parse(mode, &amount).map_err(super::map_raindex_error)?;
 
     let orders = ds
         .get_orders_for_pair(req.input_token, req.output_token)
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::OrdersQueryFailed))?;
     if orders.is_empty() {
-        return Err(ApiError::NotFound(
-            "no liquidity found for this pair".into(),
-        ));
+        return Err(no_liquidity_error());
     }
 
     let candidates = ds
@@ -278,9 +282,10 @@ async fn process_swap_quote_v2(
             req.output_token,
             req.taker.unwrap_or(Address::ZERO),
         )
-        .await?;
+        .await
+        .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
     if candidates.is_empty() {
-        return Err(ApiError::NotFound("no valid quotes available".into()));
+        return Err(no_liquidity_error());
     }
 
     let price_cap = match (
@@ -366,20 +371,19 @@ async fn process_swap_quote_v2(
     };
     let fully_filled = achieved_amount.eq(target_amount).map_err(|error| {
         tracing::error!(%error, "failed to compare swap quote fill amount");
-        ApiError::Internal("failed to calculate quote".into())
+        quote_failed_error()
     })?;
     if is_exact_mode && !fully_filled {
         let requested = target_amount.format().map_err(|error| {
             tracing::error!(%error, "failed to format requested quote amount");
-            ApiError::Internal("failed to calculate quote".into())
+            quote_failed_error()
         })?;
         let available = achieved_amount.format().map_err(|error| {
             tracing::error!(%error, "failed to format available quote amount");
-            ApiError::Internal("failed to calculate quote".into())
+            quote_failed_error()
         })?;
-        return Err(ApiError::NotFound(format!(
-            "insufficient liquidity: requested {requested}, available {available}"
-        )));
+        tracing::warn!(%requested, %available, "insufficient executable liquidity");
+        return Err(no_liquidity_error());
     }
 
     let (estimated_input, estimated_output) = normalize_quote_amounts(
@@ -390,10 +394,11 @@ async fn process_swap_quote_v2(
         simulation.total_input,
         simulation.total_output,
     )
-    .await?;
+    .await
+    .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
     let estimated_io_ratio = estimated_input.div(estimated_output).map_err(|error| {
         tracing::error!(%error, "failed to compute v2 swap quote ratio");
-        ApiError::Internal("failed to compute ratio".into())
+        quote_failed_error()
     })?;
     let resolved_price_cap = denormalize_calldata_price_cap(
         price_cap,
@@ -401,12 +406,13 @@ async fn process_swap_quote_v2(
         req.input_token,
         req.output_token,
         &wrap_ratios,
-    )?;
+    )
+    .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     let format_estimate = |value: Float, label: &str| {
         value.format().map_err(|error| {
             tracing::error!(%error, label, "failed to format v2 swap quote");
-            ApiError::Internal(format!("failed to format {label}"))
+            quote_failed_error()
         })
     };
 
@@ -422,6 +428,34 @@ async fn process_swap_quote_v2(
         fully_filled,
         resolved_price_cap,
     })
+}
+
+fn no_liquidity_error() -> ApiError {
+    ApiError::coded(
+        ApiErrorCode::SwapNoLiquidity,
+        "no executable liquidity is available for this pair",
+    )
+}
+
+fn quote_failed_error() -> ApiError {
+    ApiError::coded(
+        ApiErrorCode::SwapQuoteFailed,
+        "the swap quote could not be generated",
+    )
+}
+
+fn map_quote_boundary_error(error: ApiError, fallback_code: ApiErrorCode) -> ApiError {
+    if matches!(error, ApiError::Coded { .. } | ApiError::BadRequest(_)) {
+        return error;
+    }
+    tracing::error!(%error, code = %fallback_code, "swap quote boundary failed");
+    match fallback_code {
+        ApiErrorCode::OrdersQueryFailed => ApiError::coded(
+            fallback_code,
+            "the order source could not serve this request",
+        ),
+        _ => quote_failed_error(),
+    }
 }
 
 #[cfg(test)]
@@ -473,6 +507,13 @@ mod tests {
             reference_io_ratio: None,
             denomination: SwapDenomination::Wrapped,
         }
+    }
+
+    fn assert_error_code<T>(result: Result<T, ApiError>, expected: ApiErrorCode) {
+        assert!(matches!(
+            result,
+            Err(ApiError::Coded { code, .. }) if code == expected
+        ));
     }
 
     fn unwrapped_quote_request(
@@ -703,8 +744,7 @@ mod tests {
         let result =
             process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::SpendExact, "8")).await;
 
-        assert!(matches!(result, Err(ApiError::NotFound(message))
-                if message.contains("requested 8, available 6")));
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
     }
 
     #[rocket::async_test]
@@ -1007,7 +1047,7 @@ mod tests {
             calldata_result: Err(ApiError::Internal("unused".into())),
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
-        assert!(matches!(result, Err(ApiError::NotFound(msg)) if msg.contains("no liquidity")));
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
     }
 
     #[rocket::async_test]
@@ -1019,7 +1059,7 @@ mod tests {
             calldata_result: Err(ApiError::Internal("unused".into())),
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
-        assert!(matches!(result, Err(ApiError::NotFound(msg)) if msg.contains("no valid quotes")));
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
     }
 
     #[rocket::async_test]
@@ -1043,23 +1083,34 @@ mod tests {
             calldata_result: Err(ApiError::Internal("unused".into())),
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
-        assert!(matches!(result, Err(ApiError::Internal(_))));
+        assert_error_code(result, ApiErrorCode::OrdersQueryFailed);
     }
 
     #[rocket::async_test]
     async fn test_process_swap_quote_rejects_unsupported_tokens() {
         let ds = MockSwapDataSource {
-            supported_tokens: Err(ApiError::BadRequest(
-                "unsupported token for this API".into(),
+            supported_tokens: Err(ApiError::coded(
+                ApiErrorCode::SwapUnsupportedToken,
+                "one or both swap tokens are unsupported",
             )),
             orders: Ok(vec![mock_order()]),
             candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::Internal("unused".into())),
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
-        assert!(
-            matches!(result, Err(ApiError::BadRequest(msg)) if msg.contains("unsupported token"))
-        );
+        assert_error_code(result, ApiErrorCode::SwapUnsupportedToken);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_registry_failure_is_not_retryable() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::Internal("invalid local registry".into())),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let result = process_swap_quote(&ds, quote_request("100")).await;
+        assert_error_code(result, ApiErrorCode::SwapQuoteFailed);
     }
 
     #[rocket::async_test]
@@ -1087,6 +1138,9 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(response.status(), Status::BadRequest);
+        let body = response.into_json::<ApiErrorResponse>().await.unwrap();
+        assert_eq!(body.error.code, ApiErrorCode::SwapUnsupportedToken);
+        assert!(!body.request_id.is_empty());
     }
 
     #[rocket::async_test]

--- a/src/routes/tokens.rs
+++ b/src/routes/tokens.rs
@@ -658,6 +658,7 @@ pub(super) fn api_error_message(error: &ApiError) -> String {
         | ApiError::Internal(message)
         | ApiError::RateLimited(message)
         | ApiError::NotYetIndexed(message) => message.clone(),
+        ApiError::Coded { public_message, .. } => (*public_message).to_string(),
     }
 }
 


### PR DESCRIPTION
## Chained PRs

- Stack 2 of 2
- Parent: [#155](https://github.com/ST0x-Technology/st0x.rest.api/pull/155)
- Companion website stack: [SARKEX/st0x#224](https://github.com/SARKEX/st0x/pull/224) → [#225](https://github.com/SARKEX/st0x/pull/225) → [#226](https://github.com/SARKEX/st0x/pull/226)

## Motivation

The typed envelope needs deterministic trade-domain codes so quote, calldata, order-query, and upstream failures can be distinguished from screenshots and correlated to server logs.

## Solution

- Map unsupported tokens, no liquidity, quote computation, calldata, orders-query, and transient upstream failures to stable catalog codes.
- Use 502 for downstream order-query failures and 503 only for typed transient RPC/provider failures.
- Keep RPC configuration, permanent metadata, and ambiguous preflight failures out of the transient category.
- Preserve detailed causes in structured server logs while returning static public messages.
- Update OpenAPI responses and the error catalog documentation for active and reserved trade codes.

## Checks

- [x] `nix develop -c cargo test` — 308 passed
- [x] Swap and orders focused tests
- [x] `nix develop -c cargo check`
- [x] `nix develop -c rainix-rs-static`
- [x] Local API envelope and correlation check
- [x] Staged local review completed clean after fixes

## Linear

Fixes RAI-333

- [RAI-333 — Surface user-facing error codes for support and debugging](https://linear.app/makeitrain/issue/RAI-333/surface-user-facing-error-codes-for-support-and-debugging)