### PR TITLE
feat: embed API key attribution in swap calldata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 RUST_LOG=st0x_rest_api=info,rocket=warn,warn
+
+# EOA private key used to sign REST attribution contexts embedded in executable
+# swap calldata. Production receives this as a protected systemd credential.
+ST0X_GATING_SIGNER_KEY=

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -60,13 +60,36 @@ jobs:
         run: |
           host_key=$(nix eval --raw --file keys.nix keys.host)
           echo "$HOST_IP $host_key" > ~/.ssh/known_hosts
+      - name: Install attribution signer credential
+        env:
+          ST0X_GATING_SIGNER_KEY: ${{ secrets.ST0X_GATING_SIGNER_KEY }}
+        run: |
+          if [ -z "$ST0X_GATING_SIGNER_KEY" ]; then
+            echo "ST0X_GATING_SIGNER_KEY secret is required" >&2
+            exit 1
+          fi
+          printf '%s\n' "$ST0X_GATING_SIGNER_KEY" | ssh "root@$HOST_IP" \
+            'install -d -m 700 /mnt/data/st0x-rest-api/secrets && umask 077 && tee /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp >/dev/null && test -s /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp && mv /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp /mnt/data/st0x-rest-api/secrets/attribution-signer'
+      - name: Check attribution credential unit
+        if: (inputs.deploy_scope || 'service') == 'service'
+        run: |
+          if ssh "root@$HOST_IP" 'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer'; then
+            echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=false" >> "$GITHUB_ENV"
+          else
+            echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=true" >> "$GITHUB_ENV"
+          fi
       - run: ./prep.sh
+      - name: Deploy attribution credential system prerequisite
+        if: (inputs.deploy_scope || 'service') == 'service' && env.NEEDS_ATTRIBUTION_SYSTEM_DEPLOY == 'true'
+        run: nix run .#deployNixos
       - name: Deploy service
         if: (inputs.deploy_scope || 'service') == 'service'
         run: nix run .#deployService -- rest-api
       - name: Deploy system
         if: (inputs.deploy_scope || 'service') == 'system'
-        run: nix run .#deployNixos
+        run: |
+          nix run .#deployNixos
+          ssh "root@$HOST_IP" 'systemctl try-restart rest-api.service'
       - name: Deploy system and service
         if: (inputs.deploy_scope || 'service') == 'all'
         run: nix run .#deployAll

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,9 @@ jobs:
         run: |
           set -euxo pipefail
           if [ "${{ matrix.run_static }}" = "true" ]; then
+            nix build --impure .#st0x-rest-api --no-link
             nix develop -c rainix-rs-static
+            nix develop -c cargo test --features oracle-integration-tests test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution
           fi
           nix develop -c cargo nextest run --workspace --partition hash:${{ matrix.partition }}/4
   rust-checks:

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -120,8 +120,30 @@ jobs:
           else
             ssh-keyscan -H "$HOST_IP" > ~/.ssh/known_hosts
           fi
+      - name: Install preview attribution signer credential
+        env:
+          ST0X_GATING_SIGNER_KEY: ${{ secrets.ST0X_GATING_SIGNER_KEY }}
+        run: |
+          if [ -z "$ST0X_GATING_SIGNER_KEY" ]; then
+            echo "ST0X_GATING_SIGNER_KEY secret is required" >&2
+            exit 1
+          fi
+          printf '%s\n' "$ST0X_GATING_SIGNER_KEY" | ssh "root@$HOST_IP" \
+            'install -d -m 700 /mnt/data/st0x-rest-api-preview/secrets && umask 077 && tee /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp >/dev/null && test -s /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp && mv /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp /mnt/data/st0x-rest-api-preview/secrets/attribution-signer'
+      - name: Check preview attribution credential unit
+        if: (inputs.deploy_scope || 'service') == 'service'
+        run: |
+          if ssh "root@$HOST_IP" 'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer'; then
+            echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=false" >> "$GITHUB_ENV"
+          else
+            echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=true" >> "$GITHUB_ENV"
+          fi
       # Prepare local build artifacts used by deploy-rs.
       - run: ./prep.sh
+      - name: Deploy preview attribution credential system prerequisite
+        if: (inputs.deploy_scope || 'service') == 'service' && env.NEEDS_ATTRIBUTION_SYSTEM_DEPLOY == 'true'
+        timeout-minutes: 60
+        run: nix run .#deployPreviewNixos
       - name: Deploy preview service
         if: (inputs.deploy_scope || 'service') == 'service'
         timeout-minutes: 60
@@ -129,7 +151,9 @@ jobs:
       - name: Deploy preview system
         if: (inputs.deploy_scope || 'service') == 'system'
         timeout-minutes: 60
-        run: nix run .#deployPreviewNixos
+        run: |
+          nix run .#deployPreviewNixos
+          ssh "root@$HOST_IP" 'systemctl try-restart rest-api.service'
       - name: Deploy preview system and service
         if: (inputs.deploy_scope || 'service') == 'all'
         timeout-minutes: 60

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
+ "alloy-node-bindings",
  "alloy-provider",
  "alloy-rpc-client",
  "alloy-rpc-types",
