### PR TITLE
feat(swap): add optional slippage to v2 calldata

### DIFF
--- a/docs/src/swap-flow.md
+++ b/docs/src/swap-flow.md
@@ -5,62 +5,131 @@ Swapping is a two-step process: get a **quote** to preview pricing, then get
 
 ## Step 1: Get a Quote
 
+For new integrations, use `POST /v2/swap/quote`. It uses the same mode,
+slippage, reference-price guard, and SDK simulation as V2 calldata, so the
+displayed quote describes the route the API can execute.
+
+### Recommended: V2 Mode-Based Quote
+
 ```
-POST /v1/swap/quote
+POST /v2/swap/quote
 ```
 
-### Request
+#### Request
 
 ```bash
-curl -X POST https://api.st0x.io/v1/swap/quote \
+curl -X POST https://api.st0x.io/v2/swap/quote \
   -H "Authorization: Basic <credentials>" \
   -H "Content-Type: application/json" \
   -d '{
+    "taker": "0xYourWalletAddress",
     "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "outputToken": "0x4200000000000000000000000000000000000006",
-    "outputAmount": "1.0",
+    "mode": "buyUpTo",
+    "amount": "1.0",
+    "slippageBps": 50,
+    "referenceIoRatio": "2500",
     "denomination": "wrapped"
   }'
 ```
 
-| Field          | Type   | Description                                                                                                                                                                   |
-| -------------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inputToken`   | string | Address of the token you are selling                                                                                                                                          |
-| `outputToken`  | string | Address of the token you want to receive                                                                                                                                      |
-| `outputAmount` | string | Desired output amount (human-readable, e.g. `"1.0"` for 1 WETH)                                                                                                               |
-| `denomination` | string | Optional. `"wrapped"` (default) returns orderbook-denominated values. `"unwrapped"` returns normalized display values for wrapped ST0x/ERC4626 tokens after quote simulation. |
+| Field              | Required | Description                                                                                                                                                            |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `taker`            | No       | Wallet that would execute the swap. Recommended because oracle-backed orders can use it when building signed context                                                   |
+| `inputToken`       | Yes      | Address of the token the taker will spend                                                                                                                              |
+| `outputToken`      | Yes      | Address of the token the taker will receive                                                                                                                            |
+| `mode`             | Yes      | `"buyUpTo"`, `"spendExact"`, or `"spendUpTo"`                                                                                                                          |
+| `amount`           | Yes      | Output-token amount for `buyUpTo`; input-token amount for `spendExact` and `spendUpTo`                                                                                 |
+| `priceCap`         | One of   | Explicit maximum input-token amount per one output token                                                                                                               |
+| `slippageBps`      | One of   | Integer from 1 to 5000. The API derives the final price cap from the selected SDK simulation                                                                           |
+| `referenceIoRatio` | No       | Optional trusted input-token-per-output-token reference. Valid only with `slippageBps`; candidate ratios more than 5% above it are excluded before slippage is applied |
+| `denomination`     | No       | `"wrapped"` by default. `"unwrapped"` changes the units of numeric fields, but `inputToken` and `outputToken` must still be wrapped/orderbook token addresses          |
 
-### Response
+Provide exactly one of `priceCap` or `slippageBps`.
+
+#### Response
 
 ```json
 {
   "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
   "outputToken": "0x4200000000000000000000000000000000000006",
-  "outputAmount": "1.0",
+  "mode": "buyUpTo",
+  "amount": "1.0",
   "denomination": "wrapped",
   "estimatedOutput": "1.0",
   "estimatedInput": "2500.0",
-  "estimatedIoRatio": "2500.0"
+  "estimatedIoRatio": "2500.0",
+  "fullyFilled": true,
+  "resolvedPriceCap": "2512.5"
 }
 ```
 
-| Field              | Type   | Description                                                                       |
-| ------------------ | ------ | --------------------------------------------------------------------------------- |
-| `denomination`     | string | Denomination used for `estimatedOutput`, `estimatedInput`, and `estimatedIoRatio` |
-| `estimatedOutput`  | string | Expected output amount                                                            |
-| `estimatedInput`   | string | Expected input amount required                                                    |
-| `estimatedIoRatio` | string | Input-to-output ratio                                                             |
+| Field              | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `estimatedOutput`  | Output-token amount selected by the simulation                                                                                                 |
+| `estimatedInput`   | Input-token amount selected by the simulation                                                                                                  |
+| `estimatedIoRatio` | Simulated input-token amount per one output token                                                                                              |
+| `fullyFilled`      | Whether the requested amount was completely filled. Up-to modes can return `false`; exact modes fail when they cannot fill the complete amount |
+| `resolvedPriceCap` | Final maximum input-token amount per one output token: either the supplied `priceCap` or the cap derived from `slippageBps`                    |
+| `denomination`     | Units used by the numeric response fields                                                                                                      |
 
 The quote reflects current orderbook state. Prices may change between quoting
 and execution.
 
-When `denomination` is omitted or set to `"wrapped"`, quote values use the
-wrapped/orderbook token units required by the swap endpoints. When
-`denomination` is `"unwrapped"`, the API still simulates against the
-wrapped/orderbook `inputToken` and `outputToken` addresses, then normalizes only
-the displayed `estimatedInput`, `estimatedOutput`, and `estimatedIoRatio` for
-wrapped ST0x/ERC4626 tokens. `outputAmount` remains in `outputToken` units and
-is not pre-converted.
+### Understanding Price Limits
+
+`priceCap`, `estimatedIoRatio`, `referenceIoRatio`, and `resolvedPriceCap`
+always mean:
+
+```
+input-token amount / output-token amount
+```
+
+For example:
+
+- USDC -> WETH at 2500 USDC per WETH uses an I/O ratio of `2500`.
+- WETH -> USDC at the same market price uses the reciprocal ratio, `0.0004` WETH
+  per USDC.
+
+`slippageBps` is an integer tolerance in basis points:
+
+| BPS   | Percentage |
+| ----- | ---------- |
+| `1`   | 0.01%      |
+| `50`  | 0.5%       |
+| `100` | 1%         |
+| `500` | 5%         |
+
+The API simulates the executable route with the SDK, finds the worst selected
+fill ratio, and calculates:
+
+```
+resolvedPriceCap = worst selected I/O ratio * (1 + slippageBps / 10,000)
+```
+
+`referenceIoRatio` is not another slippage value. It is an optional independent
+safety reference, normally derived from a trusted oracle. Before calculating the
+slippage cap, the API excludes any candidate whose I/O ratio is more than 5%
+above the reference. Omit it when no trusted reference is available.
+
+Alternatively, send `priceCap` to provide the final maximum I/O ratio directly.
+Do not send `slippageBps` or `referenceIoRatio` with an explicit `priceCap`.
+
+When `denomination` is omitted or set to `"wrapped"`, all numeric values use
+wrapped/orderbook token units. With `"unwrapped"`, the API converts numeric
+request and response values for wrapped ST0x/ERC4626 tokens, while token
+addresses remain wrapped/orderbook addresses.
+
+### Legacy: V1 Output-Targeted Quote
+
+```
+POST /v1/swap/quote
+```
+
+V1 accepts `inputToken`, `outputToken`, `outputAmount`, and optional
+`denomination`. It only supports an output-targeted quote and does not apply a
+slippage limit. Existing integrations can continue using it; new mode-based
+integrations should use V2.
 
 Do not pass unwrapped-normalized quote values into other endpoints unless those
 endpoints explicitly support `denomination=unwrapped` and you call them that
@@ -91,20 +160,23 @@ curl -X POST https://api.st0x.io/v2/swap/calldata \
     "outputToken": "0x4200000000000000000000000000000000000006",
     "mode": "spendExact",
     "amount": "2500.0",
-    "priceCap": "2600.0",
+    "slippageBps": 50,
+    "referenceIoRatio": "2500",
     "denomination": "wrapped"
   }'
 ```
 
-| Field          | Type   | Description                                                                                                                                                         |
-| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `taker`        | string | Your wallet address that will execute the transaction                                                                                                               |
-| `inputToken`   | string | Wrapped/orderbook token address you are selling                                                                                                                     |
-| `outputToken`  | string | Wrapped/orderbook token address you want to receive                                                                                                                 |
-| `mode`         | string | Swap mode. One of `"buyUpTo"`, `"spendExact"`, or `"spendUpTo"`                                                                                                     |
-| `amount`       | string | Target amount in the selected `denomination`. For `buyUpTo`, this is output amount. For `spendExact` and `spendUpTo`, this is input amount                          |
-| `priceCap`     | string | Maximum input-token amount you are willing to spend per 1 output token, in the selected `denomination`                                                              |
-| `denomination` | string | Optional. `"wrapped"` (default) uses orderbook units. `"unwrapped"` interprets `amount` and `priceCap` as unwrapped display values for wrapped ST0x/ERC4626 tokens. |
+| Field              | Type   | Description                                                                                                                                                                                      |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `taker`            | string | Wallet that will execute the swap and whose allowance is checked                                                                                                                                 |
+| `inputToken`       | string | Wrapped/orderbook token the taker will spend                                                                                                                                                     |
+| `outputToken`      | string | Wrapped/orderbook token the taker will receive                                                                                                                                                   |
+| `mode`             | string | `"buyUpTo"`, `"spendExact"`, or `"spendUpTo"`                                                                                                                                                    |
+| `amount`           | string | Output-token amount for `buyUpTo`; input-token amount for `spendExact` and `spendUpTo`                                                                                                           |
+| `priceCap`         | string | Explicit maximum input-token amount per one output token. Provide exactly one of `priceCap` or `slippageBps`                                                                                     |
+| `slippageBps`      | number | Integer from 1 to 5000. For example, `50` means 0.5% and `100` means 1%. The API derives `resolvedPriceCap` from the selected SDK simulation. Provide exactly one of `priceCap` or `slippageBps` |
+| `referenceIoRatio` | string | Optional trusted input-token-per-output-token reference. Valid only with `slippageBps`; candidate ratios more than 5% above it are excluded before slippage is applied                           |
+| `denomination`     | string | Optional. `"wrapped"` is the default. `"unwrapped"` changes the units of `amount`, price ratios, and returned estimates; token addresses remain wrapped/orderbook addresses                      |
 
 Mode behavior:
 
@@ -114,9 +186,10 @@ Mode behavior:
 | `spendExact` | Input-token amount to spend  | Spend exactly `amount`; fails if not fillable   |
 | `spendUpTo`  | Maximum input-token to spend | Spend up to `amount`; partial fills are allowed |
 
-Set `priceCap` slightly above the quote price to allow for price movement. For
-example, when selling USDC for WETH, `"priceCap": "2600"` means the swap will
-not pay more than 2600 USDC per 1 WETH.
+The price-control fields have exactly the same meaning and orientation as in the
+V2 quote request described above. No orderbook walking or price-cap calculation
+is required in the client. For example, on USDC -> WETH, `"priceCap": "2600"`
+means the swap will not spend more than 2600 USDC per one WETH.
 
 ### Legacy: V1 Output-Targeted Calldata
 
@@ -163,7 +236,8 @@ endpoint does not translate unwrapped asset addresses.
 
 ### Response
 
-The response always includes all fields, but the content depends on whether your
+The following examples show the v2 response. V1 returns the same transaction and
+approval fields without `resolvedPriceCap`. The content depends on whether your
 `taker` address has sufficient token approvals.
 
 **If approvals are needed**, `data` is empty and `approvals` contains the
@@ -176,6 +250,7 @@ required transactions:
   "value": "0x0",
   "estimatedInput": "2500.0",
   "denomination": "wrapped",
