### PR TITLE
test(swap): verify signed oracle context in calldata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types",
@@ -290,6 +291,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives 1.6.0",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "alloy-hardforks"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
@@ -380,6 +394,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks 0.2.13",
+ "alloy-network",
+ "alloy-primitives 1.6.0",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "libc",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,8 +501,10 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives 1.6.0",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types 1.6.0",
@@ -545,6 +583,18 @@ checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
+dependencies = [
+ "alloy-primitives 1.6.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -2718,7 +2768,7 @@ checksum = "198b205ccbd3e54041e9a145374a6e170c71deb6d4c84dede8cd504a75694ad6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives 1.6.0",
  "alloy-provider",
  "alloy-rpc-types",
@@ -5266,6 +5316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "raindex_test_fixtures"
+version = "0.0.0-alpha.0"
+dependencies = [
+ "alloy",
+ "getrandom 0.2.16",
+ "rain-math-float",
+ "rainlang_test_fixtures",
+ "serde_json",
+]
+
+[[package]]
 name = "rainlang-eval"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,6 +5371,15 @@ dependencies = [
  "rainlang_dispair",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rainlang_test_fixtures"
+version = "0.0.0"
+source = "git+https://github.com/rainlanguage/rainlang?rev=580205d244a94097b06602ecda36faedf54d7775#580205d244a94097b06602ecda36faedf54d7775"
+dependencies = [
+ "alloy",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -6997,6 +7067,7 @@ dependencies = [
  "raindex_bindings",
  "raindex_common",
  "raindex_js_api",
+ "raindex_test_fixtures",
  "rand 0.9.1",
  "reqwest 0.13.2",
  "rocket",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ url = "2"
 [dev-dependencies]
 tracing-test = "0.2"
 tempfile = "3"
+raindex_test_fixtures = { path = "lib/rain.orderbook/crates/test_fixtures" }

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -211,6 +211,9 @@ async fn process_swap_calldata_build(
 }
 
 #[cfg(test)]
+mod oracle_integration_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -1,0 +1,451 @@
+use super::*;
+use crate::cache::RouteResponseCaches;
+use alloy::hex::encode_prefixed;
+use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy::signers::{local::PrivateKeySigner, Signer};
+use alloy::sol_types::{SolCall, SolValue};
+use rain_orderbook_bindings::IRaindexV6::{takeOrders4Call, OrderV4};
+use rain_orderbook_common::add_order::AddOrderArgs;
+use rain_orderbook_common::dotrain_order::DotrainOrder;
+use rain_orderbook_common::raindex_client::RaindexClient;
+use raindex_test_fixtures::LocalEvm;
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::RwLock;
+
+struct MockSwapServices {
+    base_url: String,
+    subgraph_order: Arc<RwLock<Option<Value>>>,
+    oracle_available: Arc<AtomicBool>,
+    oracle_bodies: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl MockSwapServices {
+    async fn start(oracle_response: Value) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let subgraph_order = Arc::new(RwLock::new(None));
+        let oracle_available = Arc::new(AtomicBool::new(true));
+        let oracle_bodies = Arc::new(Mutex::new(Vec::new()));
+
+        let orders = Arc::clone(&subgraph_order);
+        let available = Arc::clone(&oracle_available);
+        let bodies = Arc::clone(&oracle_bodies);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let orders = Arc::clone(&orders);
+                let available = Arc::clone(&available);
+                let bodies = Arc::clone(&bodies);
+                let oracle_response = oracle_response.clone();
+                tokio::spawn(async move {
+                    let Some((path, body)) = read_request(&mut socket).await else {
+                        return;
+                    };
+                    let (status, response) = match path.as_str() {
+                        "/oracle" if available.load(Ordering::SeqCst) => {
+                            bodies.lock().unwrap().push(body);
+                            ("200 OK", oracle_response.to_string())
+                        }
+                        "/oracle" => {
+                            bodies.lock().unwrap().push(body);
+                            (
+                                "503 Service Unavailable",
+                                json!({"error": "offline"}).to_string(),
+                            )
+                        }
+                        "/sg" => {
+                            let orders = orders.read().await;
+                            let values = orders.iter().cloned().collect::<Vec<_>>();
+                            ("200 OK", json!({"data": {"orders": values}}).to_string())
+                        }
+                        _ => ("404 Not Found", json!({"error": "not found"}).to_string()),
+                    };
+                    write_response(&mut socket, status, &response).await;
+                });
+            }
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            subgraph_order,
+            oracle_available,
+            oracle_bodies,
+        }
+    }
+
+    fn oracle_url(&self) -> String {
+        format!("{}/oracle", self.base_url)
+    }
+
+    fn subgraph_url(&self) -> String {
+        format!("{}/sg", self.base_url)
+    }
+}
+
+async fn read_request(socket: &mut tokio::net::TcpStream) -> Option<(String, Vec<u8>)> {
+    let mut request = Vec::new();
+    let mut chunk = [0u8; 8192];
+    let (header_end, content_length) = loop {
+        let read = socket.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+            let header_end = header_end + 4;
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or_default();
+            break (header_end, content_length);
+        }
+    };
+    while request.len() < header_end + content_length {
+        let read = socket.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        request.extend_from_slice(&chunk[..read]);
+    }
+
+    let request_line = String::from_utf8_lossy(&request)
+        .lines()
+        .next()?
+        .to_string();
+    let path = request_line.split_whitespace().nth(1)?.to_string();
+    Some((
+        path,
+        request[header_end..header_end + content_length].to_vec(),
+    ))
+}
+
+async fn write_response(socket: &mut tokio::net::TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket.write_all(response.as_bytes()).await.unwrap();
+}
+
+fn oracle_order_dotrain(
+    rpc_url: &str,
+    oracle_url: &str,
+    rainlang: Address,
+    input_token: Address,
+    output_token: Address,
+) -> String {
+    format!(
+        r#"
+version: 6
+networks:
+    test-network:
+        rpcs:
+            - {rpc_url}
+        chain-id: 8453
+        network-id: 8453
+        currency: ETH
+rainlangs:
+    test-rainlang:
+        network: test-network
+        address: {rainlang}
+tokens:
+    input:
+        network: test-network
+        address: {input_token}
+        decimals: 18
+        label: Input
+        symbol: INPUT
+    output:
+        network: test-network
+        address: {output_token}
+        decimals: 18
+        label: Output
+        symbol: OUTPUT
+raindex:
+    test-raindex:
+        address: 0x0000000000000000000000000000000000000001
+orders:
+    test-order:
+        oracle-url: {oracle_url}
+        inputs:
+            - token: input
+        outputs:
+            - token: output
+              vault-id: 1
+scenarios:
+    test-scenario:
+        rainlang: test-rainlang
+        bindings:
+            max-amount: 1000
+deployments:
+    test-deployment:
+        scenario: test-scenario
+        order: test-order
+---
+#max-amount !Max output amount
+#calculate-io
+amount price: 100 2;
+#handle-add-order
+:;
+#handle-io
+:;
+"#
+    )
+}
+
+fn client_yaml(
+    rpc_url: &str,
+    subgraph_url: &str,
+    raindex: Address,
+    input_token: Address,
+    output_token: Address,
+) -> String {
+    format!(
+        r#"
+version: 6
+networks:
+    test-network:
+        rpcs:
+            - {rpc_url}
+        chain-id: 8453
+        network-id: 8453
+        currency: ETH
+subgraphs:
+    test-subgraph: {subgraph_url}
+raindexes:
+    test-raindex:
+        address: {raindex}
+        network: test-network
+        subgraph: test-subgraph
+        deployment-block: 0
+tokens:
+    input:
+        network: test-network
+        address: {input_token}
+        decimals: 18
+        label: Input
+        symbol: INPUT
+    output:
+        network: test-network
+        address: {output_token}
+        decimals: 18
+        label: Output
+        symbol: OUTPUT
+"#
+    )
+}
+
+fn vault_json(
+    id: &str,
+    owner: Address,
+    vault_id: B256,
+    balance: U256,
+    token: Address,
+    symbol: &str,
+    raindex: Address,
+) -> Value {
+    json!({
+        "id": id,
+        "owner": owner,
+        "vaultId": vault_id,
+        "balance": B256::from(balance),
+        "token": {
+            "id": token,
+            "address": token,
+            "name": symbol,
+            "symbol": symbol,
+            "decimals": "18",
+        },
+        "raindex": {"id": raindex},
+        "ordersAsOutput": [],
+        "ordersAsInput": [],
+        "balanceChanges": [],
+    })
+}
+
+fn subgraph_order_json(order: &OrderV4, order_hash: B256, meta: &[u8], raindex: Address) -> Value {
+    let owner = order.owner;
+    let input = &order.validInputs[0];
+    let output = &order.validOutputs[0];
+    json!({
+        "id": order_hash,
+        "orderBytes": encode_prefixed(order.abi_encode()),
+        "orderHash": order_hash,
+        "owner": owner,
+        "outputs": [vault_json(
+            "0x02",
+            owner,
+            output.vaultId,
+            U256::from(10).pow(U256::from(20)),
+            output.token,
+            "OUTPUT",
+            raindex
+        )],
+        "inputs": [vault_json(
+            "0x01",
+            owner,
+            input.vaultId,
+            U256::ZERO,
+            input.token,
+            "INPUT",
+            raindex
+        )],
+        "raindex": {"id": raindex},
+        "active": true,
+        "timestampAdded": "1739448802",
+        "meta": encode_prefixed(meta),
+        "addEvents": [{
+            "transaction": {
+                "id": B256::from(U256::from(1)),
+                "from": owner,
+                "blockNumber": "1",
+                "timestamp": "1739448802",
+            }
+        }],
+        "trades": [],
+        "removeEvents": [],
+    })
+}
+
+#[rocket::async_test]
+async fn test_v1_calldata_fetches_and_preserves_oracle_signed_context() {
+    let mut local_evm = LocalEvm::new().await;
+    let oracle_signer = PrivateKeySigner::from(local_evm.anvil.keys()[1].clone());
+    let oracle_context = B256::from(U256::from(42));
+    let oracle_signature = oracle_signer
+        .sign_message(keccak256(oracle_context).as_slice())
+        .await
+        .unwrap();
+    let oracle_signature = Bytes::from(oracle_signature.as_bytes().to_vec());
+    let oracle_signer_address = oracle_signer.address();
+    let services = MockSwapServices::start(json!([{
+        "signer": oracle_signer_address,
+        "context": [oracle_context],
+        "signature": oracle_signature,
+    }]))
+    .await;
+    let owner = local_evm.signer_wallets[0].default_signer().address();
+    let input = local_evm
+        .deploy_new_token("Input", "INPUT", 18, U256::MAX, owner)
+        .await;
+    let output = local_evm
+        .deploy_new_token("Output", "OUTPUT", 18, U256::MAX, owner)
+        .await;
+    let input_address = *input.address();
+    let output_address = *output.address();
+    let raindex = *local_evm.raindex.address();
+
+    let dotrain = oracle_order_dotrain(
+        &local_evm.url(),
+        &services.oracle_url(),
+        local_evm.rainlang,
+        input_address,
+        output_address,
+    );
+    let dotrain_order = DotrainOrder::create(dotrain.clone(), None).await.unwrap();
+    let deployment = dotrain_order
+        .dotrain_yaml()
+        .get_deployment("test-deployment")
+        .unwrap();
+    let add_order_args = AddOrderArgs::new_from_deployment(dotrain, deployment, None)
+        .await
+        .unwrap();
+    let add_order_call = add_order_args
+        .try_into_call(vec![local_evm.url()])
+        .await
+        .unwrap();
+    let meta = add_order_call.config.meta.clone();
+    let (event, _) = local_evm
+        .add_order(&add_order_call.abi_encode(), owner)
+        .await;
+    let order = OrderV4::abi_decode(&event.order.abi_encode()).unwrap();
+    local_evm
+        .deposit(
+            owner,
+            output_address,
+            U256::from(10).pow(U256::from(20)),
+            18,
+            order.validOutputs[0].vaultId,
+        )
+        .await;
+    input
+        .approve(raindex, U256::MAX)
+        .from(owner)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    *services.subgraph_order.write().await =
+        Some(subgraph_order_json(&order, event.orderHash, &meta, raindex));
+    let client = RaindexClient::new(
+        vec![client_yaml(
+            &local_evm.url(),
+            &services.subgraph_url(),
+            raindex,
+            input_address,
+            output_address,
+        )],
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let database_url = format!(
+        "sqlite:file:{}?mode=memory&cache=shared",
+        uuid::Uuid::new_v4()
+    );
+    let pool = crate::db::init(&database_url, 1).await.unwrap();
+    let caches = RouteResponseCaches::new(0, Duration::ZERO);
+    let data_source = RaindexSwapDataSource {
+        client: &client,
+        caches: &caches,
+        pool: &pool,
+    };
+    let request = SwapCalldataRequest {
+        taker: owner,
+        input_token: input_address,
+        output_token: output_address,
+        output_amount: "10".to_string(),
+        maximum_io_ratio: "3".to_string(),
+        denomination: crate::types::swap::SwapDenomination::Wrapped,
+    };
+
+    let response = process_swap_calldata(&data_source, request.clone())
+        .await
+        .unwrap();
+    let decoded = takeOrders4Call::abi_decode(&response.data).unwrap();
+    let signed_context = &decoded.config.orders[0].signedContext[0];
+    assert_eq!(signed_context.signer, oracle_signer_address);
+    assert_eq!(signed_context.context[0], oracle_context);
+    assert_eq!(signed_context.signature, oracle_signature);
+
+    let oracle_body = services.oracle_bodies.lock().unwrap()[0].clone();
+    let oracle_request = <(OrderV4, U256, U256, Address)>::abi_decode(&oracle_body).unwrap();
+    assert_eq!(oracle_request.0, order);
+    assert_eq!(oracle_request.1, U256::ZERO);
+    assert_eq!(oracle_request.2, U256::ZERO);
+    assert_eq!(oracle_request.3, owner);
+
+    services.oracle_available.store(false, Ordering::SeqCst);
+    let error = process_swap_calldata(&data_source, request)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, ApiError::NotFound(message) if message == "no liquidity found for this pair")
+    );
+}


### PR DESCRIPTION
## Chained PRs

- REST stack 1 of 2
- Child: [#159](https://github.com/ST0x-Technology/st0x.rest.api/pull/159)
- Companion website stack: [#236](https://github.com/SARKEX/st0x/pull/236) → [#237](https://github.com/SARKEX/st0x/pull/237)

## Motivation

The v1 swap-calldata path relies on signed oracle context produced by the SDK, but the API had no end-to-end regression coverage proving that the signed payload reaches the generated `takeOrders4` calldata or that missing context fails closed.

## Solution

- Add a local EVM/subgraph/oracle fixture that exercises the real v1 SDK processing path.
- Decode the generated transaction and verify the signed context payload and taker address.
- Verify calldata generation fails closed when the signed context cannot be produced.

## Checks

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo check`
- `nix develop -c cargo test`

## Linear

Fixes [RAI-740](https://linear.app/makeitrain/issue/RAI-740/populate-signed-oracle-context-in-v1swapcalldata)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for swap calldata generation with oracle-signed context.
  * Verified oracle request data is forwarded correctly, including order and input/output amounts.
  * Added coverage for unavailable oracle responses, ensuring the system reports that no liquidity is available.
  * Added local test fixtures to support realistic swap and routing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->