@@ -290,6 +291,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165210652f71dfc094b051602bafd691f506c54050a174b1cba18fb5ef706a3"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives 1.6.0",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "alloy-hardforks"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
@@ -380,6 +394,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-node-bindings"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
+dependencies = [
+ "alloy-genesis",
+ "alloy-hardforks 0.2.13",
+ "alloy-network",
+ "alloy-primitives 1.6.0",
+ "alloy-signer",
+ "alloy-signer-local",
+ "k256",
+ "libc",
+ "rand 0.8.5",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,8 +501,10 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
+ "alloy-node-bindings",
  "alloy-primitives 1.6.0",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types 1.6.0",
@@ -545,6 +583,18 @@ checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives 1.6.0",
  "alloy-rpc-types-engine",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-anvil"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
+dependencies = [
+ "alloy-primitives 1.6.0",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -2718,7 +2768,7 @@ checksum = "198b205ccbd3e54041e9a145374a6e170c71deb6d4c84dede8cd504a75694ad6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-hardforks",
+ "alloy-hardforks 0.4.7",
  "alloy-primitives 1.6.0",
  "alloy-provider",
  "alloy-rpc-types",
@@ -5266,6 +5316,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "raindex_test_fixtures"
+version = "0.0.0-alpha.0"
+dependencies = [
+ "alloy",
+ "getrandom 0.2.16",
+ "rain-math-float",
+ "rainlang_test_fixtures",
+ "serde_json",
+]
+
+[[package]]
 name = "rainlang-eval"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,6 +5371,15 @@ dependencies = [
  "rainlang_dispair",
  "thiserror 1.0.69",
  "tokio",
+]
+
+[[package]]
+name = "rainlang_test_fixtures"
+version = "0.0.0"
+source = "git+https://github.com/rainlanguage/rainlang?rev=580205d244a94097b06602ecda36faedf54d7775#580205d244a94097b06602ecda36faedf54d7775"
+dependencies = [
+ "alloy",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -6997,6 +7067,7 @@ dependencies = [
  "raindex_bindings",
  "raindex_common",
  "raindex_js_api",
+ "raindex_test_fixtures",
  "rand 0.9.1",
  "reqwest 0.13.2",
  "rocket",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ name = "st0x_rest_api"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+# The full-EVM calldata regression fixture is intentionally excluded from
+# production builds and enabled explicitly by CI and the rs-test command.
+oracle-integration-tests = ["dep:raindex_test_fixtures"]
+
 [dependencies]
 rocket = { version = "0.5.1", features = ["json"] }
 rocket_cors = "0.6"
@@ -40,6 +45,7 @@ rain-erc = { git = "https://github.com/rainlanguage/rain.erc", rev = "755b0bf5ca
 rain-math-float = "0.1.7"
 wasm-bindgen = "=0.2.122"
 url = "2"
+raindex_test_fixtures = { path = "lib/rain.orderbook/crates/test_fixtures", optional = true }
 
 [dev-dependencies]
 tracing-test = "0.2"

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
             name = "rs-test";
             body = ''
               set -euxo pipefail
-              cargo test --workspace
+              cargo test --workspace --features oracle-integration-tests
             '';
           };
           inherit (infraPkgs)

--- a/os.nix
+++ b/os.nix
@@ -39,6 +39,8 @@ let
         User = "st0x-rest-api";
         Group = "st0x";
         ExecStart = "${path} serve --config /etc/st0x-rest-api/config.toml";
+        LoadCredential =
+          [ "attribution-signer:${env.dataDir}/secrets/attribution-signer" ];
         Restart = "always";
         RestartSec = 5;
         ReadWritePaths = [ "/mnt/data" ];
@@ -211,6 +213,7 @@ in {
   systemd.tmpfiles.rules = [
     "d ${env.dataDir} 0775 root st0x -"
     "d ${env.dataDir}/logs 0775 root st0x -"
+    "d ${env.dataDir}/secrets 0700 root root -"
   ];
   systemd.services = lib.mapAttrs mkService enabledServices;
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,19 +1,23 @@
+use crate::attribution::AttributionState;
 use crate::cache::RouteResponseCaches;
 use crate::registry_artifact::RegistryArtifactStore;
 
 pub(crate) struct ApplicationState {
     pub registry_artifact_store: RegistryArtifactStore,
     pub response_caches: RouteResponseCaches,
+    pub attribution: AttributionState,
 }
 
 impl ApplicationState {
     pub(crate) fn new(
         registry_artifact_store: RegistryArtifactStore,
         response_caches: RouteResponseCaches,
+        attribution: AttributionState,
     ) -> Self {
         Self {
             registry_artifact_store,
             response_caches,
+            attribution,
         }
     }
 }

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -1,0 +1,187 @@
+//! REST API attribution contexts embedded in generated `takeOrders4` calldata.
+//!
+//! These contexts are not used by order Rainlang for authorization. They are
+//! signed by the REST API so an off-chain indexer can attribute an executed
+//! transaction to the API key that requested its calldata.
+
+use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy::signers::local::PrivateKeySigner;
+use alloy::signers::Signer as AlloySigner;
+use rain_orderbook_bindings::IRaindexV6::SignedContextV1;
+
+pub(crate) const ATTRIBUTION_SCHEMA_VERSION: u64 = 1;
+pub(crate) const ATTRIBUTION_CONTEXT_WORDS: usize = 4;
+
+/// EIP-191 signer for REST attribution contexts.
+///
+/// The private key is deliberately omitted from `Debug` output.
+pub(crate) struct AttributionSigner {
+    inner: PrivateKeySigner,
+}
+
+impl std::fmt::Debug for AttributionSigner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AttributionSigner")
+            .field("address", &self.inner.address())
+            .field("key", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AttributionSignerError {
+    #[error("invalid attribution signer private key: {0}")]
+    InvalidKey(String),
+    #[error("attribution signing failed: {0}")]
+    SignFailed(String),
+}
+
+impl AttributionSigner {
+    pub(crate) fn from_hex_key(private_key: &str) -> Result<Self, AttributionSignerError> {
+        let key = private_key.strip_prefix("0x").unwrap_or(private_key);
+        let inner: PrivateKeySigner =
+            key.parse()
+                .map_err(|error: alloy::signers::local::LocalSignerError| {
+                    AttributionSignerError::InvalidKey(error.to_string())
+                })?;
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn address(&self) -> Address {
+        self.inner.address()
+    }
+
+    /// Sign the versioned attribution frame:
+    ///
+    /// `[version, api_key_hash, taker, order_hash]`.
+    pub(crate) async fn sign_context(
+        &self,
+        attribution: &Attribution,
+        order_hash: B256,
+    ) -> Result<SignedContextV1, AttributionSignerError> {
+        let context = attribution.context_for_order(order_hash);
+        let hash = attribution_message_hash(&context);
+        let signature = self
+            .inner
+            .sign_message(hash.as_slice())
+            .await
+            .map_err(|error| AttributionSignerError::SignFailed(error.to_string()))?;
+
+        Ok(SignedContextV1 {
+            signer: self.address(),
+            context: context.to_vec(),
+            signature: Bytes::copy_from_slice(signature.as_bytes().as_slice()),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Attribution {
+    pub(crate) api_key_hash: B256,
+    pub(crate) taker: Address,
+}
+
+impl Attribution {
+    pub(crate) fn context_for_order(&self, order_hash: B256) -> [B256; ATTRIBUTION_CONTEXT_WORDS] {
+        [
+            u64_to_b256(ATTRIBUTION_SCHEMA_VERSION),
+            self.api_key_hash,
+            address_to_b256(self.taker),
+            order_hash,
+        ]
+    }
+}
+
+pub(crate) struct AttributionState {
+    pub(crate) signer: AttributionSigner,
+}
+
+impl AttributionState {
+    pub(crate) fn new(signer: AttributionSigner) -> Self {
+        Self { signer }
+    }
+
+    pub(crate) fn for_api_key(&self, key_id: &str, taker: Address) -> Attribution {
+        Attribution {
+            api_key_hash: compute_api_key_hash(key_id),
+            taker,
+        }
+    }
+}
+
+pub(crate) fn compute_api_key_hash(key_id: &str) -> B256 {
+    keccak256(key_id.as_bytes())
+}
+
+pub(crate) fn attribution_message_hash(context: &[B256; ATTRIBUTION_CONTEXT_WORDS]) -> B256 {
+    let mut packed = [0u8; ATTRIBUTION_CONTEXT_WORDS * 32];
+    for (target, word) in packed.chunks_exact_mut(32).zip(context) {
+        target.copy_from_slice(word.as_slice());
+    }
+    keccak256(packed)
+}
+
+pub(crate) fn address_to_b256(address: Address) -> B256 {
+    let mut value = [0u8; 32];
+    value[12..].copy_from_slice(address.as_slice());
+    B256::from(value)
+}
+
+pub(crate) fn u64_to_b256(value: u64) -> B256 {
+    B256::from(U256::from(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::primitives::{address, Signature};
+
+    const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const TEST_ADDRESS: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    fn attribution() -> Attribution {
+        Attribution {
+            api_key_hash: compute_api_key_hash("customer-key"),
+            taker: Address::from([0x22; 20]),
+        }
+    }
+
+    #[test]
+    fn derives_expected_address() {
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).unwrap();
+        assert_eq!(signer.address(), TEST_ADDRESS);
+    }
+
+    #[test]
+    fn redacts_private_key_from_debug() {
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).unwrap();
+        let debug = format!("{signer:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains(TEST_KEY));
+    }
+
+    #[tokio::test]
+    async fn signs_versioned_attribution_layout() {
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).unwrap();
+        let attribution = attribution();
+        let order_hash = B256::from([0x33; 32]);
+        let signed = signer.sign_context(&attribution, order_hash).await.unwrap();
+
+        assert_eq!(signed.signer, signer.address());
+        assert_eq!(signed.signature.len(), 65);
+        assert_eq!(signed.context.len(), ATTRIBUTION_CONTEXT_WORDS);
+        assert_eq!(signed.context[0], u64_to_b256(ATTRIBUTION_SCHEMA_VERSION));
+        assert_eq!(signed.context[1], attribution.api_key_hash);
+        assert_eq!(signed.context[2], address_to_b256(attribution.taker));
+        assert_eq!(signed.context[3], order_hash);
+
+        let context_hash = attribution_message_hash(&attribution.context_for_order(order_hash));
+        let signature = Signature::try_from(signed.signature.as_ref()).unwrap();
+        assert_eq!(
+            signature
+                .recover_address_from_msg(context_hash.as_slice())
+                .unwrap(),
+            signer.address()
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate rocket;
 
 mod app_state;
+mod attribution;
 mod auth;
 mod cache;
 mod catchers;
@@ -53,6 +54,34 @@ enum StartupError {
     InvalidMethod(String),
     #[error("CORS configuration failed: {0}")]
     Cors(#[from] rocket_cors::Error),
+}
+
+const ATTRIBUTION_SIGNER_CREDENTIAL: &str = "attribution-signer";
+
+fn load_attribution_signer_key() -> Result<String, String> {
+    if let Ok(key) = std::env::var("ST0X_GATING_SIGNER_KEY") {
+        let key = key.trim();
+        if !key.is_empty() {
+            return Ok(key.to_string());
+        }
+    }
+
+    let credentials_directory = std::env::var("CREDENTIALS_DIRECTORY").map_err(|_| {
+        "ST0X_GATING_SIGNER_KEY or a systemd attribution-signer credential is required".to_string()
+    })?;
+    let credential_path =
+        std::path::Path::new(&credentials_directory).join(ATTRIBUTION_SIGNER_CREDENTIAL);
+    let key = std::fs::read_to_string(&credential_path).map_err(|error| {
+        format!(
+            "failed to read attribution signer credential {}: {error}",
+            credential_path.display()
+        )
+    })?;
+    let key = key.trim();
+    if key.is_empty() {
+        return Err("attribution signer credential is empty".to_string());
+    }
+    Ok(key.to_string())
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -398,8 +427,33 @@ async fn main() {
             }
             tracing::info!(docs_dir = %cfg.docs_dir, "serving documentation at /docs");
 
-            let app_state =
-                app_state::ApplicationState::new(registry_artifact_store, response_caches);
+            let attribution_key = match load_attribution_signer_key() {
+                Ok(key) => key,
+                Err(error) => {
+                    tracing::error!(%error, "failed to load attribution signer key");
+                    drop(log_guard);
+                    std::process::exit(1);
+                }
+            };
+            let attribution_signer =
+                match attribution::AttributionSigner::from_hex_key(&attribution_key) {
+                    Ok(signer) => signer,
+                    Err(error) => {
+                        tracing::error!(%error, "failed to initialize attribution signer");
+                        drop(log_guard);
+                        std::process::exit(1);
+                    }
+                };
+            tracing::info!(
+                signer = %attribution_signer.address(),
+                "attribution signer loaded"
+            );
+            let attribution_state = attribution::AttributionState::new(attribution_signer);
+            let app_state = app_state::ApplicationState::new(
+                registry_artifact_store,
+                response_caches,
+                attribution_state,
+            );
 
             let rocket = match rocket(
                 pool,

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1,5 +1,6 @@
 use super::{RaindexSwapDataSource, SwapDataSource};
 use crate::app_state::ApplicationState;
+use crate::attribution::{attribution_message_hash, Attribution, AttributionSigner};
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorResponse};
@@ -10,7 +11,9 @@ use crate::routes::swap::denomination::{
 use crate::types::swap::{
     SwapCalldataMode, SwapCalldataRequest, SwapCalldataResponse, SwapCalldataV2Request,
 };
-use alloy::primitives::Address;
+use alloy::primitives::{keccak256, Address, Bytes, Signature};
+use alloy::sol_types::{SolCall, SolValue};
+use rain_orderbook_bindings::IRaindexV6::takeOrders4Call;
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::take_orders::TakeOrdersMode;
 use rocket::serde::json::Json;
@@ -36,7 +39,7 @@ use tracing::Instrument;
 #[post("/calldata", data = "<request>")]
 pub async fn post_swap_calldata(
     _global: GlobalRateLimit,
-    _key: AuthenticatedKey,
+    key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
     pool: &State<DbPool>,
@@ -44,6 +47,7 @@ pub async fn post_swap_calldata(
     request: Json<SwapCalldataRequest>,
 ) -> Result<Json<SwapCalldataResponse>, ApiError> {
     let req = request.into_inner();
+    let attribution = app_state.attribution.for_api_key(&key.key_id, req.taker);
     async move {
         tracing::info!(body = ?req, "request received");
         let raindex = shared_raindex.read().await;
@@ -52,7 +56,10 @@ pub async fn post_swap_calldata(
             caches: &app_state.response_caches,
             pool: pool.inner(),
         };
-        let response = process_swap_calldata(&ds, req).await?;
+        let mut response = process_swap_calldata(&ds, req).await?;
+        drop(raindex);
+        embed_and_validate_attribution(&mut response, &app_state.attribution.signer, &attribution)
+            .await?;
         Ok(Json(response))
     }
     .instrument(span.0)
@@ -78,7 +85,7 @@ pub async fn post_swap_calldata(
 #[post("/calldata", data = "<request>")]
 pub async fn post_swap_calldata_v2(
     _global: GlobalRateLimit,
-    _key: AuthenticatedKey,
+    key: AuthenticatedKey,
     shared_raindex: &State<crate::raindex::SharedRaindexProvider>,
     app_state: &State<ApplicationState>,
     pool: &State<DbPool>,
@@ -86,6 +93,7 @@ pub async fn post_swap_calldata_v2(
     request: Json<SwapCalldataV2Request>,
 ) -> Result<Json<SwapCalldataResponse>, ApiError> {
     let req = request.into_inner();
+    let attribution = app_state.attribution.for_api_key(&key.key_id, req.taker);
     async move {
         tracing::info!(
             mode = ?req.mode,
@@ -98,11 +106,134 @@ pub async fn post_swap_calldata_v2(
             caches: &app_state.response_caches,
             pool: pool.inner(),
         };
-        let response = process_swap_calldata_v2(&ds, req).await?;
+        let mut response = process_swap_calldata_v2(&ds, req).await?;
+        drop(raindex);
+        embed_and_validate_attribution(&mut response, &app_state.attribution.signer, &attribution)
+            .await?;
         Ok(Json(response))
     }
     .instrument(span.0)
     .await
+}
+
+async fn embed_and_validate_attribution(
+    response: &mut SwapCalldataResponse,
+    signer: &AttributionSigner,
+    attribution: &Attribution,
+) -> Result<(), ApiError> {
+    if !response.approvals.is_empty() || response.data.is_empty() {
+        return validate_attribution_calldata(response, signer.address(), attribution);
+    }
+
+    let mut decoded = takeOrders4Call::abi_decode(&response.data).map_err(|error| {
+        tracing::error!(
+            %error,
+            api_key_hash = %attribution.api_key_hash,
+            "failed to decode generated takeOrders4 calldata for attribution"
+        );
+        ApiError::Internal("generated swap calldata is missing attribution".into())
+    })?;
+    for order_config in &mut decoded.config.orders {
+        let order_hash = keccak256(order_config.order.abi_encode());
+        let context = signer
+            .sign_context(attribution, order_hash)
+            .await
+            .map_err(|error| {
+                tracing::error!(
+                    %error,
+                    %order_hash,
+                    api_key_hash = %attribution.api_key_hash,
+                    "failed to sign REST attribution context"
+                );
+                ApiError::Internal("failed to sign swap calldata attribution".into())
+            })?;
+        order_config.signedContext.push(context);
+    }
+    response.data = Bytes::from(decoded.abi_encode());
+
+    validate_attribution_calldata(response, signer.address(), attribution)
+}
+
+fn validate_attribution_calldata(
+    response: &SwapCalldataResponse,
+    signer_address: Address,
+    attribution: &Attribution,
+) -> Result<(), ApiError> {
+    if !response.approvals.is_empty() {
+        if !response.data.is_empty() {
+            tracing::error!(
+                api_key_hash = %attribution.api_key_hash,
+                "swap response unexpectedly contains approvals and executable calldata"
+            );
+            return Err(ApiError::Internal(
+                "generated swap calldata has an invalid state".into(),
+            ));
+        }
+        tracing::info!(
+            api_key_hash = %attribution.api_key_hash,
+            "swap calldata requires approval; executable attribution is not expected"
+        );
+        return Ok(());
+    }
+
+    if response.data.is_empty() {
+        tracing::error!(
+            api_key_hash = %attribution.api_key_hash,
+            "swap response contains neither approvals nor executable calldata"
+        );
+        return Err(ApiError::Internal(
+            "generated swap calldata is missing attribution".into(),
+        ));
+    }
+    let decoded = takeOrders4Call::abi_decode(&response.data).map_err(|error| {
+        tracing::error!(
+            %error,
+            api_key_hash = %attribution.api_key_hash,
+            "failed to decode generated takeOrders4 calldata for attribution validation"
+        );
+        ApiError::Internal("generated swap calldata is missing attribution".into())
+    })?;
+    if decoded.config.orders.is_empty() {
+        tracing::error!(
+            api_key_hash = %attribution.api_key_hash,
+            "generated takeOrders4 calldata contains no orders"
+        );
+        return Err(ApiError::Internal(
+            "generated swap calldata is missing attribution".into(),
+        ));
+    }
+
+    for order_config in &decoded.config.orders {
+        let order_hash = keccak256(order_config.order.abi_encode());
+        let expected_context = attribution.context_for_order(order_hash);
+        let mut matching_attribution = order_config.signedContext.iter().filter(|context| {
+            context.signer == signer_address && context.context.as_slice() == expected_context
+        });
+        let first_match = matching_attribution.next();
+        let has_duplicate = matching_attribution.next().is_some();
+        let signature_is_valid = if let Some(context) = first_match {
+            let context_hash = attribution_message_hash(&expected_context);
+            Signature::try_from(context.signature.as_ref())
+                .and_then(|signature| signature.recover_address_from_msg(context_hash.as_slice()))
+                .is_ok_and(|recovered| recovered == signer_address)
+        } else {
+            false
+        };
+        if first_match.is_none() || has_duplicate || !signature_is_valid {
+            tracing::error!(
+                %order_hash,
+                api_key_hash = %attribution.api_key_hash,
+                signer = %signer_address,
+                duplicate_attribution_context = has_duplicate,
+                "generated order is missing its exact REST attribution context"
+            );
+            return Err(ApiError::Internal(
+                "generated swap calldata is missing attribution".into(),
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 #[derive(Debug)]
@@ -209,6 +340,9 @@ async fn process_swap_calldata_build(
     let response = ds.get_calldata(take_req).await?;
     normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)
 }
+
+#[cfg(all(test, feature = "oracle-integration-tests"))]
+mod oracle_integration_tests;
 
 #[cfg(test)]
 mod tests {
@@ -472,6 +606,22 @@ mod tests {
         assert_eq!(result.approvals.len(), 1);
         assert_eq!(result.approvals[0].token, USDC);
         assert_eq!(result.approvals[0].spender, ORDERBOOK);
+    }
+
+    #[rocket::async_test]
+    async fn test_approval_response_does_not_require_executable_attribution() {
+        let state = crate::attribution::AttributionState::new(
+            crate::attribution::AttributionSigner::from_hex_key(
+                "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            )
+            .unwrap(),
+        );
+        let attribution = state.for_api_key("customer-key", TAKER);
+        let mut response = approval_response();
+
+        embed_and_validate_attribution(&mut response, &state.signer, &attribution)
+            .await
+            .unwrap();
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -1,0 +1,516 @@
+use super::*;
+use crate::attribution::{
+    address_to_b256, u64_to_b256, AttributionSigner, AttributionState, ATTRIBUTION_SCHEMA_VERSION,
+};
+use crate::cache::RouteResponseCaches;
+use alloy::hex::encode_prefixed;
+use alloy::network::TransactionBuilder;
+use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy::rpc::types::TransactionRequest;
+use alloy::serde::WithOtherFields;
+use alloy::signers::{local::PrivateKeySigner, Signer};
+use alloy::sol_types::{SolCall, SolValue};
+use rain_orderbook_bindings::IRaindexV6::{takeOrders4Call, OrderV4};
+use rain_orderbook_common::add_order::AddOrderArgs;
+use rain_orderbook_common::dotrain_order::DotrainOrder;
+use rain_orderbook_common::raindex_client::RaindexClient;
+use raindex_test_fixtures::LocalEvm;
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::RwLock;
+
+struct MockSwapServices {
+    base_url: String,
+    subgraph_order: Arc<RwLock<Option<Value>>>,
+    oracle_available: Arc<AtomicBool>,
+    oracle_bodies: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl MockSwapServices {
+    async fn start(oracle_response: Value) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let subgraph_order = Arc::new(RwLock::new(None));
+        let oracle_available = Arc::new(AtomicBool::new(true));
+        let oracle_bodies = Arc::new(Mutex::new(Vec::new()));
+
+        let orders = Arc::clone(&subgraph_order);
+        let available = Arc::clone(&oracle_available);
+        let bodies = Arc::clone(&oracle_bodies);
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut socket, _)) = listener.accept().await else {
+                    break;
+                };
+                let orders = Arc::clone(&orders);
+                let available = Arc::clone(&available);
+                let bodies = Arc::clone(&bodies);
+                let oracle_response = oracle_response.clone();
+                tokio::spawn(async move {
+                    let Some((path, body)) = read_request(&mut socket).await else {
+                        return;
+                    };
+                    let (status, response) = match path.as_str() {
+                        "/oracle" if available.load(Ordering::SeqCst) => {
+                            bodies.lock().unwrap().push(body);
+                            ("200 OK", oracle_response.to_string())
+                        }
+                        "/oracle" => {
+                            bodies.lock().unwrap().push(body);
+                            (
+                                "503 Service Unavailable",
+                                json!({"error": "offline"}).to_string(),
+                            )
+                        }
+                        "/sg" => {
+                            let orders = orders.read().await;
+                            let values = orders.iter().cloned().collect::<Vec<_>>();
+                            ("200 OK", json!({"data": {"orders": values}}).to_string())
+                        }
+                        _ => ("404 Not Found", json!({"error": "not found"}).to_string()),
+                    };
+                    write_response(&mut socket, status, &response).await;
+                });
+            }
+        });
+
+        Self {
+            base_url: format!("http://{address}"),
+            subgraph_order,
+            oracle_available,
+            oracle_bodies,
+        }
+    }
+
+    fn oracle_url(&self) -> String {
+        format!("{}/oracle", self.base_url)
+    }
+
+    fn subgraph_url(&self) -> String {
+        format!("{}/sg", self.base_url)
+    }
+}
+
+async fn read_request(socket: &mut tokio::net::TcpStream) -> Option<(String, Vec<u8>)> {
+    let mut request = Vec::new();
+    let mut chunk = [0u8; 8192];
+    let (header_end, content_length) = loop {
+        let read = socket.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        request.extend_from_slice(&chunk[..read]);
+        if let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+            let header_end = header_end + 4;
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or_default();
+            break (header_end, content_length);
+        }
+    };
+    while request.len() < header_end + content_length {
+        let read = socket.read(&mut chunk).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        request.extend_from_slice(&chunk[..read]);
+    }
+
+    let request_line = String::from_utf8_lossy(&request)
+        .lines()
+        .next()?
+        .to_string();
+    let path = request_line.split_whitespace().nth(1)?.to_string();
+    Some((
+        path,
+        request[header_end..header_end + content_length].to_vec(),
+    ))
+}
+
+async fn write_response(socket: &mut tokio::net::TcpStream, status: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    socket.write_all(response.as_bytes()).await.unwrap();
+}
+
+fn oracle_order_dotrain(
+    rpc_url: &str,
+    oracle_url: &str,
+    rainlang: Address,
+    input_token: Address,
+    output_token: Address,
+) -> String {
+    format!(
+        r#"
+version: 6
+networks:
+    test-network:
+        rpcs:
+            - {rpc_url}
+        chain-id: 8453
+        network-id: 8453
+        currency: ETH
+rainlangs:
+    test-rainlang:
+        network: test-network
+        address: {rainlang}
+tokens:
+    input:
+        network: test-network
+        address: {input_token}
+        decimals: 18
+        label: Input
+        symbol: INPUT
+    output:
+        network: test-network
+        address: {output_token}
+        decimals: 18
+        label: Output
+        symbol: OUTPUT
+raindex:
+    test-raindex:
+        address: 0x0000000000000000000000000000000000000001
+orders:
+    test-order:
+        oracle-url: {oracle_url}
+        inputs:
+            - token: input
+        outputs:
+            - token: output
+              vault-id: 1
+scenarios:
+    test-scenario:
+        rainlang: test-rainlang
+        bindings:
+            max-amount: 1000
+deployments:
+    test-deployment:
+        scenario: test-scenario
+        order: test-order
+---
+#max-amount !Max output amount
+#calculate-io
+amount price: 100 2;
+#handle-add-order
+:;
+#handle-io
+:;
+"#
+    )
+}
+
+fn client_yaml(
+    rpc_url: &str,
+    subgraph_url: &str,
+    raindex: Address,
+    input_token: Address,
+    output_token: Address,
+) -> String {
+    format!(
+        r#"
+version: 6
+networks:
+    test-network:
+        rpcs:
+            - {rpc_url}
+        chain-id: 8453
+        network-id: 8453
+        currency: ETH
+subgraphs:
+    test-subgraph: {subgraph_url}
+raindexes:
+    test-raindex:
+        address: {raindex}
+        network: test-network
+        subgraph: test-subgraph
+        deployment-block: 0
+tokens:
+    input:
+        network: test-network
+        address: {input_token}
+        decimals: 18
+        label: Input
+        symbol: INPUT
+    output:
+        network: test-network
+        address: {output_token}
+        decimals: 18
+        label: Output
+        symbol: OUTPUT
+"#
+    )
+}
+
+fn vault_json(
+    id: &str,
+    owner: Address,
+    vault_id: B256,
+    balance: U256,
+    token: Address,
+    symbol: &str,
+    raindex: Address,
+) -> Value {
+    json!({
+        "id": id,
+        "owner": owner,
+        "vaultId": vault_id,
+        "balance": B256::from(balance),
+        "token": {
+            "id": token,
+            "address": token,
+            "name": symbol,
+            "symbol": symbol,
+            "decimals": "18",
+        },
+        "raindex": {"id": raindex},
+        "ordersAsOutput": [],
+        "ordersAsInput": [],
+        "balanceChanges": [],
+    })
+}
+
+fn subgraph_order_json(order: &OrderV4, order_hash: B256, meta: &[u8], raindex: Address) -> Value {
+    let owner = order.owner;
+    let input = &order.validInputs[0];
+    let output = &order.validOutputs[0];
+    json!({
+        "id": order_hash,
+        "orderBytes": encode_prefixed(order.abi_encode()),
+        "orderHash": order_hash,
+        "owner": owner,
+        "outputs": [vault_json(
+            "0x02",
+            owner,
+            output.vaultId,
+            U256::from(10).pow(U256::from(20)),
+            output.token,
+            "OUTPUT",
+            raindex
+        )],
+        "inputs": [vault_json(
+            "0x01",
+            owner,
+            input.vaultId,
+            U256::ZERO,
+            input.token,
+            "INPUT",
+            raindex
+        )],
+        "raindex": {"id": raindex},
+        "active": true,
+        "timestampAdded": "1739448802",
+        "meta": encode_prefixed(meta),
+        "addEvents": [{
+            "transaction": {
+                "id": B256::from(U256::from(1)),
+                "from": owner,
+                "blockNumber": "1",
+                "timestamp": "1739448802",
+            }
+        }],
+        "trades": [],
+        "removeEvents": [],
+    })
+}
+
+#[rocket::async_test]
+async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution() {
+    let mut local_evm = LocalEvm::new().await;
+    let oracle_signer = PrivateKeySigner::from(local_evm.anvil.keys()[0].clone());
+    let oracle_context = B256::from(U256::from(42));
+    let oracle_signature = oracle_signer
+        .sign_message(keccak256(oracle_context).as_slice())
+        .await
+        .unwrap();
+    let oracle_signature = Bytes::from(oracle_signature.as_bytes().to_vec());
+    let oracle_signer_address = oracle_signer.address();
+    let services = MockSwapServices::start(json!([{
+        "signer": oracle_signer_address,
+        "context": [oracle_context],
+        "signature": oracle_signature,
+    }]))
+    .await;
+    let owner = local_evm.signer_wallets[0].default_signer().address();
+    let input = local_evm
+        .deploy_new_token("Input", "INPUT", 18, U256::MAX, owner)
+        .await;
+    let output = local_evm
+        .deploy_new_token("Output", "OUTPUT", 18, U256::MAX, owner)
+        .await;
+    let input_address = *input.address();
+    let output_address = *output.address();
+    let raindex = *local_evm.raindex.address();
+
+    let dotrain = oracle_order_dotrain(
+        &local_evm.url(),
+        &services.oracle_url(),
+        local_evm.rainlang,
+        input_address,
+        output_address,
+    );
+    let dotrain_order = DotrainOrder::create(dotrain.clone(), None).await.unwrap();
+    let deployment = dotrain_order
+        .dotrain_yaml()
+        .get_deployment("test-deployment")
+        .unwrap();
+    let add_order_args = AddOrderArgs::new_from_deployment(dotrain, deployment, None)
+        .await
+        .unwrap();
+    let add_order_call = add_order_args
+        .try_into_call(vec![local_evm.url()])
+        .await
+        .unwrap();
+    let meta = add_order_call.config.meta.clone();
+    let (event, _) = local_evm
+        .add_order(&add_order_call.abi_encode(), owner)
+        .await;
+    let order = OrderV4::abi_decode(&event.order.abi_encode()).unwrap();
+    local_evm
+        .deposit(
+            owner,
+            output_address,
+            U256::from(10).pow(U256::from(20)),
+            18,
+            order.validOutputs[0].vaultId,
+        )
+        .await;
+    input
+        .approve(raindex, U256::MAX)
+        .from(owner)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+
+    *services.subgraph_order.write().await =
+        Some(subgraph_order_json(&order, event.orderHash, &meta, raindex));
+    let client = RaindexClient::new(
+        vec![client_yaml(
+            &local_evm.url(),
+            &services.subgraph_url(),
+            raindex,
+            input_address,
+            output_address,
+        )],
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let database_url = format!(
+        "sqlite:file:{}?mode=memory&cache=shared",
+        uuid::Uuid::new_v4()
+    );
+    let pool = crate::db::init(&database_url, 1).await.unwrap();
+    let caches = RouteResponseCaches::new(0, Duration::ZERO);
+    let attribution_state = AttributionState::new(
+        AttributionSigner::from_hex_key(
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        )
+        .unwrap(),
+    );
+    assert_eq!(oracle_signer_address, attribution_state.signer.address());
+    let attribution = attribution_state.for_api_key("customer-key", owner);
+    let data_source = RaindexSwapDataSource {
+        client: &client,
+        caches: &caches,
+        pool: &pool,
+    };
+    let request = SwapCalldataRequest {
+        taker: owner,
+        input_token: input_address,
+        output_token: output_address,
+        output_amount: "10".to_string(),
+        maximum_io_ratio: "3".to_string(),
+        denomination: crate::types::swap::SwapDenomination::Wrapped,
+    };
+
+    let mut response = process_swap_calldata(&data_source, request.clone())
+        .await
+        .unwrap();
+    embed_and_validate_attribution(&mut response, &attribution_state.signer, &attribution)
+        .await
+        .unwrap();
+    let decoded = takeOrders4Call::abi_decode(&response.data).unwrap();
+    assert_eq!(decoded.config.orders[0].signedContext.len(), 2);
+    let signed_context = &decoded.config.orders[0].signedContext[0];
+    assert_eq!(signed_context.signer, oracle_signer_address);
+    assert_eq!(signed_context.context[0], oracle_context);
+    assert_eq!(signed_context.signature, oracle_signature);
+
+    let attributed_context = &decoded.config.orders[0].signedContext[1];
+    assert_eq!(
+        attributed_context.signer,
+        attribution_state.signer.address()
+    );
+    assert_eq!(attributed_context.context.len(), 4);
+    assert_eq!(
+        attributed_context.context[0],
+        u64_to_b256(ATTRIBUTION_SCHEMA_VERSION)
+    );
+    assert_eq!(attributed_context.context[1], attribution.api_key_hash);
+    assert_eq!(attributed_context.context[2], address_to_b256(owner));
+    assert_eq!(
+        attributed_context.context[3],
+        keccak256(decoded.config.orders[0].order.abi_encode())
+    );
+
+    local_evm
+        .send_transaction(WithOtherFields::new(
+            TransactionRequest::default()
+                .with_input(response.data.clone())
+                .with_to(response.to)
+                .with_from(owner),
+        ))
+        .await
+        .unwrap();
+
+    let v2_attribution = attribution_state.for_api_key("customer-key", owner);
+    let v2_request = SwapCalldataV2Request {
+        taker: owner,
+        input_token: input_address,
+        output_token: output_address,
+        mode: SwapCalldataMode::BuyUpTo,
+        amount: "10".to_string(),
+        price_cap: "3".to_string(),
+        denomination: crate::types::swap::SwapDenomination::Wrapped,
+    };
+    let mut v2_response = process_swap_calldata_v2(&data_source, v2_request)
+        .await
+        .unwrap();
+    embed_and_validate_attribution(&mut v2_response, &attribution_state.signer, &v2_attribution)
+        .await
+        .unwrap();
+    let v2_decoded = takeOrders4Call::abi_decode(&v2_response.data).unwrap();
+    let v2_context = &v2_decoded.config.orders[0].signedContext[1];
+    assert_eq!(v2_context.context[1], v2_attribution.api_key_hash);
+
+    let oracle_body = services.oracle_bodies.lock().unwrap()[0].clone();
+    let oracle_request = <(OrderV4, U256, U256, Address)>::abi_decode(&oracle_body).unwrap();
+    assert_eq!(oracle_request.0, order);
+    assert_eq!(oracle_request.1, U256::ZERO);
+    assert_eq!(oracle_request.2, U256::ZERO);
+    assert_eq!(oracle_request.3, owner);
+
+    services.oracle_available.store(false, Ordering::SeqCst);
+    let error = process_swap_calldata(&data_source, request)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, ApiError::NotFound(message) if message == "no liquidity found for this pair")
+    );
+}

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -87,7 +87,13 @@ impl TestClientBuilder {
             crate::registry_artifact::RegistryArtifactStore::new(private_registry_path);
         let response_caches =
             crate::cache::RouteResponseCaches::new(100, std::time::Duration::from_secs(10));
-        let app_state = crate::app_state::ApplicationState::new(artifact_store, response_caches);
+        let attribution_signer = crate::attribution::AttributionSigner::from_hex_key(
+            "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        )
+        .expect("test attribution signer");
+        let attribution = crate::attribution::AttributionState::new(attribution_signer);
+        let app_state =
+            crate::app_state::ApplicationState::new(artifact_store, response_caches, attribution);
         let docs_dir = std::env::temp_dir().to_string_lossy().into_owned();
         let rocket = crate::rocket(
             pool,


### PR DESCRIPTION
## Motivation

We need to attribute actual on-chain swap executions to the authenticated API customer that generated the calldata. Recording every generated response is unnecessary for that goal: the blockchain already tells us which calldata was executed.

This PR is based directly on `main` and can land independently of #78.

## Solution

- Hash the authenticated API key ID and embed a signed, versioned attribution frame in every selected order of executable V1 and V2 `takeOrders4` calldata:
  `[schemaVersion, apiKeyHash, taker, orderHash]`.
- Sign the frame with EIP-191 using the existing `ST0X_GATING_SIGNER_KEY` EOA private key.
- Append attribution only after Raindex has built the final selected-order calldata. Existing oracle contexts are preserved unchanged.
- Decode and verify the final returned calldata, including the exact context and recovered signer, before returning it.
- Leave approval-only responses unchanged because they contain no executable swap calldata.

There is deliberately no issuance ID, expiry/TTL, generated-calldata database write, or database migration. The swap endpoint therefore does not depend on attribution persistence.

The private key and API secret are never exposed. The public calldata contains only the API key ID hash; an indexer can recompute that hash from the existing API-key records to map it to the customer.

## Execution attribution follow-up

A separate indexer/reporting change can:

1. Read actual trade events from the Raindex local database or chain logs.
2. Fetch each executed transaction's input from the configured network RPC.
3. Decode `takeOrders4`, locate the exact signed frame from the configured REST signer, and verify its signature.
4. Join `apiKeyHash` to the existing API-key/customer record and aggregate the event's executed volume.

Only transactions that actually emitted trade events are counted. If hard-deleting API-key rows must remain supported, that follow-up should retain a small historical hash-to-customer mapping; this PR does not add generated-calldata records.

## Regression coverage

- Creates local oracle and REST EOA signatures and verifies the attribution layout and signer recovery.
- Generates real V1 and V2 calldata against a local EVM order.
- Preserves the existing oracle context and appends REST attribution after it, including when oracle and REST contexts use the same signer.
- Broadcasts the attributed calldata to the local EVM and verifies that the swap transaction executes successfully.
- Verifies approval-only responses do not require executable attribution.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo nextest run --workspace` (304 passed)
- `nix develop -c nix build .#st0x-docs --no-link`
- Three focused simplify reviewers; actionable findings fixed and retested.

## Deployment

The existing GitHub secret `ST0X_GATING_SIGNER_KEY` must contain the EOA private key, not the public address. Production and preview install it as a protected systemd credential. The service derives and logs the public signer address at startup and exits safely if the credential is missing or invalid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap calldata responses now include verifiable API attribution for executable v1 and v2 requests.
  * Attribution is generated per request (API key, taker, and order) and validated via signatures before returning calldata.
  * Approval-only responses still skip executable attribution embedding.

* **Bug Fixes**
  * Improved deployment automation for attribution signing credentials, including necessary service restart behavior.

* **Tests**
  * Added integration coverage for attribution ordering/embedding, signature recovery validation, oracle interactions, and offline liquidity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->