+  "resolvedPriceCap": "2613",
   "approvals": [
     {
       "token": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
@@ -198,18 +273,20 @@ the swap calldata:
   "value": "0x0",
   "estimatedInput": "2500.0",
   "denomination": "wrapped",
+  "resolvedPriceCap": "2613",
   "approvals": []
 }
 ```
 
-| Field            | Type   | Description                                                                                                                                                                                    |
-| ---------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `to`             | string | Contract address to send the transaction to                                                                                                                                                    |
-| `data`           | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed                                                                                                                        |
-| `value`          | string | Native token value to send (usually `"0x0"`)                                                                                                                                                   |
-| `estimatedInput` | string | Expected input amount in the requested `denomination` when calldata is ready. When approvals are needed, this is the input-token approval amount/cap required before calldata can be generated |
-| `denomination`   | string | Denomination used for `estimatedInput`                                                                                                                                                         |
-| `approvals`      | array  | Token approvals needed — if non-empty, approve first then call this endpoint again                                                                                                             |
+| Field              | Type   | Description                                                                                                                                                                                    |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `to`               | string | Contract address to send the transaction to                                                                                                                                                    |
+| `data`             | string | Encoded transaction calldata — empty (`"0x"`) when approvals are needed                                                                                                                        |
+| `value`            | string | Native token value to send (usually `"0x0"`)                                                                                                                                                   |
+| `estimatedInput`   | string | Expected input amount in the requested `denomination` when calldata is ready. When approvals are needed, this is the input-token approval amount/cap required before calldata can be generated |
+| `denomination`     | string | Denomination used for `estimatedInput`                                                                                                                                                         |
+| `approvals`        | array  | Token approvals needed — if non-empty, approve first then call this endpoint again                                                                                                             |
+| `resolvedPriceCap` | string | V2 only. Final maximum input-token amount per one output token. If approvals are required, send it as `priceCap` on the retry and omit `slippageBps` and `referenceIoRatio`                    |
 
 Approval entries always describe the actual on-chain approval requirements in
 wrapped/orderbook token units. They are not converted or relabeled when
@@ -225,8 +302,11 @@ If the `approvals` array is **not empty**, send the approval transactions first:
 1. For each approval, send a transaction to the `token` address with
    `approvalData` as calldata
 2. Wait for confirmation
-3. **Call the calldata endpoint again** — with approvals in place, the response
-   will now contain the swap calldata
+3. **Call the calldata endpoint again** with the first response's
+   `resolvedPriceCap` as `priceCap`. Omit `slippageBps` and `referenceIoRatio`.
+   Preserve the original `denomination`, including when it is `"unwrapped"`.
+   With approvals in place, the response will now contain the swap calldata
+   while preserving the original units and price limit
 
 ## Step 4: Execute the Swap
 
@@ -237,18 +317,23 @@ transaction using `to`, `data`, and `value`.
 
 ```bash
 # 1. Get quote
-QUOTE=$(curl -s -X POST https://api.st0x.io/v1/swap/quote \
+QUOTE=$(curl -s -X POST https://api.st0x.io/v2/swap/quote \
   -H "Authorization: Basic <credentials>" \
   -H "Content-Type: application/json" \
   -d '{
+    "taker": "0xYourWalletAddress",
     "inputToken": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "outputToken": "0x4200000000000000000000000000000000000006",
-    "outputAmount": "1.0"
+    "mode": "buyUpTo",
+    "amount": "1.0",
+    "slippageBps": 50,
+    "referenceIoRatio": "2500",
+    "denomination": "wrapped"
   }')
 
-echo "$QUOTE" | jq .estimatedIoRatio
+echo "$QUOTE" | jq '{estimatedInput, estimatedOutput, estimatedIoRatio, fullyFilled, resolvedPriceCap}'
 
-# 2. Get calldata (add some slippage to the quoted price)
+# 2. Get fresh executable calldata with the same price controls
 CALLDATA=$(curl -s -X POST https://api.st0x.io/v2/swap/calldata \
   -H "Authorization: Basic <credentials>" \
   -H "Content-Type: application/json" \
@@ -258,8 +343,12 @@ CALLDATA=$(curl -s -X POST https://api.st0x.io/v2/swap/calldata \
     "outputToken": "0x4200000000000000000000000000000000000006",
     "mode": "buyUpTo",
     "amount": "1.0",
-    "priceCap": "2600.0"
+    "slippageBps": 50,
+    "referenceIoRatio": "2500",
+    "denomination": "wrapped"
   }')
+
+RESOLVED_PRICE_CAP=$(echo "$CALLDATA" | jq -r '.resolvedPriceCap')
 
 # 3. Check if approvals are needed
 #    The first response only contains approvals — "data" will be empty ("0x").
@@ -281,7 +370,8 @@ if [ "$APPROVALS" != "[]" ]; then
       "outputToken": "0x4200000000000000000000000000000000000006",
       "mode": "buyUpTo",
       "amount": "1.0",
-      "priceCap": "2600.0"
+      "priceCap": "'"$RESOLVED_PRICE_CAP"'",
+      "denomination": "wrapped"
     }')
 fi
 

--- a/src/analytics/events.rs
+++ b/src/analytics/events.rs
@@ -6,7 +6,7 @@
 
 use super::AnalyticsEvent;
 use crate::auth::{AuthClientInfo, AuthenticatedKey};
-use crate::types::swap::{SwapCalldataResponse, SwapQuoteResponse};
+use crate::types::swap::{SwapCalldataResponse, SwapQuoteResponse, SwapQuoteV2Response};
 use alloy::primitives::Address;
 use serde_json::{Map, Value};
 
@@ -106,6 +106,54 @@ pub(crate) fn swap_quoted_event(
     props.insert(
         "estimated_io_ratio".to_string(),
         resp.estimated_io_ratio.clone().into(),
+    );
+    AnalyticsEvent {
+        event: "swap_quoted",
+        distinct_id: client_distinct_id(&info),
+        properties: props,
+    }
+}
+
+/// Mode-based swap quote event. Attributed to the client, with the optional
+/// taker deliberately omitted from analytics because this is still quote intent.
+pub(crate) fn swap_quoted_v2_event(
+    key: &AuthenticatedKey,
+    resp: &SwapQuoteV2Response,
+) -> AnalyticsEvent {
+    let info = key.client_info();
+    let mut props = base_props(&info);
+    props.insert(
+        "input_token".to_string(),
+        token_str(resp.input_token).into(),
+    );
+    props.insert(
+        "output_token".to_string(),
+        token_str(resp.output_token).into(),
+    );
+    props.insert(
+        "denomination".to_string(),
+        serde_json::to_value(resp.denomination).unwrap_or(Value::Null),
+    );
+    props.insert(
+        "mode".to_string(),
+        serde_json::to_value(resp.mode).unwrap_or(Value::Null),
+    );
+    props.insert(
+        "estimated_input".to_string(),
+        resp.estimated_input.clone().into(),
+    );
+    props.insert(
+        "estimated_output".to_string(),
+        resp.estimated_output.clone().into(),
+    );
+    props.insert(
+        "estimated_io_ratio".to_string(),
+        resp.estimated_io_ratio.clone().into(),
+    );
+    props.insert("fully_filled".to_string(), resp.fully_filled.into());
+    props.insert(
+        "resolved_price_cap".to_string(),
+        resp.resolved_price_cap.clone().into(),
     );
     AnalyticsEvent {
         event: "swap_quoted",

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -15,7 +15,8 @@ mod posthog;
 mod recording;
 
 pub(crate) use events::{
-    api_request_event, swap_calldata_generated_event, swap_quoted_event, ApiVersion,
+    api_request_event, swap_calldata_generated_event, swap_quoted_event, swap_quoted_v2_event,
+    ApiVersion,
 };
 pub(crate) use posthog::PostHogSink;
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,7 @@ enum StartupRegistryError {
         routes::tokens::get_token_details_by_address,
         routes::tokens::get_token_proofs,
         routes::swap::post_swap_quote,
+        routes::swap::post_swap_quote_v2,
         routes::swap::post_swap_calldata,
         routes::swap::post_swap_calldata_v2,
         routes::order::post_order_dca,
@@ -516,6 +517,7 @@ mod tests {
     fn test_openapi_includes_token_proofs_schema() {
         let openapi = serde_json::to_value(super::ApiDoc::openapi()).expect("serialize openapi");
         let proofs_path = &openapi["paths"]["/v1/tokens/{address}/proofs"]["get"];
+        let swap_quote_v2_path = &openapi["paths"]["/v2/swap/quote"]["post"];
         let swap_calldata_v2_path = &openapi["paths"]["/v2/swap/calldata"]["post"];
 
         assert_eq!(proofs_path["tags"][0], "Tokens");
@@ -538,14 +540,80 @@ mod tests {
         assert!(schemas["TokenProofReceipt"]["properties"]["receiptId"].is_object());
         assert!(schemas["TokenProofReceipt"]["properties"]["txHash"].is_object());
         assert!(schemas["TokenProofReceipt"]["properties"]["type"].is_object());
+        assert_eq!(swap_quote_v2_path["tags"][0], "Swap");
+        assert_eq!(
+            swap_quote_v2_path["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/SwapQuoteV2RequestBody"
+        );
+        assert_eq!(
+            schemas["SwapQuoteV2RequestBody"]["oneOf"],
+            serde_json::json!([
+                { "$ref": "#/components/schemas/SwapQuoteV2PriceCapRequest" },
+                { "$ref": "#/components/schemas/SwapQuoteV2SlippageRequest" }
+            ])
+        );
+        assert!(
+            schemas["SwapQuoteV2SlippageRequest"]["allOf"][1]["properties"]["slippageBps"]
+                ["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("1 BPS = 0.01%"))
+        );
+        assert!(
+            schemas["SwapQuoteV2SlippageRequest"]["allOf"][1]["properties"]["referenceIoRatio"]
+                ["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("input-token-per-output-token"))
+        );
         assert_eq!(swap_calldata_v2_path["tags"][0], "Swap");
         assert_eq!(
             swap_calldata_v2_path["requestBody"]["content"]["application/json"]["schema"]["$ref"],
-            "#/components/schemas/SwapCalldataV2Request"
+            "#/components/schemas/SwapCalldataV2RequestBody"
         );
         assert_eq!(
             schemas["SwapCalldataMode"]["enum"],
             serde_json::json!(["buyUpTo", "spendExact", "spendUpTo"])
+        );
+        assert_eq!(
+            swap_calldata_v2_path["responses"]["200"]["content"]["application/json"]["schema"]
+                ["$ref"],
+            "#/components/schemas/SwapCalldataV2Response"
+        );
+        assert_eq!(
+            schemas["SwapCalldataV2RequestBody"]["oneOf"],
+            serde_json::json!([
+                { "$ref": "#/components/schemas/SwapCalldataV2PriceCapRequest" },
+                { "$ref": "#/components/schemas/SwapCalldataV2SlippageRequest" }
+            ])
+        );
+        assert!(
+            schemas["SwapCalldataV2PriceCapRequest"]["allOf"][1]["required"]
+                .as_array()
+                .is_some_and(|required| required.contains(&serde_json::json!("priceCap")))
+        );
+        assert!(
+            schemas["SwapCalldataV2SlippageRequest"]["allOf"][1]["required"]
+                .as_array()
+                .is_some_and(|required| required.contains(&serde_json::json!("slippageBps")))
+        );
+        assert!(
+            schemas["SwapCalldataV2SlippageRequest"]["allOf"][1]["properties"]["referenceIoRatio"]
+                .is_object()
+        );
+        assert!(
+            schemas["SwapCalldataV2SlippageRequest"]["allOf"][1]["properties"]["slippageBps"]
+                ["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("1 BPS = 0.01%"))
+        );
+        assert!(
+            schemas["SwapCalldataV2SlippageRequest"]["allOf"][1]["properties"]["referenceIoRatio"]
+                ["description"]
+                .as_str()
+                .is_some_and(|description| description.contains("input-token-per-output-token"))
+        );
+        assert!(
+            schemas["SwapCalldataV2Response"]["allOf"][1]["properties"]["resolvedPriceCap"]
+                .is_object()
         );
     }
 

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -7,13 +7,17 @@ use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use crate::routes::swap::denomination::{
-    normalize_calldata_request_values, normalize_calldata_response, CalldataRequestNormalization,
+    denormalize_calldata_price_cap, normalize_calldata_price_cap,
+    normalize_calldata_request_amount, normalize_calldata_request_values,
+    normalize_calldata_response, CalldataAmountNormalization, CalldataRequestNormalization,
 };
 use crate::types::swap::{
-    SwapCalldataMode, SwapCalldataRequest, SwapCalldataResponse, SwapCalldataV2Request,
+    SwapCalldataRequest, SwapCalldataResponse, SwapCalldataV2Request, SwapCalldataV2RequestBody,
+    SwapCalldataV2Response,
 };
 use alloy::primitives::{keccak256, Address, Bytes, Signature};
 use alloy::sol_types::{SolCall, SolValue};
+use rain_math_float::Float;
 use rain_orderbook_bindings::IRaindexV6::takeOrders4Call;
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::take_orders::TakeOrdersMode;
@@ -79,10 +83,12 @@ pub async fn post_swap_calldata(
     post,
     path = "/v2/swap/calldata",
     tag = "Swap",
+    summary = "Build ready-to-send swap calldata",
+    description = "Builds SDK calldata for one executable route. Provide exactly one of priceCap or slippageBps. When approvals are returned, submit them and retry with the response's resolvedPriceCap as priceCap so the original limit remains fixed.",
     security(("basicAuth" = [])),
-    request_body = SwapCalldataV2Request,
+    request_body = SwapCalldataV2RequestBody,
     responses(
-        (status = 200, description = "Swap calldata", body = SwapCalldataResponse),
+        (status = 200, description = "Swap calldata", body = SwapCalldataV2Response),
         (status = 400, description = "Bad request", body = ApiErrorResponse),
         (status = 401, description = "Unauthorized", body = ApiErrorResponse),
         (status = 404, description = "No liquidity found", body = ApiErrorResponse),
@@ -102,7 +108,7 @@ pub async fn post_swap_calldata_v2(
     analytics: &State<Analytics>,
     span: TracingSpan,
     request: Json<SwapCalldataV2Request>,
-) -> Result<Json<SwapCalldataResponse>, ApiError> {
+) -> Result<Json<SwapCalldataV2Response>, ApiError> {
     async move {
         let req = request.into_inner();
         tracing::info!(
@@ -177,7 +183,7 @@ async fn handle_swap_calldata_v2(
     signer: &AttributionSigner,
     attribution: &Attribution,
     req: SwapCalldataV2Request,
-) -> Result<SwapCalldataResponse, ApiError> {
+) -> Result<SwapCalldataV2Response, ApiError> {
     let analytics_context = analytics.is_enabled().then(|| {
         (
             req.taker,
@@ -188,7 +194,7 @@ async fn handle_swap_calldata_v2(
         )
     });
     let mut response = process_swap_calldata_v2(ds, req).await?;
-    embed_and_validate_attribution(&mut response, signer, attribution).await?;
+    embed_and_validate_attribution(&mut response.calldata, signer, attribution).await?;
 
     if let Some((taker, input_token, output_token, denomination, mode)) = analytics_context {
         analytics.capture(|| {
@@ -200,7 +206,7 @@ async fn handle_swap_calldata_v2(
                 denomination,
                 ApiVersion::V2,
                 mode,
-                &response,
+                &response.calldata,
             )
         });
     }
@@ -336,9 +342,25 @@ struct SwapCalldataBuildRequest {
     mode: TakeOrdersMode,
     amount: String,
     amount_field: &'static str,
-    price_cap: String,
-    price_cap_field: &'static str,
+    price_limit: SwapCalldataPriceLimit,
     denomination: crate::types::swap::SwapDenomination,
+}
+
+#[derive(Debug)]
+enum SwapCalldataPriceLimit {
+    Explicit {
+        value: String,
+        field: &'static str,
+    },
+    SlippageBps {
+        slippage_bps: u16,
+        reference_io_ratio: Option<String>,
+    },
+}
+
+struct SwapCalldataBuildResult {
+    calldata: SwapCalldataResponse,
+    resolved_price_cap: String,
 }
 
 impl From<SwapCalldataRequest> for SwapCalldataBuildRequest {
@@ -350,36 +372,62 @@ impl From<SwapCalldataRequest> for SwapCalldataBuildRequest {
             mode: TakeOrdersMode::BuyUpTo,
             amount: req.output_amount,
             amount_field: "output_amount",
-            price_cap: req.maximum_io_ratio,
-            price_cap_field: "maximum_io_ratio",
+            price_limit: SwapCalldataPriceLimit::Explicit {
+                value: req.maximum_io_ratio,
+                field: "maximum_io_ratio",
+            },
             denomination: req.denomination,
         }
     }
 }
 
-impl From<SwapCalldataV2Request> for SwapCalldataBuildRequest {
-    fn from(req: SwapCalldataV2Request) -> Self {
-        Self {
+impl TryFrom<SwapCalldataV2Request> for SwapCalldataBuildRequest {
+    type Error = ApiError;
+
+    fn try_from(req: SwapCalldataV2Request) -> Result<Self, Self::Error> {
+        let price_limit = match (req.price_cap, req.slippage_bps, req.reference_io_ratio) {
+            (Some(value), None, None) => SwapCalldataPriceLimit::Explicit {
+                value,
+                field: "price_cap",
+            },
+            (Some(_), None, Some(_)) => {
+                tracing::warn!(
+                    "swap calldata rejected because reference_io_ratio was provided without slippage_bps"
+                );
+                return Err(ApiError::BadRequest(
+                    "reference_io_ratio requires slippage_bps".into(),
+                ));
+            }
+            (None, Some(slippage_bps @ 1..=5000), reference_io_ratio) => {
+                SwapCalldataPriceLimit::SlippageBps {
+                    slippage_bps,
+                    reference_io_ratio,
+                }
+            }
+            (None, Some(_), _) => {
+                tracing::warn!("swap calldata rejected for out-of-range slippage_bps");
+                return Err(ApiError::BadRequest(
+                    "slippage_bps must be between 1 and 5000".into(),
+                ));
+            }
+            _ => {
+                tracing::warn!("swap calldata rejected without exactly one price limit");
+                return Err(ApiError::BadRequest(
+                    "provide exactly one of price_cap or slippage_bps".into(),
+                ));
+            }
+        };
+
+        Ok(Self {
             taker: req.taker,
             input_token: req.input_token,
             output_token: req.output_token,
             mode: req.mode.into(),
             amount: req.amount,
             amount_field: "amount",
-            price_cap: req.price_cap,
-            price_cap_field: "price_cap",
+            price_limit,
             denomination: req.denomination,
-        }
-    }
-}
-
-impl From<SwapCalldataMode> for TakeOrdersMode {
-    fn from(mode: SwapCalldataMode) -> Self {
-        match mode {
-            SwapCalldataMode::BuyUpTo => TakeOrdersMode::BuyUpTo,
-            SwapCalldataMode::SpendExact => TakeOrdersMode::SpendExact,
-            SwapCalldataMode::SpendUpTo => TakeOrdersMode::SpendUpTo,
-        }
+        })
     }
 }
 
@@ -387,37 +435,121 @@ async fn process_swap_calldata(
     ds: &dyn SwapDataSource,
     req: SwapCalldataRequest,
 ) -> Result<SwapCalldataResponse, ApiError> {
-    process_swap_calldata_build(ds, req.into()).await
+    Ok(process_swap_calldata_build(ds, req.into()).await?.calldata)
 }
 
 async fn process_swap_calldata_v2(
     ds: &dyn SwapDataSource,
     req: SwapCalldataV2Request,
-) -> Result<SwapCalldataResponse, ApiError> {
-    process_swap_calldata_build(ds, req.into()).await
+) -> Result<SwapCalldataV2Response, ApiError> {
+    let result = process_swap_calldata_build(ds, req.try_into()?).await?;
+    Ok(SwapCalldataV2Response {
+        calldata: result.calldata,
+        resolved_price_cap: result.resolved_price_cap,
+    })
 }
 
 async fn process_swap_calldata_build(
     ds: &dyn SwapDataSource,
     req: SwapCalldataBuildRequest,
-) -> Result<SwapCalldataResponse, ApiError> {
+) -> Result<SwapCalldataBuildResult, ApiError> {
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await?;
 
-    let (amount, price_cap, wrap_ratios) = normalize_calldata_request_values(
-        ds,
-        CalldataRequestNormalization {
-            denomination: req.denomination,
-            input_token: req.input_token,
-            output_token: req.output_token,
-            mode: req.mode,
-            amount: req.amount,
-            amount_field: req.amount_field,
-            price_cap: req.price_cap,
-            price_cap_field: req.price_cap_field,
-        },
-    )
-    .await?;
+    let (amount, price_cap, resolved_price_cap, wrap_ratios) = match req.price_limit {
+        SwapCalldataPriceLimit::Explicit { value, field } => {
+            let resolved_price_cap = value.clone();
+            let (amount, price_cap, wrap_ratios) = normalize_calldata_request_values(
+                ds,
+                CalldataRequestNormalization {
+                    denomination: req.denomination,
+                    input_token: req.input_token,
+                    output_token: req.output_token,
+                    mode: req.mode,
+                    amount: req.amount,
+                    amount_field: req.amount_field,
+                    price_cap: value,
+                    price_cap_field: field,
+                },
+            )
+            .await?;
+            (amount, price_cap, resolved_price_cap, wrap_ratios)
+        }
+        SwapCalldataPriceLimit::SlippageBps {
+            slippage_bps,
+            reference_io_ratio,
+        } => {
+            let (amount, wrap_ratios) = normalize_calldata_request_amount(
+                ds,
+                CalldataAmountNormalization {
+                    denomination: req.denomination,
+                    input_token: req.input_token,
+                    output_token: req.output_token,
+                    mode: req.mode,
+                    amount: req.amount,
+                    amount_field: req.amount_field,
+                },
+            )
+            .await?;
+            let reference_io_ratio = reference_io_ratio
+                .map(|reference_io_ratio| {
+                    normalize_calldata_price_cap(
+                        reference_io_ratio,
+                        "reference_io_ratio",
+                        req.denomination,
+                        req.input_token,
+                        req.output_token,
+                        &wrap_ratios,
+                    )
+                    .and_then(|reference_io_ratio| {
+                        Float::parse(reference_io_ratio).map_err(|error| {
+                            tracing::warn!(
+                                %error,
+                                "swap calldata rejected for invalid reference_io_ratio"
+                            );
+                            ApiError::BadRequest("invalid reference_io_ratio".into())
+                        })
+                    })
+                })
+                .transpose()?;
+            let orders = ds
+                .get_orders_for_pair(req.input_token, req.output_token)
+                .await?;
+            if orders.is_empty() {
+                return Err(ApiError::NotFound(
+                    "no liquidity found for this pair".into(),
+                ));
+            }
+            let candidates = ds
+                .build_candidates_for_pair(&orders, req.input_token, req.output_token, req.taker)
+                .await?;
+            let price_cap = super::slippage::resolve_slippage_price_cap(
+                candidates,
+                req.mode,
+                &amount,
+                slippage_bps,
+                reference_io_ratio,
+            )?;
+            let resolved_price_cap = denormalize_calldata_price_cap(
+                price_cap,
+                req.denomination,
+                req.input_token,
+                req.output_token,
+                &wrap_ratios,
+            )?;
+            tracing::info!(
+                slippage_bps,
+                resolved_price_cap = %resolved_price_cap,
+                denomination = ?req.denomination,
+                "resolved swap slippage price cap"
+            );
+            let price_cap = price_cap.format().map_err(|error| {
+                tracing::error!(%error, "failed to format resolved slippage price cap");
+                ApiError::Internal("failed to resolve slippage".into())
+            })?;
+            (amount, price_cap, resolved_price_cap, wrap_ratios)
+        }
+    };
 
     let take_req = TakeOrdersRequest {
         taker: req.taker.to_string(),
@@ -430,7 +562,12 @@ async fn process_swap_calldata_build(
     };
 
     let response = ds.get_calldata(take_req).await?;
-    normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)
+    let calldata =
+        normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)?;
+    Ok(SwapCalldataBuildResult {
+        calldata,
+        resolved_price_cap,
+    })
 }
 
 #[cfg(all(test, feature = "oracle-integration-tests"))]
@@ -442,7 +579,7 @@ mod tests {
     use crate::analytics::{Analytics, RecordingSink};
     use crate::auth::AuthenticatedKey;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
-    use crate::test_helpers::TestClientBuilder;
+    use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
     use crate::types::common::Approval;
     use crate::types::swap::{SwapCalldataMode, SwapDenomination};
     use crate::wrap_ratio::WrapRatioValue;
@@ -458,6 +595,8 @@ mod tests {
     const ORDERBOOK: Address = address!("d2938e7c9fe3597f78832ce780feb61945c377d7");
     const WT_MSTR: Address = address!("Ff05e1BD696900DC6A52cA35cA61bB1024eDA8e2");
     const WT_COIN: Address = address!("EeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE");
+    type CapturedTakeOrdersRequest = Arc<Mutex<Option<TakeOrdersRequest>>>;
+    type CapturedCounterparty = Arc<Mutex<Option<Address>>>;
 
     fn test_key() -> AuthenticatedKey {
         AuthenticatedKey {
@@ -500,7 +639,9 @@ mod tests {
             output_token: WETH,
             mode,
             amount: amount.to_string(),
-            price_cap: price_cap.to_string(),
+            price_cap: Some(price_cap.to_string()),
+            slippage_bps: None,
+            reference_io_ratio: None,
             denomination: SwapDenomination::Wrapped,
         }
     }
@@ -534,8 +675,28 @@ mod tests {
             output_token,
             mode,
             amount: amount.to_string(),
-            price_cap: price_cap.to_string(),
+            price_cap: Some(price_cap.to_string()),
+            slippage_bps: None,
+            reference_io_ratio: None,
             denomination: SwapDenomination::Unwrapped,
+        }
+    }
+
+    fn slippage_v2_request(
+        mode: SwapCalldataMode,
+        amount: &str,
+        slippage_bps: u16,
+    ) -> SwapCalldataV2Request {
+        SwapCalldataV2Request {
+            taker: TAKER,
+            input_token: USDC,
+            output_token: WETH,
+            mode,
+            amount: amount.to_string(),
+            price_cap: None,
+            slippage_bps: Some(slippage_bps),
+            reference_io_ratio: None,
+            denomination: SwapDenomination::Wrapped,
         }
     }
 
@@ -577,20 +738,14 @@ mod tests {
     fn capture_ds(
         response: SwapCalldataResponse,
         wrap_ratios: HashMap<Address, WrapRatioValue>,
-    ) -> (
-        MockCalldataDataSource,
-        Arc<Mutex<Option<TakeOrdersRequest>>>,
-    ) {
+    ) -> (MockCalldataDataSource, CapturedTakeOrdersRequest) {
         capture_ds_with_wrap_result(response, Ok(wrap_ratios))
     }
 
     fn capture_ds_with_wrap_result(
         response: SwapCalldataResponse,
         wrap_ratios: Result<HashMap<Address, WrapRatioValue>, ApiError>,
-    ) -> (
-        MockCalldataDataSource,
-        Arc<Mutex<Option<TakeOrdersRequest>>>,
-    ) {
+    ) -> (MockCalldataDataSource, CapturedTakeOrdersRequest) {
         let captured_request = Arc::new(Mutex::new(None));
         (
             MockCalldataDataSource {
@@ -602,15 +757,43 @@ mod tests {
                 },
                 wrap_ratios,
                 captured_request: Arc::clone(&captured_request),
+                captured_counterparty: Arc::new(Mutex::new(None)),
             },
             captured_request,
+        )
+    }
+
+    fn capture_slippage_ds(
+        wrap_ratios: HashMap<Address, WrapRatioValue>,
+    ) -> (
+        MockCalldataDataSource,
+        CapturedTakeOrdersRequest,
+        CapturedCounterparty,
+    ) {
+        let captured_request = Arc::new(Mutex::new(None));
+        let captured_counterparty = Arc::new(Mutex::new(None));
+        (
+            MockCalldataDataSource {
+                base: MockSwapDataSource {
+                    supported_tokens: Ok(()),
+                    orders: Ok(vec![mock_order()]),
+                    candidates: vec![mock_candidate("100", "2")],
+                    calldata_result: Ok(ready_response()),
+                },
+                wrap_ratios: Ok(wrap_ratios),
+                captured_request: Arc::clone(&captured_request),
+                captured_counterparty: Arc::clone(&captured_counterparty),
+            },
+            captured_request,
+            captured_counterparty,
         )
     }
 
     struct MockCalldataDataSource {
         base: MockSwapDataSource,
         wrap_ratios: Result<HashMap<Address, WrapRatioValue>, ApiError>,
-        captured_request: Arc<Mutex<Option<TakeOrdersRequest>>>,
+        captured_request: CapturedTakeOrdersRequest,
+        captured_counterparty: CapturedCounterparty,
     }
 
     #[async_trait]
@@ -641,9 +824,11 @@ mod tests {
             orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
             input_token: Address,
             output_token: Address,
+            counterparty: Address,
         ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+            *self.captured_counterparty.lock().unwrap() = Some(counterparty);
             self.base
-                .build_candidates_for_pair(orders, input_token, output_token)
+                .build_candidates_for_pair(orders, input_token, output_token, counterparty)
                 .await
         }
 
@@ -672,12 +857,12 @@ mod tests {
     }
 
     fn captured_take_orders_request(
-        captured_request: &Arc<Mutex<Option<TakeOrdersRequest>>>,
+        captured_request: &CapturedTakeOrdersRequest,
     ) -> TakeOrdersRequest {
         captured_request.lock().unwrap().clone().unwrap()
     }
 
-    fn no_take_orders_request_was_made(captured_request: &Arc<Mutex<Option<TakeOrdersRequest>>>) {
+    fn no_take_orders_request_was_made(captured_request: &CapturedTakeOrdersRequest) {
         assert!(captured_request.lock().unwrap().is_none());
     }
 
@@ -834,8 +1019,9 @@ mod tests {
         assert_eq!(request.mode, TakeOrdersMode::SpendExact);
         assert_eq!(request.amount, "100");
         assert_eq!(request.price_cap, "2.5");
-        assert_eq!(result.estimated_input, "150");
-        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.calldata.estimated_input, "150");
+        assert_eq!(result.calldata.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.resolved_price_cap, "2.5");
     }
 
     #[rocket::async_test]
@@ -852,7 +1038,8 @@ mod tests {
         assert_eq!(request.mode, TakeOrdersMode::SpendUpTo);
         assert_eq!(request.amount, "75");
         assert_eq!(request.price_cap, "3");
-        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.calldata.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.resolved_price_cap, "3");
     }
 
     #[rocket::async_test]
@@ -869,7 +1056,119 @@ mod tests {
         assert_eq!(request.mode, TakeOrdersMode::BuyUpTo);
         assert_eq!(request.amount, "50");
         assert_eq!(request.price_cap, "2");
-        assert_eq!(result.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.calldata.denomination, SwapDenomination::Wrapped);
+        assert_eq!(result.resolved_price_cap, "2");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_resolves_optional_slippage() {
+        let (ds, captured_request, captured_counterparty) = capture_slippage_ds(HashMap::new());
+        let result = process_swap_calldata_v2(
+            &ds,
+            slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50),
+        )
+        .await
+        .unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.price_cap, "2.01");
+        assert_eq!(result.resolved_price_cap, "2.01");
+        assert_eq!(*captured_counterparty.lock().unwrap(), Some(TAKER));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_applies_reference_price_guard() {
+        let (ds, captured_request, _) = capture_slippage_ds(HashMap::new());
+        let mut request = slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50);
+        request.reference_io_ratio = Some("1".to_string());
+
+        let result = process_swap_calldata_v2(&ds, request).await;
+
+        assert!(
+            matches!(result, Err(ApiError::NotFound(message)) if message == "no liquidity found for this pair")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[test]
+    fn test_swap_calldata_v2_response_flattens_calldata_fields() {
+        let response = serde_json::to_value(SwapCalldataV2Response {
+            calldata: ready_response(),
+            resolved_price_cap: "2.01".to_string(),
+        })
+        .unwrap();
+
+        assert_eq!(response["to"], ORDERBOOK.to_string().to_lowercase());
+        assert_eq!(response["estimatedInput"], "150");
+        assert_eq!(response["resolvedPriceCap"], "2.01");
+        assert!(response.get("calldata").is_none());
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_denormalizes_resolved_slippage_cap() {
+        let (ds, captured_request, _) =
+            capture_slippage_ds(HashMap::from([(WT_COIN, wrap_ratio(WT_COIN, "4"))]));
+        let mut request = slippage_v2_request(SwapCalldataMode::BuyUpTo, "100", 50);
+        request.output_token = WT_COIN;
+        request.denomination = SwapDenomination::Unwrapped;
+
+        let result = process_swap_calldata_v2(&ds, request).await.unwrap();
+        let request = captured_take_orders_request(&captured_request);
+
+        assert_eq!(request.amount, "25");
+        assert_eq!(request.price_cap, "2.01");
+        assert_eq!(result.resolved_price_cap, "0.5025");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_requires_exactly_one_price_limit() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let mut request = calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2.5");
+        request.slippage_bps = Some(50);
+        let result = process_swap_calldata_v2(&ds, request).await;
+
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(message)) if message == "provide exactly one of price_cap or slippage_bps")
+        );
+        no_take_orders_request_was_made(&captured_request);
+
+        let mut request = slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50);
+        request.slippage_bps = None;
+        let result = process_swap_calldata_v2(&ds, request).await;
+
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(message)) if message == "provide exactly one of price_cap or slippage_bps")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_rejects_reference_ratio_without_slippage() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let mut request = calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2.5");
+        request.reference_io_ratio = Some("2".to_string());
+
+        let result = process_swap_calldata_v2(&ds, request).await;
+
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(message)) if message == "reference_io_ratio requires slippage_bps")
+        );
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_rejects_slippage_out_of_range() {
+        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
+        let result = process_swap_calldata_v2(
+            &ds,
+            slippage_v2_request(SwapCalldataMode::SpendExact, "100", 5001),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ApiError::BadRequest(message)) if message == "slippage_bps must be between 1 and 5000")
+        );
+        no_take_orders_request_was_made(&captured_request);
     }
 
     #[rocket::async_test]
@@ -950,8 +1249,9 @@ mod tests {
         assert_eq!(request.mode, TakeOrdersMode::SpendExact);
         assert_eq!(request.amount, "50");
         assert_eq!(request.price_cap, "1.25");
-        assert_eq!(result.estimated_input, "300");
-        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+        assert_eq!(result.calldata.estimated_input, "300");
+        assert_eq!(result.calldata.denomination, SwapDenomination::Unwrapped);
+        assert_eq!(result.resolved_price_cap, "2.5");
     }
 
     #[rocket::async_test]
@@ -971,8 +1271,9 @@ mod tests {
         assert_eq!(request.mode, TakeOrdersMode::BuyUpTo);
         assert_eq!(request.amount, "25");
         assert_eq!(request.price_cap, "10");
-        assert_eq!(result.estimated_input, "150");
-        assert_eq!(result.denomination, SwapDenomination::Unwrapped);
+        assert_eq!(result.calldata.estimated_input, "150");
+        assert_eq!(result.calldata.denomination, SwapDenomination::Unwrapped);
+        assert_eq!(result.resolved_price_cap, "2.5");
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -3,6 +3,7 @@ use crate::attribution::{
     address_to_b256, u64_to_b256, AttributionSigner, AttributionState, ATTRIBUTION_SCHEMA_VERSION,
 };
 use crate::cache::RouteResponseCaches;
+use crate::types::swap::SwapCalldataMode;
 use alloy::hex::encode_prefixed;
 use alloy::network::TransactionBuilder;
 use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
@@ -486,18 +487,40 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
         output_token: output_address,
         mode: SwapCalldataMode::BuyUpTo,
         amount: "10".to_string(),
-        price_cap: "3".to_string(),
+        price_cap: None,
+        slippage_bps: Some(50),
+        reference_io_ratio: Some("2".to_string()),
         denomination: crate::types::swap::SwapDenomination::Wrapped,
     };
     let mut v2_response = process_swap_calldata_v2(&data_source, v2_request)
         .await
         .unwrap();
-    embed_and_validate_attribution(&mut v2_response, &attribution_state.signer, &v2_attribution)
-        .await
-        .unwrap();
-    let v2_decoded = takeOrders4Call::abi_decode(&v2_response.data).unwrap();
+    assert_eq!(v2_response.resolved_price_cap, "2.01");
+    embed_and_validate_attribution(
+        &mut v2_response.calldata,
+        &attribution_state.signer,
+        &v2_attribution,
+    )
+    .await
+    .unwrap();
+    let v2_decoded = takeOrders4Call::abi_decode(&v2_response.calldata.data).unwrap();
+    assert_eq!(v2_decoded.config.orders[0].signedContext.len(), 2);
+    let v2_oracle_context = &v2_decoded.config.orders[0].signedContext[0];
+    assert_eq!(v2_oracle_context.signer, oracle_signer_address);
+    assert_eq!(v2_oracle_context.context[0], oracle_context);
+    assert_eq!(v2_oracle_context.signature, oracle_signature);
     let v2_context = &v2_decoded.config.orders[0].signedContext[1];
     assert_eq!(v2_context.context[1], v2_attribution.api_key_hash);
+
+    local_evm
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_input(v2_response.calldata.data.clone())
+                .with_to(v2_response.calldata.to)
+                .with_from(owner),
+        ))
+        .await
+        .unwrap();
 
     let oracle_body = services.oracle_bodies.lock().unwrap()[0].clone();
     let oracle_request = <(OrderV4, U256, U256, Address)>::abi_decode(&oracle_body).unwrap();

--- a/src/routes/swap/denomination.rs
+++ b/src/routes/swap/denomination.rs
@@ -19,6 +19,15 @@ pub(crate) struct CalldataRequestNormalization {
     pub price_cap_field: &'static str,
 }
 
+pub(crate) struct CalldataAmountNormalization {
+    pub denomination: SwapDenomination,
+    pub input_token: Address,
+    pub output_token: Address,
+    pub mode: TakeOrdersMode,
+    pub amount: String,
+    pub amount_field: &'static str,
+}
+
 pub(crate) async fn normalize_quote_amounts(
     ds: &dyn SwapDataSource,
     denomination: SwapDenomination,
@@ -49,56 +58,112 @@ pub(crate) async fn normalize_calldata_request_values(
     ds: &dyn SwapDataSource,
     req: CalldataRequestNormalization,
 ) -> Result<(String, String, HashMap<Address, WrapRatioValue>), ApiError> {
-    match req.denomination {
-        SwapDenomination::Wrapped => Ok((req.amount, req.price_cap, HashMap::new())),
-        SwapDenomination::Unwrapped => {
-            tracing::info!("normalizing swap calldata request to wrapped denomination");
-            let ratios = ds
-                .get_wrap_ratios_for_tokens(&[req.input_token, req.output_token])
-                .await?;
-            let input_is_wrapped = ratios.contains_key(&req.input_token);
-            let output_is_wrapped = ratios.contains_key(&req.output_token);
+    let denomination = req.denomination;
+    let input_token = req.input_token;
+    let output_token = req.output_token;
+    let price_cap = req.price_cap;
+    let price_cap_field = req.price_cap_field;
+    let (amount, ratios) = normalize_calldata_request_amount(
+        ds,
+        CalldataAmountNormalization {
+            denomination,
+            input_token,
+            output_token,
+            mode: req.mode,
+            amount: req.amount,
+            amount_field: req.amount_field,
+        },
+    )
+    .await?;
+    let price_cap = normalize_calldata_price_cap(
+        price_cap,
+        price_cap_field,
+        denomination,
+        input_token,
+        output_token,
+        &ratios,
+    )?;
+    Ok((amount, price_cap, ratios))
+}
 
-            if !input_is_wrapped && !output_is_wrapped {
-                return Ok((req.amount, req.price_cap, ratios));
-            }
-
-            let input_assets_per_share = ratio_for_token(req.input_token, &ratios)?;
-            let output_assets_per_share = ratio_for_token(req.output_token, &ratios)?;
-
-            let price_cap = parse_user_float(req.price_cap, req.price_cap_field)?;
-
-            let normalized_amount = if amount_needs_wrapped_normalization(
-                req.mode,
-                input_is_wrapped,
-                output_is_wrapped,
-            ) {
-                let amount = parse_user_float(req.amount, req.amount_field)?;
-                let ratio = amount_ratio(req.mode, input_assets_per_share, output_assets_per_share);
-                let wrapped_amount = amount.div(ratio).map_err(|e| {
-                    tracing::error!(error = %e, "failed to normalize calldata amount");
-                    ApiError::Internal("failed to normalize amount".into())
-                })?;
-                format_float(wrapped_amount, "amount")?
-            } else {
-                req.amount
-            };
-
-            let normalized_io_ratio = price_cap
-                .mul(output_assets_per_share)
-                .and_then(|ratio| ratio.div(input_assets_per_share))
-                .map_err(|e| {
-                    tracing::error!(error = %e, "failed to normalize calldata IO ratio");
-                    ApiError::Internal("failed to normalize IO ratio".into())
-                })?;
-
-            Ok((
-                normalized_amount,
-                format_float(normalized_io_ratio, "IO ratio")?,
-                ratios,
-            ))
-        }
+pub(crate) async fn normalize_calldata_request_amount(
+    ds: &dyn SwapDataSource,
+    req: CalldataAmountNormalization,
+) -> Result<(String, HashMap<Address, WrapRatioValue>), ApiError> {
+    if req.denomination == SwapDenomination::Wrapped {
+        return Ok((req.amount, HashMap::new()));
     }
+
+    tracing::info!("normalizing swap calldata request to wrapped denomination");
+    let ratios = ds
+        .get_wrap_ratios_for_tokens(&[req.input_token, req.output_token])
+        .await?;
+    let input_is_wrapped = ratios.contains_key(&req.input_token);
+    let output_is_wrapped = ratios.contains_key(&req.output_token);
+
+    if !amount_needs_wrapped_normalization(req.mode, input_is_wrapped, output_is_wrapped) {
+        return Ok((req.amount, ratios));
+    }
+
+    let input_assets_per_share = ratio_for_token(req.input_token, &ratios)?;
+    let output_assets_per_share = ratio_for_token(req.output_token, &ratios)?;
+    let amount = parse_user_float(req.amount, req.amount_field)?;
+    let ratio = amount_ratio(req.mode, input_assets_per_share, output_assets_per_share);
+    let wrapped_amount = amount.div(ratio).map_err(|e| {
+        tracing::error!(error = %e, "failed to normalize calldata amount");
+        ApiError::Internal("failed to normalize amount".into())
+    })?;
+    Ok((format_float(wrapped_amount, "amount")?, ratios))
+}
+
+pub(crate) fn normalize_calldata_price_cap(
+    price_cap: String,
+    price_cap_field: &'static str,
+    denomination: SwapDenomination,
+    input_token: Address,
+    output_token: Address,
+    ratios: &HashMap<Address, WrapRatioValue>,
+) -> Result<String, ApiError> {
+    if denomination == SwapDenomination::Wrapped
+        || (!ratios.contains_key(&input_token) && !ratios.contains_key(&output_token))
+    {
+        return Ok(price_cap);
+    }
+
+    let input_assets_per_share = ratio_for_token(input_token, ratios)?;
+    let output_assets_per_share = ratio_for_token(output_token, ratios)?;
+    let price_cap = parse_user_float(price_cap, price_cap_field)?;
+    let normalized_io_ratio = price_cap
+        .mul(output_assets_per_share)
+        .and_then(|ratio| ratio.div(input_assets_per_share))
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to normalize calldata IO ratio");
+            ApiError::Internal("failed to normalize IO ratio".into())
+        })?;
+    format_float(normalized_io_ratio, "IO ratio")
+}
+
+pub(crate) fn denormalize_calldata_price_cap(
+    price_cap: Float,
+    denomination: SwapDenomination,
+    input_token: Address,
+    output_token: Address,
+    ratios: &HashMap<Address, WrapRatioValue>,
+) -> Result<String, ApiError> {
+    if denomination == SwapDenomination::Wrapped {
+        return format_float(price_cap, "IO ratio");
+    }
+
+    let input_assets_per_share = ratio_for_token(input_token, ratios)?;
+    let output_assets_per_share = ratio_for_token(output_token, ratios)?;
+    let unwrapped_io_ratio = price_cap
+        .mul(input_assets_per_share)
+        .and_then(|ratio| ratio.div(output_assets_per_share))
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to denormalize calldata IO ratio");
+            ApiError::Internal("failed to denormalize IO ratio".into())
+        })?;
+    format_float(unwrapped_io_ratio, "IO ratio")
 }
 
 fn amount_needs_wrapped_normalization(

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -1,11 +1,12 @@
 mod calldata;
 mod denomination;
 mod quote;
+mod slippage;
 
 use crate::cache::RouteResponseCaches;
 use crate::db::DbPool;
 use crate::error::ApiError;
-use crate::types::swap::{SwapCalldataResponse, SwapDenomination};
+use crate::types::swap::{SwapCalldataMode, SwapCalldataResponse, SwapDenomination};
 use crate::wrap_ratio::{
     persist_wrap_ratio_snapshots_best_effort, read_wrap_ratio_responses_for_addresses,
     wrap_ratio_values_from_responses, WrapRatioValue,
@@ -16,10 +17,11 @@ use rain_orderbook_common::raindex_client::orders::{
     GetOrdersFilters, GetOrdersTokenFilter, RaindexOrder,
 };
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
+use rain_orderbook_common::raindex_client::types::ChainIds;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_common::raindex_client::RaindexError;
 use rain_orderbook_common::take_orders::{
-    build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate,
+    build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate, TakeOrdersMode,
 };
 use rocket::Route;
 use std::collections::HashMap;
@@ -43,6 +45,7 @@ pub(crate) trait SwapDataSource: Send + Sync {
         orders: &[RaindexOrder],
         input_token: Address,
         output_token: Address,
+        counterparty: Address,
     ) -> Result<Vec<TakeOrderCandidate>, ApiError>;
 
     async fn get_calldata(
@@ -62,6 +65,10 @@ pub(crate) struct RaindexSwapDataSource<'a> {
     pub client: &'a RaindexClient,
     pub caches: &'a RouteResponseCaches,
     pub pool: &'a DbPool,
+}
+
+fn swap_chain_ids() -> ChainIds {
+    ChainIds(vec![crate::CHAIN_ID])
 }
 
 fn swap_candidates_cache_key(
@@ -132,7 +139,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             ..Default::default()
         };
         self.client
-            .get_orders(None, Some(filters), None, None)
+            .get_orders(Some(swap_chain_ids()), Some(filters), None, None)
             .await
             .map(|r| r.orders().to_vec())
             .map_err(|e| {
@@ -146,6 +153,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         orders: &[RaindexOrder],
         input_token: Address,
         output_token: Address,
+        counterparty: Address,
     ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
         let fetch = || async {
             build_take_order_candidates_for_pair(
@@ -154,7 +162,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 output_token,
                 None,
                 None,
-                Address::ZERO,
+                counterparty,
                 &NoopInjector,
             )
             .await
@@ -164,7 +172,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             })
         };
 
-        if !self.caches.is_enabled() {
+        if !self.caches.is_enabled() || counterparty != Address::ZERO {
             return fetch().await;
         }
 
@@ -269,6 +277,16 @@ fn map_raindex_error(e: RaindexError) -> ApiError {
     }
 }
 
+impl From<SwapCalldataMode> for TakeOrdersMode {
+    fn from(mode: SwapCalldataMode) -> Self {
+        match mode {
+            SwapCalldataMode::BuyUpTo => TakeOrdersMode::BuyUpTo,
+            SwapCalldataMode::SpendExact => TakeOrdersMode::SpendExact,
+            SwapCalldataMode::SpendUpTo => TakeOrdersMode::SpendUpTo,
+        }
+    }
+}
+
 pub use calldata::*;
 pub use quote::*;
 
@@ -277,12 +295,12 @@ pub fn routes() -> Vec<Route> {
 }
 
 pub fn routes_v2() -> Vec<Route> {
-    rocket::routes![calldata::post_swap_calldata_v2]
+    rocket::routes![quote::post_swap_quote_v2, calldata::post_swap_calldata_v2]
 }
 
 #[cfg(test)]
 mod tests {
-    use super::swap_candidates_cache_key;
+    use super::{swap_candidates_cache_key, swap_chain_ids};
     use alloy::primitives::address;
     use rain_orderbook_common::raindex_client::orders::RaindexOrder;
     use serde_json::json;
@@ -315,6 +333,11 @@ mod tests {
             ),
             swap_candidates_cache_key(&[order_b, order_a], input_token, output_token)
         );
+    }
+
+    #[test]
+    fn test_swap_orders_are_scoped_to_calldata_chain() {
+        assert_eq!(swap_chain_ids().0, vec![crate::CHAIN_ID]);
     }
 }
 
@@ -362,6 +385,7 @@ pub(crate) mod test_fixtures {
             _orders: &[RaindexOrder],
             _input_token: Address,
             _output_token: Address,
+            _counterparty: Address,
         ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
             Ok(self.candidates.clone())
         }

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -1,14 +1,23 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
-use crate::analytics::{swap_quoted_event, Analytics};
+use crate::analytics::{swap_quoted_event, swap_quoted_v2_event, Analytics};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
-use crate::routes::swap::denomination::normalize_quote_amounts;
-use crate::types::swap::{SwapQuoteRequest, SwapQuoteResponse};
+use crate::routes::swap::denomination::{
+    denormalize_calldata_price_cap, normalize_calldata_price_cap,
+    normalize_calldata_request_amount, normalize_quote_amounts, CalldataAmountNormalization,
+};
+use crate::types::swap::{
+    SwapQuoteRequest, SwapQuoteResponse, SwapQuoteV2Request, SwapQuoteV2RequestBody,
+    SwapQuoteV2Response,
+};
+use alloy::primitives::Address;
 use rain_math_float::Float;
-use rain_orderbook_common::take_orders::simulate_buy_over_candidates;
+use rain_orderbook_common::take_orders::{
+    simulate_buy_over_candidates, ParsedTakeOrdersMode, TakeOrdersMode,
+};
 use rocket::serde::json::Json;
 use rocket::State;
 use std::ops::Div;
@@ -59,6 +68,58 @@ pub async fn post_swap_quote(
     .await
 }
 
+#[utoipa::path(
+    post,
+    path = "/v2/swap/quote",
+    tag = "Swap",
+    summary = "Simulate a mode-based swap",
+    description = "Returns the SDK-backed executable-route simulation used by V2 calldata. Provide exactly one of priceCap or slippageBps. referenceIoRatio is an optional input-token-per-output-token guard that is valid only with slippageBps.",
+    security(("basicAuth" = [])),
+    request_body = SwapQuoteV2RequestBody,
+    responses(
+        (status = 200, description = "Mode-based swap quote", body = SwapQuoteV2Response),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 404, description = "No liquidity found", body = ApiErrorResponse),
+        (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
+        (status = 429, description = "Rate limited", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[post("/quote", data = "<request>")]
+#[allow(clippy::too_many_arguments)] // Rocket handler: args are guards + managed state + body.
+pub async fn post_swap_quote_v2(
+    _global: GlobalRateLimit,
+    key: AuthenticatedKey,
+    shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
+    app_state: &State<ApplicationState>,
+    pool: &State<DbPool>,
+    analytics: &State<Analytics>,
+    span: TracingSpan,
+    request: Json<SwapQuoteV2Request>,
+) -> Result<Json<SwapQuoteV2Response>, ApiError> {
+    async move {
+        let req = request.into_inner();
+        tracing::info!(
+            mode = ?req.mode,
+            denomination = ?req.denomination,
+            has_taker = req.taker.is_some(),
+            "request received"
+        );
+        let raindex = shared_raindex.read().await;
+        let ds = RaindexSwapDataSource {
+            client: raindex.client(),
+            caches: &app_state.response_caches,
+            pool: pool.inner(),
+        };
+        let response = handle_swap_quote_v2(&ds, &key, analytics.inner(), req).await?;
+
+        Ok(Json(response))
+    }
+    .instrument(span.0)
+    .await
+}
+
 async fn handle_swap_quote(
     ds: &dyn SwapDataSource,
     key: &AuthenticatedKey,
@@ -76,6 +137,19 @@ async fn handle_swap_quote(
             &response,
         )
     });
+
+    Ok(response)
+}
+
+async fn handle_swap_quote_v2(
+    ds: &dyn SwapDataSource,
+    key: &AuthenticatedKey,
+    analytics: &Analytics,
+    req: SwapQuoteV2Request,
+) -> Result<SwapQuoteV2Response, ApiError> {
+    let response = process_swap_quote_v2(ds, req).await?;
+
+    analytics.capture(|| swap_quoted_v2_event(key, &response));
 
     Ok(response)
 }
@@ -98,7 +172,7 @@ async fn process_swap_quote(
     }
 
     let candidates = ds
-        .build_candidates_for_pair(&orders, req.input_token, req.output_token)
+        .build_candidates_for_pair(&orders, req.input_token, req.output_token, Address::ZERO)
         .await?;
 
     if candidates.is_empty() {
@@ -165,6 +239,191 @@ async fn process_swap_quote(
     })
 }
 
+async fn process_swap_quote_v2(
+    ds: &dyn SwapDataSource,
+    req: SwapQuoteV2Request,
+) -> Result<SwapQuoteV2Response, ApiError> {
+    ds.validate_supported_tokens(req.input_token, req.output_token)
+        .await?;
+
+    let mode: TakeOrdersMode = req.mode.into();
+    let (amount, wrap_ratios) = normalize_calldata_request_amount(
+        ds,
+        CalldataAmountNormalization {
+            denomination: req.denomination,
+            input_token: req.input_token,
+            output_token: req.output_token,
+            mode,
+            amount: req.amount.clone(),
+            amount_field: "amount",
+        },
+    )
+    .await?;
+    let parsed_mode =
+        ParsedTakeOrdersMode::parse(mode, &amount).map_err(super::map_raindex_error)?;
+
+    let orders = ds
+        .get_orders_for_pair(req.input_token, req.output_token)
+        .await?;
+    if orders.is_empty() {
+        return Err(ApiError::NotFound(
+            "no liquidity found for this pair".into(),
+        ));
+    }
+
+    let candidates = ds
+        .build_candidates_for_pair(
+            &orders,
+            req.input_token,
+            req.output_token,
+            req.taker.unwrap_or(Address::ZERO),
+        )
+        .await?;
+    if candidates.is_empty() {
+        return Err(ApiError::NotFound("no valid quotes available".into()));
+    }
+
+    let price_cap = match (
+        req.price_cap.as_ref(),
+        req.slippage_bps,
+        req.reference_io_ratio.as_ref(),
+    ) {
+        (Some(price_cap), None, None) => {
+            let normalized = normalize_calldata_price_cap(
+                price_cap.clone(),
+                "price_cap",
+                req.denomination,
+                req.input_token,
+                req.output_token,
+                &wrap_ratios,
+            )?;
+            Float::parse(normalized).map_err(|error| {
+                tracing::warn!(%error, "swap quote rejected for invalid price_cap");
+                ApiError::BadRequest("invalid price_cap".into())
+            })?
+        }
+        (Some(_), None, Some(_)) => {
+            tracing::warn!(
+                "swap quote rejected because reference_io_ratio was provided without slippage_bps"
+            );
+            return Err(ApiError::BadRequest(
+                "reference_io_ratio requires slippage_bps".into(),
+            ));
+        }
+        (None, Some(slippage_bps @ 1..=5000), reference_io_ratio) => {
+            let reference_io_ratio = reference_io_ratio
+                .map(|reference_io_ratio| {
+                    normalize_calldata_price_cap(
+                        reference_io_ratio.clone(),
+                        "reference_io_ratio",
+                        req.denomination,
+                        req.input_token,
+                        req.output_token,
+                        &wrap_ratios,
+                    )
+                    .and_then(|normalized| {
+                        Float::parse(normalized).map_err(|error| {
+                            tracing::warn!(
+                                %error,
+                                "swap quote rejected for invalid reference_io_ratio"
+                            );
+                            ApiError::BadRequest("invalid reference_io_ratio".into())
+                        })
+                    })
+                })
+                .transpose()?;
+            super::slippage::resolve_slippage_price_cap(
+                candidates.clone(),
+                mode,
+                &amount,
+                slippage_bps,
+                reference_io_ratio,
+            )?
+        }
+        (None, Some(_), _) => {
+            tracing::warn!("swap quote rejected for out-of-range slippage_bps");
+            return Err(ApiError::BadRequest(
+                "slippage_bps must be between 1 and 5000".into(),
+            ));
+        }
+        _ => {
+            tracing::warn!("swap quote rejected without exactly one price limit");
+            return Err(ApiError::BadRequest(
+                "provide exactly one of price_cap or slippage_bps".into(),
+            ));
+        }
+    };
+
+    let is_buy_mode = parsed_mode.is_buy_mode();
+    let is_exact_mode = parsed_mode.is_exact_mode();
+    let target_amount = parsed_mode.target_amount();
+    let simulation =
+        super::slippage::select_best_raindex_simulation(candidates, parsed_mode, price_cap)?;
+    let achieved_amount = if is_buy_mode {
+        simulation.total_output
+    } else {
+        simulation.total_input
+    };
+    let fully_filled = achieved_amount.eq(target_amount).map_err(|error| {
+        tracing::error!(%error, "failed to compare swap quote fill amount");
+        ApiError::Internal("failed to calculate quote".into())
+    })?;
+    if is_exact_mode && !fully_filled {
+        let requested = target_amount.format().map_err(|error| {
+            tracing::error!(%error, "failed to format requested quote amount");
+            ApiError::Internal("failed to calculate quote".into())
+        })?;
+        let available = achieved_amount.format().map_err(|error| {
+            tracing::error!(%error, "failed to format available quote amount");
+            ApiError::Internal("failed to calculate quote".into())
+        })?;
+        return Err(ApiError::NotFound(format!(
+            "insufficient liquidity: requested {requested}, available {available}"
+        )));
+    }
+
+    let (estimated_input, estimated_output) = normalize_quote_amounts(
+        ds,
+        req.denomination,
+        req.input_token,
+        req.output_token,
+        simulation.total_input,
+        simulation.total_output,
+    )
+    .await?;
+    let estimated_io_ratio = estimated_input.div(estimated_output).map_err(|error| {
+        tracing::error!(%error, "failed to compute v2 swap quote ratio");
+        ApiError::Internal("failed to compute ratio".into())
+    })?;
+    let resolved_price_cap = denormalize_calldata_price_cap(
+        price_cap,
+        req.denomination,
+        req.input_token,
+        req.output_token,
+        &wrap_ratios,
+    )?;
+
+    let format_estimate = |value: Float, label: &str| {
+        value.format().map_err(|error| {
+            tracing::error!(%error, label, "failed to format v2 swap quote");
+            ApiError::Internal(format!("failed to format {label}"))
+        })
+    };
+
+    Ok(SwapQuoteV2Response {
+        input_token: req.input_token,
+        output_token: req.output_token,
+        mode: req.mode,
+        amount: req.amount,
+        denomination: req.denomination,
+        estimated_input: format_estimate(estimated_input, "estimated input")?,
+        estimated_output: format_estimate(estimated_output, "estimated output")?,
+        estimated_io_ratio: format_estimate(estimated_io_ratio, "estimated IO ratio")?,
+        fully_filled,
+        resolved_price_cap,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,13 +431,13 @@ mod tests {
     use crate::auth::AuthenticatedKey;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
-    use crate::types::swap::SwapDenomination;
+    use crate::types::swap::{SwapCalldataMode, SwapDenomination};
     use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::address;
     use async_trait::async_trait;
     use rocket::http::{ContentType, Status};
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     const USDC: alloy::primitives::Address = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
     const WETH: alloy::primitives::Address = address!("4200000000000000000000000000000000000006");
@@ -198,6 +457,20 @@ mod tests {
             input_token: USDC,
             output_token: WETH,
             output_amount: output_amount.to_string(),
+            denomination: SwapDenomination::Wrapped,
+        }
+    }
+
+    fn quote_v2_request(mode: SwapCalldataMode, amount: &str) -> SwapQuoteV2Request {
+        SwapQuoteV2Request {
+            taker: None,
+            input_token: USDC,
+            output_token: WETH,
+            mode,
+            amount: amount.to_string(),
+            price_cap: Some("2".to_string()),
+            slippage_bps: None,
+            reference_io_ratio: None,
             denomination: SwapDenomination::Wrapped,
         }
     }
@@ -230,6 +503,58 @@ mod tests {
         wrap_ratios: HashMap<alloy::primitives::Address, WrapRatioValue>,
     }
 
+    struct RecordingCounterpartyDataSource {
+        base: MockSwapDataSource,
+        counterparties: Mutex<Vec<alloy::primitives::Address>>,
+    }
+
+    #[async_trait]
+    impl SwapDataSource for RecordingCounterpartyDataSource {
+        async fn validate_supported_tokens(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<(), ApiError> {
+            self.base
+                .validate_supported_tokens(input_token, output_token)
+                .await
+        }
+
+        async fn get_orders_for_pair(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder>, ApiError>
+        {
+            self.base
+                .get_orders_for_pair(input_token, output_token)
+                .await
+        }
+
+        async fn build_candidates_for_pair(
+            &self,
+            orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+            counterparty: alloy::primitives::Address,
+        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+            self.counterparties
+                .lock()
+                .map_err(|_| ApiError::Internal("counterparty recorder poisoned".into()))?
+                .push(counterparty);
+            self.base
+                .build_candidates_for_pair(orders, input_token, output_token, counterparty)
+                .await
+        }
+
+        async fn get_calldata(
+            &self,
+            request: rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest,
+        ) -> Result<crate::types::swap::SwapCalldataResponse, ApiError> {
+            self.base.get_calldata(request).await
+        }
+    }
+
     #[async_trait]
     impl SwapDataSource for MockQuoteDataSource {
         async fn validate_supported_tokens(
@@ -258,9 +583,10 @@ mod tests {
             orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
             input_token: alloy::primitives::Address,
             output_token: alloy::primitives::Address,
+            counterparty: alloy::primitives::Address,
         ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
             self.base
-                .build_candidates_for_pair(orders, input_token, output_token)
+                .build_candidates_for_pair(orders, input_token, output_token, counterparty)
                 .await
         }
 
@@ -303,6 +629,199 @@ mod tests {
         assert_eq!(result.estimated_output, "100");
         assert_eq!(result.estimated_input, "150");
         assert_eq!(result.estimated_io_ratio, "1.5");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_buy_up_to() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("5", "1"), mock_candidate("5", "2")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+
+        let result = process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::BuyUpTo, "8"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.estimated_input, "11");
+        assert_eq!(result.estimated_output, "8");
+        assert_eq!(result.estimated_io_ratio, "1.375");
+        assert!(result.fully_filled);
+        assert_eq!(result.resolved_price_cap, "2");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_spend_up_to() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("5", "1"), mock_candidate("5", "2")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+
+        let result = process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::SpendUpTo, "8"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.estimated_input, "8");
+        assert_eq!(result.estimated_output, "6.5");
+        assert_eq!(
+            result.estimated_io_ratio,
+            "1.2307692307692307692307692307692307692307692307692307692307692307692"
+        );
+        assert!(result.fully_filled);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_reports_partial_up_to_fill() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("3", "2")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+
+        let result = process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::BuyUpTo, "5"))
+            .await
+            .unwrap();
+
+        assert_eq!(result.estimated_input, "6");
+        assert_eq!(result.estimated_output, "3");
+        assert!(!result.fully_filled);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_rejects_partial_exact_fill() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("3", "2")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+
+        let result =
+            process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::SpendExact, "8")).await;
+
+        assert!(matches!(result, Err(ApiError::NotFound(message))
+                if message.contains("requested 8, available 6")));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_resolves_same_slippage_cap_as_calldata() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("5", "1"), mock_candidate("5", "2")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let mut request = quote_v2_request(SwapCalldataMode::BuyUpTo, "8");
+        request.price_cap = None;
+        request.slippage_bps = Some(100);
+
+        let result = process_swap_quote_v2(&ds, request).await.unwrap();
+
+        assert_eq!(result.resolved_price_cap, "2.02");
+        assert_eq!(result.estimated_input, "11");
+        assert_eq!(result.estimated_output, "8");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_uses_taker_for_oracle_candidates() {
+        let taker = address!("1234567890AbcdEF1234567890aBcdef12345678");
+        let ds = RecordingCounterpartyDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates: vec![mock_candidate("5", "1")],
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            counterparties: Mutex::new(Vec::new()),
+        };
+        let mut request = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        request.taker = Some(taker);
+
+        process_swap_quote_v2(&ds, request).await.unwrap();
+
+        assert_eq!(
+            *ds.counterparties.lock().unwrap(),
+            vec![taker],
+            "quote candidates must use the wallet context passed by the website"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_validates_price_limit_options() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("5", "1")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+
+        let mut both = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        both.slippage_bps = Some(100);
+        assert!(matches!(
+            process_swap_quote_v2(&ds, both).await,
+            Err(ApiError::BadRequest(message))
+                if message.contains("exactly one")
+        ));
+
+        let mut neither = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        neither.price_cap = None;
+        assert!(matches!(
+            process_swap_quote_v2(&ds, neither).await,
+            Err(ApiError::BadRequest(message))
+                if message.contains("exactly one")
+        ));
+
+        let mut out_of_range = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        out_of_range.price_cap = None;
+        out_of_range.slippage_bps = Some(5001);
+        assert!(matches!(
+            process_swap_quote_v2(&ds, out_of_range).await,
+            Err(ApiError::BadRequest(message))
+                if message.contains("between 1 and 5000")
+        ));
+
+        let mut reference_without_slippage = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        reference_without_slippage.reference_io_ratio = Some("1".to_string());
+        assert!(matches!(
+            process_swap_quote_v2(&ds, reference_without_slippage).await,
+            Err(ApiError::BadRequest(message))
+                if message.contains("requires slippage_bps")
+        ));
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_quote_v2_captures_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("5", "1")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+
+        let response = handle_swap_quote_v2(
+            &ds,
+            &test_key(),
+            &analytics,
+            quote_v2_request(SwapCalldataMode::BuyUpTo, "5"),
+        )
+        .await
+        .expect("successful quote");
+
+        assert!(response.fully_filled);
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_quoted")
+            .expect("swap_quoted event");
+        assert_eq!(event.distinct_id, "client:test-client");
+        assert_eq!(event.properties["estimated_output"], "5");
+        assert_eq!(event.properties["fully_filled"], true);
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/slippage.rs
+++ b/src/routes/swap/slippage.rs
@@ -1,0 +1,285 @@
+use super::map_raindex_error;
+use crate::error::ApiError;
+use alloy::primitives::Address;
+use rain_math_float::Float;
+use rain_orderbook_common::take_orders::{
+    simulate_buy_over_candidates, simulate_spend_over_candidates, ParsedTakeOrdersMode,
+    SimulationResult, TakeOrderCandidate, TakeOrdersMode,
+};
+use std::collections::HashMap;
+use std::ops::{Div, Mul};
+
+const BASIS_POINTS_SCALE: u32 = 10_000;
+const REFERENCE_GUARD_BPS: u16 = 500;
+
+pub(crate) fn resolve_slippage_price_cap(
+    candidates: Vec<TakeOrderCandidate>,
+    mode: TakeOrdersMode,
+    amount: &str,
+    slippage_bps: u16,
+    reference_io_ratio: Option<Float>,
+) -> Result<Float, ApiError> {
+    let mode = ParsedTakeOrdersMode::parse(mode, amount).map_err(map_raindex_error)?;
+    let simulation_price_cap = match reference_io_ratio {
+        Some(reference_io_ratio) => {
+            let zero = Float::zero().map_err(|error| {
+                tracing::error!(%error, "failed to create zero reference price");
+                ApiError::Internal("failed to resolve slippage".into())
+            })?;
+            if !reference_io_ratio
+                .gt(zero)
+                .map_err(map_float_comparison_error)?
+            {
+                tracing::warn!("swap calldata rejected for non-positive reference_io_ratio");
+                return Err(ApiError::BadRequest(
+                    "reference_io_ratio must be greater than zero".into(),
+                ));
+            }
+            let guard_multiplier = basis_points_multiplier(REFERENCE_GUARD_BPS)?;
+            let guarded_price_cap = reference_io_ratio.mul(guard_multiplier).map_err(|error| {
+                tracing::error!(
+                    %error,
+                    reference_guard_bps = REFERENCE_GUARD_BPS,
+                    "failed to apply reference price guard"
+                );
+                ApiError::Internal("failed to resolve slippage".into())
+            })?;
+            tracing::info!(
+                reference_guard_bps = REFERENCE_GUARD_BPS,
+                "applying reference price guard to slippage candidates"
+            );
+            guarded_price_cap
+        }
+        None => Float::max_positive_value().map_err(|error| {
+            tracing::error!(%error, "failed to create unbounded slippage price cap");
+            ApiError::Internal("failed to resolve slippage".into())
+        })?,
+    };
+    let simulation = select_best_raindex_simulation(candidates, mode, simulation_price_cap)?;
+    let worst_price = worst_price(&simulation)?.ok_or_else(|| {
+        tracing::warn!("slippage simulation selected no order legs");
+        ApiError::NotFound("no liquidity found for this pair".into())
+    })?;
+    let multiplier = basis_points_multiplier(slippage_bps)?;
+    worst_price.mul(multiplier).map_err(|error| {
+        tracing::error!(%error, slippage_bps, "failed to apply slippage tolerance");
+        ApiError::Internal("failed to resolve slippage".into())
+    })
+}
+
+fn basis_points_multiplier(bps: u16) -> Result<Float, ApiError> {
+    let scale = Float::parse(BASIS_POINTS_SCALE.to_string()).map_err(|error| {
+        tracing::error!(%error, "failed to create basis points scale");
+        ApiError::Internal("failed to resolve slippage".into())
+    })?;
+    Float::parse((u32::from(bps) + BASIS_POINTS_SCALE).to_string())
+        .and_then(|value| value.div(scale))
+        .map_err(|error| {
+            tracing::error!(%error, bps, "failed to calculate basis points multiplier");
+            ApiError::Internal("failed to resolve slippage".into())
+        })
+}
+
+pub(crate) fn select_best_raindex_simulation(
+    candidates: Vec<TakeOrderCandidate>,
+    mode: ParsedTakeOrdersMode,
+    price_cap: Float,
+) -> Result<SimulationResult, ApiError> {
+    // Calldata can execute against one raindex deployment. Keep the deployment
+    // comparison aligned with the SDK's take-orders selection while using its
+    // public candidate simulation functions for the actual order walking.
+    let mut candidates_by_raindex: HashMap<Address, Vec<TakeOrderCandidate>> = HashMap::new();
+    for candidate in candidates {
+        candidates_by_raindex
+            .entry(candidate.raindex)
+            .or_default()
+            .push(candidate);
+    }
+
+    let mut best: Option<(Address, SimulationResult)> = None;
+    for (raindex, candidates) in candidates_by_raindex {
+        let simulation = if mode.is_buy_mode() {
+            simulate_buy_over_candidates(candidates, mode.target_amount(), price_cap)
+        } else {
+            simulate_spend_over_candidates(candidates, mode.target_amount(), price_cap)
+        }
+        .map_err(map_raindex_error)?;
+
+        if simulation.legs.is_empty() {
+            continue;
+        }
+
+        let replace = match &best {
+            None => true,
+            Some((best_raindex, best_simulation)) => {
+                is_better_simulation(raindex, &simulation, *best_raindex, best_simulation)?
+            }
+        };
+        if replace {
+            best = Some((raindex, simulation));
+        }
+    }
+
+    best.map(|(_, simulation)| simulation).ok_or_else(|| {
+        tracing::warn!("no raindex simulation produced liquidity for slippage resolution");
+        ApiError::NotFound("no liquidity found for this pair".into())
+    })
+}
+
+fn is_better_simulation(
+    raindex: Address,
+    simulation: &SimulationResult,
+    best_raindex: Address,
+    best_simulation: &SimulationResult,
+) -> Result<bool, ApiError> {
+    if simulation
+        .total_output
+        .gt(best_simulation.total_output)
+        .map_err(map_float_comparison_error)?
+    {
+        return Ok(true);
+    }
+    if !simulation
+        .total_output
+        .eq(best_simulation.total_output)
+        .map_err(map_float_comparison_error)?
+    {
+        return Ok(false);
+    }
+
+    match (worst_price(simulation)?, worst_price(best_simulation)?) {
+        (Some(price), Some(best_price)) => {
+            if price.lt(best_price).map_err(map_float_comparison_error)? {
+                Ok(true)
+            } else if price.eq(best_price).map_err(map_float_comparison_error)? {
+                Ok(raindex < best_raindex)
+            } else {
+                Ok(false)
+            }
+        }
+        _ => Ok(raindex < best_raindex),
+    }
+}
+
+fn worst_price(simulation: &SimulationResult) -> Result<Option<Float>, ApiError> {
+    let mut worst = None;
+    for leg in &simulation.legs {
+        if worst
+            .map(|price| {
+                leg.candidate
+                    .ratio
+                    .gt(price)
+                    .map_err(map_float_comparison_error)
+            })
+            .transpose()?
+            .unwrap_or(true)
+        {
+            worst = Some(leg.candidate.ratio);
+        }
+    }
+    Ok(worst)
+}
+
+fn map_float_comparison_error(error: rain_math_float::FloatError) -> ApiError {
+    tracing::error!(%error, "failed to compare slippage simulation values");
+    ApiError::Internal("failed to resolve slippage".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::mock_candidate;
+
+    fn candidate(raindex_byte: u8, max_output: &str, ratio: &str) -> TakeOrderCandidate {
+        let mut candidate = mock_candidate(max_output, ratio);
+        candidate.raindex = Address::from([raindex_byte; 20]);
+        candidate
+    }
+
+    #[test]
+    fn resolves_cap_from_worst_selected_buy_leg() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "5", "1"), candidate(1, "5", "2")],
+            TakeOrdersMode::BuyUpTo,
+            "8",
+            50,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "2.01");
+    }
+
+    #[test]
+    fn uses_sdk_deployment_selection_semantics() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "8", "3"), candidate(2, "10", "4")],
+            TakeOrdersMode::BuyUpTo,
+            "10",
+            100,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "4.04");
+    }
+
+    #[test]
+    fn breaks_equal_output_ties_with_lower_worst_price() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "10", "3"), candidate(2, "10", "2")],
+            TakeOrdersMode::BuyUpTo,
+            "10",
+            100,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "2.02");
+    }
+
+    #[test]
+    fn supports_spend_modes() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "5", "1"), candidate(1, "5", "2")],
+            TakeOrdersMode::SpendExact,
+            "8",
+            100,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "2.02");
+    }
+
+    #[test]
+    fn excludes_candidates_outside_reference_price_guard() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "5", "1"), candidate(1, "5", "2")],
+            TakeOrdersMode::BuyUpTo,
+            "8",
+            50,
+            Some(Float::parse("1".to_string()).unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "1.005");
+    }
+
+    #[test]
+    fn rejects_non_positive_reference_price() {
+        let result = resolve_slippage_price_cap(
+            vec![candidate(1, "5", "1")],
+            TakeOrdersMode::BuyUpTo,
+            "5",
+            50,
+            Some(Float::zero().unwrap()),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ApiError::BadRequest(message))
+                if message == "reference_io_ratio must be greater than zero"
+        ));
+    }
+}

--- a/src/types/swap.rs
+++ b/src/types/swap.rs
@@ -46,6 +46,154 @@ pub struct SwapQuoteResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
+pub struct SwapQuoteV2Request {
+    /// Wallet that would execute the swap. Optional for a read-only quote, but
+    /// recommended because oracle-backed orders can depend on the taker when
+    /// building their signed context.
+    #[schema(value_type = Option<String>, example = "0x1234567890abcdef1234567890abcdef12345678")]
+    pub taker: Option<Address>,
+    /// Token the taker will spend.
+    #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
+    pub input_token: Address,
+    /// Token the taker will receive.
+    #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
+    pub output_token: Address,
+    /// Determines which token `amount` refers to and whether a partial fill is
+    /// allowed.
+    #[schema(example = "spendExact")]
+    pub mode: SwapCalldataMode,
+    /// Human-readable target amount. This is an output-token amount for
+    /// `buyUpTo`, and an input-token amount for `spendExact` or `spendUpTo`.
+    #[schema(example = "100")]
+    pub amount: String,
+    /// Explicit maximum input-token amount per one output token. For example,
+    /// `2600` for USDC -> WETH means at most 2600 USDC per WETH. Provide
+    /// exactly one of `priceCap` or `slippageBps`.
+    #[schema(example = "2600")]
+    pub price_cap: Option<String>,
+    /// Slippage tolerance in basis points (BPS), where 1 BPS = 0.01%,
+    /// 50 BPS = 0.5%, and 100 BPS = 1%. The API applies this tolerance to the
+    /// worst price in the selected SDK simulation to produce `resolvedPriceCap`.
+    /// Provide exactly one of `priceCap` or `slippageBps`.
+    #[schema(example = 50, minimum = 1, maximum = 5000)]
+    pub slippage_bps: Option<u16>,
+    /// Optional trusted reference price, always expressed as input-token units
+    /// per one output token. For USDC -> WETH, use USDC per WETH; for
+    /// WETH -> USDC, use WETH per USDC. Only valid with `slippageBps`. Before
+    /// applying slippage, the API excludes candidates whose input/output ratio
+    /// is more than 5% above this reference.
+    #[schema(example = "2500")]
+    pub reference_io_ratio: Option<String>,
+    /// Units used by numeric request and response fields. `wrapped` is the
+    /// default orderbook denomination. `unwrapped` changes numeric units only;
+    /// token addresses must still be wrapped/orderbook token addresses.
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapDenomination,
+}
+
+/// OpenAPI-only request shape that documents the runtime requirement to provide
+/// exactly one price limit. Rocket deserializes [`SwapQuoteV2Request`] so it can
+/// return a descriptive 400 for both-or-neither requests.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum SwapQuoteV2RequestBody {
+    PriceCap(SwapQuoteV2PriceCapRequest),
+    Slippage(SwapQuoteV2SlippageRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapQuoteV2RequestCommon {
+    /// Wallet that would execute the swap. Recommended for oracle-backed
+    /// orders, whose signed context can depend on the taker.
+    #[schema(value_type = Option<String>, example = "0x1234567890abcdef1234567890abcdef12345678")]
+    pub taker: Option<Address>,
+    /// Token the taker will spend.
+    #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
+    pub input_token: Address,
+    /// Token the taker will receive.
+    #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
+    pub output_token: Address,
+    /// Determines which token `amount` refers to and whether partial fills are
+    /// allowed.
+    #[schema(example = "spendExact")]
+    pub mode: SwapCalldataMode,
+    /// Human-readable output-token amount for `buyUpTo`, or input-token amount
+    /// for `spendExact` and `spendUpTo`.
+    #[schema(example = "100")]
+    pub amount: String,
+    /// Numeric denomination. Token addresses remain wrapped/orderbook
+    /// addresses even when this is `unwrapped`.
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapDenomination,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapQuoteV2PriceCapRequest {
+    #[serde(flatten)]
+    pub request: SwapQuoteV2RequestCommon,
+    /// Maximum input-token amount per one output token.
+    #[schema(example = "2600")]
+    pub price_cap: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapQuoteV2SlippageRequest {
+    #[serde(flatten)]
+    pub request: SwapQuoteV2RequestCommon,
+    /// Slippage tolerance in basis points: 1 BPS = 0.01%, 50 BPS = 0.5%,
+    /// and 100 BPS = 1%.
+    #[schema(example = 50, minimum = 1, maximum = 5000)]
+    pub slippage_bps: u16,
+    /// Optional trusted input-token-per-output-token reference price. The API
+    /// rejects candidate ratios more than 5% above it before applying slippage.
+    #[schema(example = "2500")]
+    pub reference_io_ratio: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapQuoteV2Response {
+    /// Token the taker spends.
+    #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
+    pub input_token: Address,
+    /// Token the taker receives.
+    #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
+    pub output_token: Address,
+    #[schema(example = "spendExact")]
+    pub mode: SwapCalldataMode,
+    /// Requested target in the units implied by `mode`.
+    #[schema(example = "100")]
+    pub amount: String,
+    #[schema(example = "wrapped")]
+    pub denomination: SwapDenomination,
+    /// Input-token amount selected by the simulation.
+    #[schema(example = "100")]
+    pub estimated_input: String,
+    /// Output-token amount selected by the simulation.
+    #[schema(example = "0.04")]
+    pub estimated_output: String,
+    /// Simulated input-token amount per one output token.
+    #[schema(example = "2500")]
+    pub estimated_io_ratio: String,
+    /// Whether the simulation completely filled the requested amount. Up-to
+    /// modes can return `false`; exact modes fail instead of returning a partial
+    /// quote.
+    pub fully_filled: bool,
+    /// Final maximum input-token amount per one output token. This is the
+    /// supplied `priceCap` or the cap derived from `slippageBps`. If a later
+    /// calldata request requires approvals, reuse its resolved cap as
+    /// `priceCap` on the retry so the limit does not move.
+    #[schema(example = "2512.5")]
+    pub resolved_price_cap: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct SwapCalldataRequest {
     #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
     pub taker: Address,
@@ -65,29 +213,117 @@ pub struct SwapCalldataRequest {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum SwapCalldataMode {
+    /// Buy up to `amount` output tokens. Partial fills are allowed.
     BuyUpTo,
+    /// Spend exactly `amount` input tokens. Fails when the full amount cannot
+    /// be executed.
     SpendExact,
+    /// Spend up to `amount` input tokens. Partial fills are allowed.
     SpendUpTo,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapCalldataV2Request {
+    /// Wallet that will execute the swap and whose allowance is checked.
     #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
     pub taker: Address,
+    /// Token the taker will spend.
     #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
     pub input_token: Address,
+    /// Token the taker will receive.
     #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
     pub output_token: Address,
+    /// Determines which token `amount` refers to and whether a partial fill is
+    /// allowed.
     #[schema(example = "spendExact")]
     pub mode: SwapCalldataMode,
+    /// Human-readable output-token amount for `buyUpTo`, or input-token amount
+    /// for `spendExact` and `spendUpTo`.
     #[schema(example = "100")]
     pub amount: String,
+    /// Explicit maximum input-token amount per one output token. Provide
+    /// exactly one of `priceCap` or `slippageBps`.
     #[schema(example = "2600")]
-    pub price_cap: String,
+    pub price_cap: Option<String>,
+    /// Slippage tolerance in basis points (BPS), where 1 BPS = 0.01%,
+    /// 50 BPS = 0.5%, and 100 BPS = 1%. The API applies this tolerance to the
+    /// worst price in the selected SDK simulation. Provide exactly one of
+    /// `priceCap` or `slippageBps`.
+    #[schema(example = 50, minimum = 1, maximum = 5000)]
+    pub slippage_bps: Option<u16>,
+    /// Optional trusted reference price, expressed as input-token units per one
+    /// output token. Only valid with `slippageBps`. The API excludes candidate
+    /// ratios more than 5% above this reference before applying slippage.
+    #[schema(example = "2500")]
+    pub reference_io_ratio: Option<String>,
+    /// Units used by numeric request and response fields. Token addresses remain
+    /// wrapped/orderbook addresses when this is `unwrapped`.
     #[serde(default)]
     #[schema(example = "wrapped", default = "wrapped")]
     pub denomination: SwapDenomination,
+}
+
+/// OpenAPI-only request shape that encodes the runtime requirement to provide
+/// exactly one price limit. Rocket deserializes [`SwapCalldataV2Request`] so it
+/// can return a descriptive 400 for both-or-neither requests.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum SwapCalldataV2RequestBody {
+    PriceCap(SwapCalldataV2PriceCapRequest),
+    Slippage(SwapCalldataV2SlippageRequest),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapCalldataV2RequestCommon {
+    /// Wallet that will execute the swap and whose allowance is checked.
+    #[schema(value_type = String, example = "0x1234567890abcdef1234567890abcdef12345678")]
+    pub taker: Address,
+    /// Token the taker will spend.
+    #[schema(value_type = String, example = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913")]
+    pub input_token: Address,
+    /// Token the taker will receive.
+    #[schema(value_type = String, example = "0x4200000000000000000000000000000000000006")]
+    pub output_token: Address,
+    /// Determines which token `amount` refers to and whether a partial fill is
+    /// allowed.
+    #[schema(example = "spendExact")]
+    pub mode: SwapCalldataMode,
+    /// Human-readable output-token amount for `buyUpTo`, or input-token amount
+    /// for `spendExact` and `spendUpTo`.
+    #[schema(example = "100")]
+    pub amount: String,
+    /// Numeric denomination. Token addresses remain wrapped/orderbook
+    /// addresses even when this is `unwrapped`.
+    #[serde(default)]
+    #[schema(example = "wrapped", default = "wrapped")]
+    pub denomination: SwapDenomination,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapCalldataV2PriceCapRequest {
+    #[serde(flatten)]
+    pub request: SwapCalldataV2RequestCommon,
+    /// Maximum input-token amount per one output token.
+    #[schema(example = "2600")]
+    pub price_cap: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapCalldataV2SlippageRequest {
+    #[serde(flatten)]
+    pub request: SwapCalldataV2RequestCommon,
+    /// Slippage tolerance in basis points: 1 BPS = 0.01%, 50 BPS = 0.5%,
+    /// and 100 BPS = 1%.
+    #[schema(example = 50, minimum = 1, maximum = 5000)]
+    pub slippage_bps: u16,
+    /// Optional trusted input-token-per-output-token reference price. The API
+    /// rejects candidate ratios more than 5% above it before applying slippage.
+    #[schema(example = "2500")]
+    pub reference_io_ratio: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -104,4 +340,17 @@ pub struct SwapCalldataResponse {
     #[schema(example = "wrapped")]
     pub denomination: SwapDenomination,
     pub approvals: Vec<Approval>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapCalldataV2Response {
+    #[serde(flatten)]
+    pub calldata: SwapCalldataResponse,
+    /// Final maximum input-token amount per one output token, in the requested
+    /// denomination. If approvals are returned, reuse this value as `priceCap`
+    /// on the follow-up request and omit `slippageBps` and `referenceIoRatio`.
+    /// This keeps the original limit fixed while the approval is submitted.
+    #[schema(example = "2613")]
+    pub resolved_price_cap: String,
 }


### PR DESCRIPTION
## Dependencies

- Based directly on `main`.
- Consumed by website stack: [#236](https://github.com/SARKEX/st0x/pull/236) → [#237](https://github.com/SARKEX/st0x/pull/237)

## Motivation

Clients should be able to request a slippage-bounded market transaction without walking the orderbook or reproducing SDK pricing logic. Existing callers that provide an explicit price cap must continue to work unchanged.

## Solution

- Add `slippageBps` to v2 swap-calldata requests as an alternative to `priceCap`.
- Use SDK candidate simulation to derive the worst selected fill price, then apply the requested BPS tolerance.
- Accept an optional `referenceIoRatio` with slippage requests and exclude candidates more than 5% worse than that oracle reference before selecting fills.
- Require exactly one of `priceCap` or `slippageBps` and document the union in OpenAPI.
- Return `resolvedPriceCap` and preserve it across approval retries.
- Preserve the merged oracle signed context first and append REST attribution context second.
- Execute the V2 slippage-generated, oracle-backed calldata against a local EVM in the test-only integration suite.

No SDK changes are required.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo check`
- `nix develop -c cargo test` — 331 passed
- `nix develop -c cargo test --features oracle-integration-tests test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution` — passed

## Linear

REST API portion of [RAI-741](https://linear.app/makeitrain/issue/RAI-741/migrate-web-client-market-orders-to-api-built-calldata)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /v2/swap/quote` and `POST /v2/swap/calldata` with slippage-cap pricing.
  * V2 responses now include `resolvedPriceCap` for use in follow-up calls.
  * Liquidity selection and candidate building are now taker-aware for better quote/calldata consistency.
* **Documentation**
  * Updated swap-flow docs and examples for V2 limit semantics, including “exactly one of `priceCap` or `slippageBps`”.
* **Bug Fixes**
  * Enforced V2 validation rules for `priceCap` vs `slippageBps`, `referenceIoRatio`, and `slippageBps` bounds.
  * Fixed V2 calldata response shape and attribution embedding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->