### PR TITLE
feat: report customer volume from attributed trades

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -70,16 +70,21 @@ jobs:
           fi
           printf '%s\n' "$ST0X_GATING_SIGNER_KEY" | ssh "root@$HOST_IP" \
             'install -d -m 700 /mnt/data/st0x-rest-api/secrets && umask 077 && tee /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp >/dev/null && test -s /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp && mv /mnt/data/st0x-rest-api/secrets/.attribution-signer.tmp /mnt/data/st0x-rest-api/secrets/attribution-signer'
-      - name: Check attribution credential unit
+      - name: Check attribution system prerequisites
         if: (inputs.deploy_scope || 'service') == 'service'
         run: |
-          if ssh "root@$HOST_IP" 'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer'; then
+          expected_attribution_config="$(grep '^attribution_' config/prod.toml)"
+          deployed_attribution_config="$(ssh "root@$HOST_IP" \
+            "grep '^attribution_' /etc/st0x-rest-api/config.toml 2>/dev/null || true")"
+          if ssh "root@$HOST_IP" \
+              'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer' \
+            && [ "$deployed_attribution_config" = "$expected_attribution_config" ]; then
             echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=false" >> "$GITHUB_ENV"
           else
             echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=true" >> "$GITHUB_ENV"
           fi
       - run: ./prep.sh
-      - name: Deploy attribution credential system prerequisite
+      - name: Deploy attribution system prerequisites
         if: (inputs.deploy_scope || 'service') == 'service' && env.NEEDS_ATTRIBUTION_SYSTEM_DEPLOY == 'true'
         run: nix run .#deployNixos
       - name: Deploy service

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -130,17 +130,22 @@ jobs:
           fi
           printf '%s\n' "$ST0X_GATING_SIGNER_KEY" | ssh "root@$HOST_IP" \
             'install -d -m 700 /mnt/data/st0x-rest-api-preview/secrets && umask 077 && tee /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp >/dev/null && test -s /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp && mv /mnt/data/st0x-rest-api-preview/secrets/.attribution-signer.tmp /mnt/data/st0x-rest-api-preview/secrets/attribution-signer'
-      - name: Check preview attribution credential unit
+      - name: Check preview attribution system prerequisites
         if: (inputs.deploy_scope || 'service') == 'service'
         run: |
-          if ssh "root@$HOST_IP" 'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer'; then
+          expected_attribution_config="$(grep '^attribution_' config/preview.toml)"
+          deployed_attribution_config="$(ssh "root@$HOST_IP" \
+            "grep '^attribution_' /etc/st0x-rest-api/config.toml 2>/dev/null || true")"
+          if ssh "root@$HOST_IP" \
+              'systemctl cat rest-api.service 2>/dev/null | grep -q attribution-signer' \
+            && [ "$deployed_attribution_config" = "$expected_attribution_config" ]; then
             echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=false" >> "$GITHUB_ENV"
           else
             echo "NEEDS_ATTRIBUTION_SYSTEM_DEPLOY=true" >> "$GITHUB_ENV"
           fi
       # Prepare local build artifacts used by deploy-rs.
       - run: ./prep.sh
-      - name: Deploy preview attribution credential system prerequisite
+      - name: Deploy preview attribution system prerequisites
         if: (inputs.deploy_scope || 'service') == 'service' && env.NEEDS_ATTRIBUTION_SYSTEM_DEPLOY == 'true'
         timeout-minutes: 60
         run: nix run .#deployPreviewNixos

--- a/config/preview.toml
+++ b/config/preview.toml
@@ -11,6 +11,9 @@ rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "/var/lib/st0x-docs"
 local_db_path = "/mnt/data/st0x-rest-api-preview/raindex.db"
+attribution_start_block = 48963501
+attribution_sync_interval_seconds = 60
+attribution_sync_batch_size = 250
 
 # Push logs + traces to the rain observability stack over the rain tailnet
 # (VictoriaLogs :9428, VictoriaTraces :10428 on the rain-management-observability

--- a/config/prod.toml
+++ b/config/prod.toml
@@ -11,6 +11,9 @@ rate_limit_global_rpm = 600
 rate_limit_per_key_rpm = 60
 docs_dir = "/var/lib/st0x-docs"
 local_db_path = "/mnt/data/st0x-rest-api/raindex.db"
+attribution_start_block = 48963501
+attribution_sync_interval_seconds = 60
+attribution_sync_batch_size = 250
 
 # Push logs + traces to the rain observability stack over the rain tailnet
 # (VictoriaLogs :9428, VictoriaTraces :10428 on the rain-management-observability

--- a/migrations/20260722000000_create_attribution_reporting.sql
+++ b/migrations/20260722000000_create_attribution_reporting.sql
@@ -1,0 +1,61 @@
+CREATE TABLE IF NOT EXISTS attributed_trades (
+    chain_id          INTEGER NOT NULL,
+    raindex_address   TEXT    NOT NULL,
+    indexed_trade_id  TEXT    NOT NULL,
+    transaction_hash  TEXT    NOT NULL,
+    log_index         INTEGER NOT NULL,
+    block_number      INTEGER NOT NULL,
+    block_timestamp   INTEGER NOT NULL,
+    order_hash        TEXT    NOT NULL,
+    taker             TEXT    NOT NULL,
+    api_key_hash      TEXT    NOT NULL,
+    api_key_database_id INTEGER,
+    api_key_id        TEXT,
+    api_key_label     TEXT,
+    api_key_owner     TEXT,
+    input_token       TEXT    NOT NULL,
+    input_amount      TEXT    NOT NULL,
+    output_token      TEXT    NOT NULL,
+    output_amount     TEXT    NOT NULL,
+    created_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+    updated_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (chain_id, raindex_address, indexed_trade_id)
+);
+
+CREATE INDEX idx_attributed_trades_block
+    ON attributed_trades (block_number DESC, log_index DESC, indexed_trade_id DESC);
+CREATE INDEX idx_attributed_trades_api_key_hash
+    ON attributed_trades (
+        api_key_hash,
+        block_number DESC,
+        log_index DESC,
+        indexed_trade_id DESC
+    );
+CREATE INDEX idx_attributed_trades_transaction_hash
+    ON attributed_trades (transaction_hash);
+
+CREATE TABLE IF NOT EXISTS attribution_sync_cursors (
+    chain_id          INTEGER NOT NULL,
+    raindex_address   TEXT    NOT NULL,
+    start_block       INTEGER NOT NULL,
+    last_block        INTEGER NOT NULL,
+    last_log_index    INTEGER NOT NULL,
+    last_trade_id     TEXT    NOT NULL,
+    updated_at        TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (chain_id, raindex_address)
+);
+
+CREATE TABLE IF NOT EXISTS attribution_signers (
+    address       TEXT PRIMARY KEY,
+    first_seen_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS attribution_api_keys (
+    api_key_hash        TEXT PRIMARY KEY,
+    api_key_database_id INTEGER,
+    api_key_id          TEXT NOT NULL,
+    api_key_label       TEXT NOT NULL,
+    api_key_owner       TEXT NOT NULL,
+    created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at          TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/migrations/20260724000000_add_attribution_volume_group_index.sql
+++ b/migrations/20260724000000_add_attribution_volume_group_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_attributed_trades_volume_group
+    ON attributed_trades (api_key_hash, chain_id, input_token, output_token);

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -4,7 +4,7 @@
 //! signed by the REST API so an off-chain indexer can attribute an executed
 //! transaction to the API key that requested its calldata.
 
-use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
+use alloy::primitives::{keccak256, Address, Bytes, Signature, B256, U256};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::Signer as AlloySigner;
 use rain_orderbook_bindings::IRaindexV6::SignedContextV1;
@@ -131,10 +131,33 @@ pub(crate) fn u64_to_b256(value: u64) -> B256 {
     B256::from(U256::from(value))
 }
 
+pub(crate) fn verify_signed_attribution(
+    signed_context: &SignedContextV1,
+    expected_signer: Address,
+    taker: Address,
+    order_hash: B256,
+) -> Option<B256> {
+    if signed_context.signer != expected_signer {
+        return None;
+    }
+    let context: [B256; ATTRIBUTION_CONTEXT_WORDS] =
+        signed_context.context.clone().try_into().ok()?;
+    if context[0] != u64_to_b256(ATTRIBUTION_SCHEMA_VERSION)
+        || context[2] != address_to_b256(taker)
+        || context[3] != order_hash
+    {
+        return None;
+    }
+    let signature = Signature::try_from(signed_context.signature.as_ref()).ok()?;
+    let hash = attribution_message_hash(&context);
+    let recovered = signature.recover_address_from_msg(hash.as_slice()).ok()?;
+    (recovered == expected_signer).then_some(context[1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy::primitives::{address, Signature};
+    use alloy::primitives::address;
 
     const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
     const TEST_ADDRESS: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -182,6 +205,10 @@ mod tests {
                 .recover_address_from_msg(context_hash.as_slice())
                 .unwrap(),
             signer.address()
+        );
+        assert_eq!(
+            verify_signed_attribution(&signed, signer.address(), attribution.taker, order_hash),
+            Some(attribution.api_key_hash)
         );
     }
 }

--- a/src/attribution_reporting.rs
+++ b/src/attribution_reporting.rs
@@ -1,0 +1,1247 @@
+//! Background attribution of confirmed trades indexed by the local Raindex database.
+
+use crate::attribution::{
+    compute_api_key_hash, verify_signed_attribution, ATTRIBUTION_CONTEXT_WORDS,
+};
+use crate::db::DbPool;
+use alloy::primitives::{Address, Bytes, B256};
+use rain_orderbook_bindings::IRaindexV6::SignedContextV1;
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::{Orbit, Rocket};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{FromRow, SqlitePool};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+const SUPPORTED_RAINDEX_SCHEMA_VERSION: u32 = 5;
+const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const _: () = assert!(
+    rain_orderbook_app_settings::local_db_manifest::DB_SCHEMA_VERSION
+        == SUPPORTED_RAINDEX_SCHEMA_VERSION,
+    "Raindex local database schema changed; review the attribution queries"
+);
+
+#[derive(Debug, Clone)]
+pub(crate) struct AttributionWorker {
+    app_pool: DbPool,
+    raindex_db_path: PathBuf,
+    signer: Address,
+    start_block: u64,
+    interval: Duration,
+    batch_size: u32,
+    task: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl AttributionWorker {
+    pub(crate) fn new(
+        app_pool: DbPool,
+        raindex_db_path: PathBuf,
+        signer: Address,
+        start_block: u64,
+        interval: Duration,
+        batch_size: u32,
+    ) -> Self {
+        Self {
+            app_pool,
+            raindex_db_path,
+            signer,
+            start_block,
+            interval,
+            batch_size: batch_size.max(1),
+            task: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+#[rocket::async_trait]
+impl Fairing for AttributionWorker {
+    fn info(&self) -> Info {
+        Info {
+            name: "confirmed trade attribution worker",
+            kind: Kind::Liftoff | Kind::Shutdown,
+        }
+    }
+
+    async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
+        if let Err(error) = record_attribution_signer(&self.app_pool, self.signer).await {
+            tracing::error!(%error, "failed to record current attribution signer at startup");
+        }
+        let worker = self.clone();
+        let mut shutdown = rocket.shutdown();
+        let handle = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(worker.interval);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown => {
+                        tracing::info!("attribution worker shutting down");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                    }
+                }
+
+                let sync = run_sync_iteration(&worker);
+                tokio::select! {
+                    _ = &mut shutdown => {
+                        tracing::info!("cancelling in-flight attribution sync during shutdown");
+                        break;
+                    }
+                    _ = sync => {}
+                }
+            }
+        });
+        *self.task.lock().await = Some(handle);
+    }
+
+    async fn on_shutdown(&self, _rocket: &Rocket<Orbit>) {
+        let handle = self.task.lock().await.take();
+        if let Some(handle) = handle {
+            finish_worker_task(handle, WORKER_SHUTDOWN_TIMEOUT).await;
+        }
+    }
+}
+
+async fn finish_worker_task(mut handle: JoinHandle<()>, timeout: Duration) {
+    match tokio::time::timeout(timeout, &mut handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::error!(%error, "attribution worker task failed during shutdown");
+        }
+        Err(_) => {
+            tracing::warn!("aborting attribution worker after shutdown timeout");
+            handle.abort();
+            if let Err(error) = handle.await {
+                if !error.is_cancelled() {
+                    tracing::error!(%error, "attribution worker abort failed");
+                }
+            }
+        }
+    }
+}
+
+async fn run_sync_iteration(worker: &AttributionWorker) {
+    match open_raindex_pool(&worker.raindex_db_path).await {
+        Ok(source_pool) => {
+            let result = process_available_trades(
+                &worker.app_pool,
+                &source_pool,
+                worker.signer,
+                worker.start_block,
+                worker.batch_size,
+            )
+            .await;
+            source_pool.close().await;
+            if let Err(error) = result {
+                tracing::error!(error = %error, "attribution sync failed");
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                path = %worker.raindex_db_path.display(),
+                "attribution source database is not ready"
+            );
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AttributionReportingError {
+    #[error("database query failed: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("attribution start block does not fit in SQLite INTEGER")]
+    StartBlockOverflow,
+}
+
+async fn open_raindex_pool(path: &Path) -> Result<SqlitePool, sqlx::Error> {
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .read_only(true)
+        .busy_timeout(Duration::from_secs(5));
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+}
+
+#[derive(Debug, FromRow)]
+struct SyncTarget {
+    chain_id: i64,
+    raindex_address: String,
+    last_indexed_block: i64,
+}
+
+#[derive(Debug, FromRow)]
+struct CursorRow {
+    start_block: i64,
+    last_block: i64,
+    last_log_index: i64,
+    last_trade_id: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct IndexedContextRow {
+    chain_id: i64,
+    raindex_address: String,
+    trade_id: String,
+    transaction_hash: String,
+    log_index: i64,
+    block_number: i64,
+    block_timestamp: i64,
+    transaction_sender: String,
+    order_hash: String,
+    input_token: String,
+    input_delta: String,
+    output_token: String,
+    output_delta: String,
+    context_index: Option<i64>,
+    context_value: Option<String>,
+    value_0: Option<String>,
+    value_1: Option<String>,
+    value_2: Option<String>,
+    value_3: Option<String>,
+    value_count: i64,
+}
+
+#[derive(Debug)]
+struct IndexedTrade {
+    chain_id: i64,
+    raindex_address: String,
+    trade_id: String,
+    transaction_hash: String,
+    log_index: i64,
+    block_number: i64,
+    block_timestamp: i64,
+    transaction_sender: String,
+    order_hash: String,
+    input_token: String,
+    input_delta: String,
+    output_token: String,
+    output_delta: String,
+    contexts: Vec<IndexedSignedContext>,
+}
+
+#[derive(Debug)]
+struct IndexedSignedContext {
+    encoded_signer_and_signature: String,
+    values: [String; ATTRIBUTION_CONTEXT_WORDS],
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct ApiKeyIdentity {
+    id: i64,
+    key_id: String,
+    label: String,
+    owner: String,
+}
+
+pub(crate) async fn process_available_trades(
+    app_pool: &DbPool,
+    source_pool: &SqlitePool,
+    signer: Address,
+    start_block: u64,
+    batch_size: u32,
+) -> Result<u64, AttributionReportingError> {
+    let start_block =
+        i64::try_from(start_block).map_err(|_| AttributionReportingError::StartBlockOverflow)?;
+    record_attribution_signer(app_pool, signer).await?;
+    let targets = sqlx::query_as::<_, SyncTarget>(
+        "SELECT chain_id, raindex_address, last_block AS last_indexed_block \
+         FROM target_watermarks WHERE chain_id = ? ORDER BY raindex_address",
+    )
+    .bind(i64::from(crate::CHAIN_ID))
+    .fetch_all(source_pool)
+    .await?;
+    snapshot_current_api_keys(app_pool).await?;
+    let identities = load_api_key_identities(app_pool).await?;
+    let identity_by_hash: HashMap<B256, ApiKeyIdentity> = identities
+        .into_iter()
+        .map(|identity| (compute_api_key_hash(&identity.key_id), identity))
+        .collect();
+
+    let mut attributed_count = 0;
+    let trusted_signers = load_attribution_signers(app_pool).await?;
+    for mut target in targets {
+        let mut source_transaction = source_pool.begin().await?;
+        let Some(last_indexed_block) = sqlx::query_scalar::<_, i64>(
+            "SELECT last_block FROM target_watermarks \
+             WHERE chain_id = ? AND raindex_address = ?",
+        )
+        .bind(target.chain_id)
+        .bind(&target.raindex_address)
+        .fetch_optional(&mut *source_transaction)
+        .await?
+        else {
+            source_transaction.commit().await?;
+            continue;
+        };
+        target.last_indexed_block = last_indexed_block;
+        attributed_count += process_target(
+            app_pool,
+            &mut source_transaction,
+            &trusted_signers,
+            start_block,
+            batch_size.max(1),
+            &target,
+            &identity_by_hash,
+        )
+        .await?;
+        source_transaction.commit().await?;
+    }
+    Ok(attributed_count)
+}
+
+async fn load_api_key_identities(app_pool: &DbPool) -> Result<Vec<ApiKeyIdentity>, sqlx::Error> {
+    sqlx::query_as::<_, ApiKeyIdentity>(
+        "SELECT api_key_database_id AS id, api_key_id AS key_id, \
+                api_key_label AS label, api_key_owner AS owner \
+         FROM attribution_api_keys ORDER BY api_key_id",
+    )
+    .fetch_all(app_pool)
+    .await
+}
+
+async fn snapshot_current_api_keys(app_pool: &DbPool) -> Result<(), sqlx::Error> {
+    let identities = sqlx::query_as::<_, ApiKeyIdentity>(
+        "SELECT id, key_id, label, owner FROM api_keys ORDER BY id",
+    )
+    .fetch_all(app_pool)
+    .await?;
+    let mut transaction = app_pool.begin().await?;
+    for identity in identities {
+        upsert_api_key_identity(&mut transaction, &identity).await?;
+    }
+    transaction.commit().await
+}
+
+async fn upsert_api_key_identity(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    identity: &ApiKeyIdentity,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO attribution_api_keys (\
+            api_key_hash, api_key_database_id, api_key_id, api_key_label, api_key_owner\
+         ) VALUES (?, ?, ?, ?, ?) \
+         ON CONFLICT(api_key_hash) DO UPDATE SET \
+            api_key_database_id = excluded.api_key_database_id, \
+            api_key_id = excluded.api_key_id, \
+            api_key_label = excluded.api_key_label, \
+            api_key_owner = excluded.api_key_owner, \
+            updated_at = datetime('now') \
+         WHERE api_key_database_id IS NOT excluded.api_key_database_id \
+            OR api_key_id IS NOT excluded.api_key_id \
+            OR api_key_label IS NOT excluded.api_key_label \
+            OR api_key_owner IS NOT excluded.api_key_owner",
+    )
+    .bind(compute_api_key_hash(&identity.key_id).to_string())
+    .bind(identity.id)
+    .bind(&identity.key_id)
+    .bind(&identity.label)
+    .bind(&identity.owner)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn snapshot_api_key(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    id: i64,
+    key_id: &str,
+    label: &str,
+    owner: &str,
+) -> Result<(), sqlx::Error> {
+    upsert_api_key_identity(
+        transaction,
+        &ApiKeyIdentity {
+            id,
+            key_id: key_id.to_string(),
+            label: label.to_string(),
+            owner: owner.to_string(),
+        },
+    )
+    .await
+}
+
+async fn record_attribution_signer(app_pool: &DbPool, signer: Address) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO attribution_signers (address) VALUES (?) \
+         ON CONFLICT(address) DO NOTHING",
+    )
+    .bind(signer.to_string())
+    .execute(app_pool)
+    .await?;
+    Ok(())
+}
+
+async fn load_attribution_signers(app_pool: &DbPool) -> Result<Vec<Address>, sqlx::Error> {
+    let values: Vec<String> =
+        sqlx::query_scalar("SELECT address FROM attribution_signers ORDER BY first_seen_at")
+            .fetch_all(app_pool)
+            .await?;
+    Ok(values
+        .into_iter()
+        .filter_map(|value| match Address::from_str(&value) {
+            Ok(address) => Some(address),
+            Err(error) => {
+                tracing::error!(%error, address = %value, "invalid trusted attribution signer");
+                None
+            }
+        })
+        .collect())
+}
+
+async fn process_target(
+    app_pool: &DbPool,
+    source_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    trusted_signers: &[Address],
+    configured_start_block: i64,
+    batch_size: u32,
+    target: &SyncTarget,
+    identities: &HashMap<B256, ApiKeyIdentity>,
+) -> Result<u64, AttributionReportingError> {
+    // The cursor read, attributed-trade upserts, and cursor update share one transaction.
+    // A concurrent worker therefore cannot commit a cursor derived from stale progress.
+    let mut transaction = app_pool.begin().await?;
+    let mut stored_cursor = sqlx::query_as::<_, CursorRow>(
+        "SELECT start_block, last_block, last_log_index, last_trade_id \
+         FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?",
+    )
+    .bind(target.chain_id)
+    .bind(&target.raindex_address)
+    .fetch_optional(&mut *transaction)
+    .await?;
+
+    let start_block_reset = stored_cursor
+        .as_ref()
+        .is_some_and(|cursor| cursor.start_block != configured_start_block);
+    if start_block_reset {
+        reset_target_start_block(&mut transaction, target, configured_start_block).await?;
+        stored_cursor = None;
+    }
+    let cursor = stored_cursor;
+    let last_block = cursor.as_ref().map_or(0, |cursor| cursor.last_block);
+    let last_log_index = cursor.as_ref().map_or(-1, |cursor| cursor.last_log_index);
+    let last_trade_id = cursor
+        .as_ref()
+        .map_or_else(String::new, |cursor| cursor.last_trade_id.clone());
+    let has_cursor = cursor.is_some();
+    let mut attributed_count = 0;
+
+    let rows = fetch_batch(
+        source_transaction,
+        target,
+        configured_start_block,
+        has_cursor,
+        last_block,
+        last_log_index,
+        &last_trade_id,
+        batch_size,
+    )
+    .await?;
+    let trades = group_context_rows(rows);
+    // Raindex materializes all derived rows through a target's watermark before advancing
+    // target_watermarks in the same source transaction. Because this function rereads the
+    // watermark and the rows from one source snapshot, a partial batch proves that every
+    // trade through last_indexed_block has been observed and can safely use the MAX sentinel.
+    let next_cursor = if trades.len() < batch_size as usize {
+        (target.last_indexed_block, i64::MAX, String::new())
+    } else {
+        let last_trade = trades
+            .last()
+            .ok_or_else(|| sqlx::Error::Protocol("non-empty attribution batch expected".into()))?;
+        (
+            last_trade.block_number,
+            last_trade.log_index,
+            last_trade.trade_id.clone(),
+        )
+    };
+
+    for trade in &trades {
+        let Some(api_key_hash) = trade
+            .contexts
+            .iter()
+            .find_map(|context| verify_context(context, trade, trusted_signers))
+        else {
+            continue;
+        };
+        let identity = identities.get(&api_key_hash);
+        sqlx::query(
+            "INSERT INTO attributed_trades (\
+                    chain_id, raindex_address, indexed_trade_id, transaction_hash, log_index, \
+                    block_number, block_timestamp, order_hash, taker, api_key_hash, \
+                    api_key_database_id, api_key_id, api_key_label, api_key_owner, \
+                    input_token, input_amount, \
+                    output_token, output_amount\
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+                 ON CONFLICT(chain_id, raindex_address, indexed_trade_id) DO UPDATE SET \
+                    api_key_database_id = excluded.api_key_database_id, \
+                    api_key_id = excluded.api_key_id, \
+                    api_key_label = excluded.api_key_label, \
+                    api_key_owner = excluded.api_key_owner, \
+                    updated_at = datetime('now')",
+        )
+        .bind(trade.chain_id)
+        .bind(&trade.raindex_address)
+        .bind(&trade.trade_id)
+        .bind(&trade.transaction_hash)
+        .bind(trade.log_index)
+        .bind(trade.block_number)
+        .bind(trade.block_timestamp)
+        .bind(&trade.order_hash)
+        .bind(&trade.transaction_sender)
+        .bind(api_key_hash.to_string())
+        .bind(identity.map(|value| value.id))
+        .bind(identity.map(|value| value.key_id.as_str()))
+        .bind(identity.map(|value| value.label.as_str()))
+        .bind(identity.map(|value| value.owner.as_str()))
+        .bind(&trade.input_token)
+        .bind(&trade.input_delta)
+        .bind(&trade.output_token)
+        .bind(&trade.output_delta)
+        .execute(&mut *transaction)
+        .await?;
+        attributed_count += 1;
+    }
+    sqlx::query(
+        "INSERT INTO attribution_sync_cursors (\
+                chain_id, raindex_address, start_block, last_block, last_log_index, last_trade_id\
+             ) VALUES (?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(chain_id, raindex_address) DO UPDATE SET \
+                start_block = excluded.start_block, \
+                last_block = excluded.last_block, \
+                last_log_index = excluded.last_log_index, \
+                last_trade_id = excluded.last_trade_id, \
+                updated_at = datetime('now')",
+    )
+    .bind(target.chain_id)
+    .bind(&target.raindex_address)
+    .bind(configured_start_block)
+    .bind(next_cursor.0)
+    .bind(next_cursor.1)
+    .bind(&next_cursor.2)
+    .execute(&mut *transaction)
+    .await?;
+    transaction.commit().await?;
+
+    if start_block_reset {
+        tracing::warn!(
+            chain_id = target.chain_id,
+            raindex_address = %target.raindex_address,
+            configured_start_block,
+            "attribution start block changed; target cursor reset"
+        );
+    }
+    if attributed_count > 0 {
+        tracing::info!(
+            chain_id = target.chain_id,
+            raindex_address = %target.raindex_address,
+            attributed_count,
+            last_indexed_block = target.last_indexed_block,
+            "confirmed trades attributed"
+        );
+    }
+    Ok(attributed_count)
+}
+
+async fn reset_target_start_block(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    target: &SyncTarget,
+    configured_start_block: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "DELETE FROM attributed_trades \
+         WHERE chain_id = ? AND raindex_address = ? AND block_number < ?",
+    )
+    .bind(target.chain_id)
+    .bind(&target.raindex_address)
+    .bind(configured_start_block)
+    .execute(&mut **transaction)
+    .await?;
+    sqlx::query("DELETE FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?")
+        .bind(target.chain_id)
+        .bind(&target.raindex_address)
+        .execute(&mut **transaction)
+        .await?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn fetch_batch(
+    source_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    target: &SyncTarget,
+    start_block: i64,
+    has_cursor: bool,
+    last_block: i64,
+    last_log_index: i64,
+    last_trade_id: &str,
+    batch_size: u32,
+) -> Result<Vec<IndexedContextRow>, sqlx::Error> {
+    sqlx::query_as::<_, IndexedContextRow>(
+        "WITH batch AS (\
+            SELECT chain_id, raindex_address, trade_id, transaction_hash, log_index, \
+                   block_number, block_timestamp, transaction_sender, order_hash, \
+                   input_token, input_delta, output_token, output_delta \
+            FROM derived_trades \
+            WHERE trade_kind = 'take' \
+              AND chain_id = ? AND raindex_address = ? \
+              AND block_number >= ? AND block_number <= ? \
+              AND (? = 0 OR block_number > ? \
+                   OR (block_number = ? AND log_index > ?) \
+                   OR (block_number = ? AND log_index = ? AND trade_id > ?)) \
+            ORDER BY block_number, log_index, trade_id \
+            LIMIT ?\
+         ) \
+         SELECT b.*, c.context_index, c.context_value, \
+                MAX(CASE WHEN v.value_index = 0 THEN v.value END) AS value_0, \
+                MAX(CASE WHEN v.value_index = 1 THEN v.value END) AS value_1, \
+                MAX(CASE WHEN v.value_index = 2 THEN v.value END) AS value_2, \
+                MAX(CASE WHEN v.value_index = 3 THEN v.value END) AS value_3, \
+                COUNT(v.value_index) AS value_count \
+         FROM batch b \
+         LEFT JOIN take_order_contexts c \
+           ON c.chain_id = b.chain_id \
+          AND c.raindex_address = b.raindex_address \
+          AND c.transaction_hash = b.transaction_hash \
+          AND c.log_index = b.log_index \
+         LEFT JOIN context_values v \
+           ON v.chain_id = c.chain_id \
+          AND v.raindex_address = c.raindex_address \
+          AND v.transaction_hash = c.transaction_hash \
+          AND v.log_index = c.log_index \
+          AND v.context_index = c.context_index \
+         GROUP BY b.chain_id, b.raindex_address, b.trade_id, b.transaction_hash, b.log_index, \
+                  b.block_number, b.block_timestamp, b.transaction_sender, b.order_hash, \
+                  b.input_token, b.input_delta, b.output_token, b.output_delta, \
+                  c.context_index, c.context_value \
+         ORDER BY b.block_number, b.log_index, b.trade_id, c.context_index",
+    )
+    .bind(target.chain_id)
+    .bind(&target.raindex_address)
+    .bind(start_block)
+    .bind(target.last_indexed_block)
+    .bind(has_cursor)
+    .bind(last_block)
+    .bind(last_block)
+    .bind(last_log_index)
+    .bind(last_block)
+    .bind(last_log_index)
+    .bind(last_trade_id)
+    .bind(i64::from(batch_size))
+    .fetch_all(&mut **source_transaction)
+    .await
+}
+
+fn group_context_rows(rows: Vec<IndexedContextRow>) -> Vec<IndexedTrade> {
+    let mut trades: Vec<IndexedTrade> = Vec::new();
+    for row in rows {
+        let is_new_trade = trades.last().is_none_or(|trade| {
+            trade.chain_id != row.chain_id
+                || trade.raindex_address != row.raindex_address
+                || trade.trade_id != row.trade_id
+        });
+        if is_new_trade {
+            trades.push(IndexedTrade {
+                chain_id: row.chain_id,
+                raindex_address: row.raindex_address.clone(),
+                trade_id: row.trade_id.clone(),
+                transaction_hash: row.transaction_hash.clone(),
+                log_index: row.log_index,
+                block_number: row.block_number,
+                block_timestamp: row.block_timestamp,
+                transaction_sender: row.transaction_sender.clone(),
+                order_hash: row.order_hash.clone(),
+                input_token: row.input_token.clone(),
+                input_delta: row.input_delta.clone(),
+                output_token: row.output_token.clone(),
+                output_delta: row.output_delta.clone(),
+                contexts: Vec::new(),
+            });
+        }
+
+        let values = match (
+            row.value_0,
+            row.value_1,
+            row.value_2,
+            row.value_3,
+            row.value_count,
+        ) {
+            (Some(v0), Some(v1), Some(v2), Some(v3), 4) => Some([v0, v1, v2, v3]),
+            _ => None,
+        };
+        if row.context_index.is_some() {
+            if let (Some(context_value), Some(values), Some(trade)) =
+                (row.context_value, values, trades.last_mut())
+            {
+                trade.contexts.push(IndexedSignedContext {
+                    encoded_signer_and_signature: context_value,
+                    values,
+                });
+            }
+        }
+    }
+    trades
+}
+
+fn verify_context(
+    candidate: &IndexedSignedContext,
+    trade: &IndexedTrade,
+    trusted_signers: &[Address],
+) -> Option<B256> {
+    let (signer, signature) = parse_signer_and_signature(&candidate.encoded_signer_and_signature)?;
+    let context = candidate
+        .values
+        .iter()
+        .map(|value| B256::from_str(value).ok())
+        .collect::<Option<Vec<_>>>()?;
+    // RaindexV6 records TakeOrderV3.sender (the immediate orderbook caller) as
+    // transaction_sender. Generated attribution deliberately binds that same caller as the
+    // taker. A relayer must request calldata with its own calling address; forwarding context
+    // signed for a different EOA is rejected instead of being attributed to the wrong customer.
+    let taker = Address::from_str(&trade.transaction_sender).ok()?;
+    let order_hash = B256::from_str(&trade.order_hash).ok()?;
+    if !trusted_signers.contains(&signer) {
+        return None;
+    }
+    verify_signed_attribution(
+        &SignedContextV1 {
+            signer,
+            context,
+            signature,
+        },
+        signer,
+        taker,
+        order_hash,
+    )
+}
+
+fn parse_signer_and_signature(value: &str) -> Option<(Address, Bytes)> {
+    let value = value.strip_prefix("signer:")?;
+    let (signer, signature) = value.split_once(",signature:")?;
+    let signer = Address::from_str(signer).ok()?;
+    let signature = signature.strip_prefix("0x").unwrap_or(signature);
+    let bytes = alloy::hex::decode(signature).ok()?;
+    Some((signer, Bytes::from(bytes)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attribution::{Attribution, AttributionSigner};
+    use alloy::primitives::address;
+    use rain_math_float::Float;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tempfile::NamedTempFile;
+
+    const TEST_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    const ORDER_HASH: B256 = B256::new([0x33; 32]);
+    const TAKER: Address = address!("A9d6ab42f32dC476269dB2407715D8c15A36D781");
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    async fn source_pool() -> SqlitePool {
+        let file = NamedTempFile::new().expect("source file");
+        let path = file.into_temp_path().keep().expect("persist source file");
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(
+                SqliteConnectOptions::new()
+                    .filename(path)
+                    .create_if_missing(true),
+            )
+            .await
+            .expect("source pool");
+        sqlx::raw_sql(rain_orderbook_common::local_db::query::create_tables::create_tables_sql())
+            .execute(&pool)
+            .await
+            .expect("source schema");
+        pool
+    }
+
+    async fn app_pool() -> DbPool {
+        crate::db::init(
+            &format!(
+                "sqlite:file:{}?mode=memory&cache=shared",
+                uuid::Uuid::new_v4()
+            ),
+            2,
+        )
+        .await
+        .expect("app pool")
+    }
+
+    #[tokio::test]
+    async fn shutdown_timeout_aborts_a_stuck_worker() {
+        let dropped = Arc::new(AtomicBool::new(false));
+        let task_flag = Arc::clone(&dropped);
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(async move {
+            let _drop_flag = DropFlag(task_flag);
+            let _ = started_tx.send(());
+            std::future::pending::<()>().await;
+        });
+        started_rx.await.expect("worker started");
+
+        finish_worker_task(handle, Duration::from_millis(1)).await;
+
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    async fn seed_trade_at(
+        source: &SqlitePool,
+        key_id: &str,
+        trade_id: &str,
+        transaction_hash: &str,
+        log_index: i64,
+        block_number: i64,
+        watermark: i64,
+    ) {
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+        let attribution = Attribution {
+            api_key_hash: compute_api_key_hash(key_id),
+            taker: TAKER,
+        };
+        let signed = signer
+            .sign_context(&attribution, ORDER_HASH)
+            .await
+            .expect("signed context");
+        let input = Float::parse("0.001".to_string())
+            .expect("input float")
+            .as_hex();
+        let output = Float::parse("-0.205184".to_string())
+            .expect("output float")
+            .as_hex();
+        let raindex = "0x1111111111111111111111111111111111111111";
+        let tx_hash = transaction_hash.to_string();
+        // Match Raindex ingestion: derived rows and their watermark become visible atomically,
+        // with the watermark written only after all rows through that block are materialized.
+        let mut transaction = source.begin().await.expect("source transaction");
+        sqlx::query(
+            "INSERT INTO derived_trades (\
+                chain_id, raindex_address, trade_id, trade_kind, trade_side, \
+                order_hash, order_owner, order_nonce, transaction_hash, log_index, \
+                block_number, block_timestamp, transaction_sender, input_vault_id, \
+                input_token, input_delta, output_vault_id, output_token, output_delta\
+             ) VALUES (?, ?, ?, 'take', 'sell', ?, ?, '0', ?, ?, ?, ?, ?, '0', ?, ?, '0', ?, ?)",
+        )
+        .bind(i64::from(crate::CHAIN_ID))
+        .bind(raindex)
+        .bind(trade_id)
+        .bind(ORDER_HASH.to_string())
+        .bind(signer.address().to_string())
+        .bind(&tx_hash)
+        .bind(log_index)
+        .bind(block_number)
+        .bind(1_753_000_000_i64)
+        .bind(TAKER.to_string())
+        .bind("0x2222222222222222222222222222222222222222")
+        .bind(input)
+        .bind("0x3333333333333333333333333333333333333333")
+        .bind(output)
+        .execute(&mut *transaction)
+        .await
+        .expect("trade");
+        let context_value = format!(
+            "signer:{},signature:{}",
+            signer.address(),
+            alloy::hex::encode_prefixed(signed.signature)
+        );
+        sqlx::query(
+            "INSERT INTO take_orders (\
+                chain_id, raindex_address, transaction_hash, log_index, block_number, \
+                block_timestamp, sender, order_owner, order_nonce, input_io_index, \
+                output_io_index, taker_input, taker_output\
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '0', 0, 0, ?, ?)",
+        )
+        .bind(i64::from(crate::CHAIN_ID))
+        .bind(raindex)
+        .bind(&tx_hash)
+        .bind(log_index)
+        .bind(block_number)
+        .bind(1_753_000_000_i64)
+        .bind(TAKER.to_string())
+        .bind(signer.address().to_string())
+        .bind("0.001")
+        .bind("0.205184")
+        .execute(&mut *transaction)
+        .await
+        .expect("take order");
+        sqlx::query(
+            "INSERT INTO take_order_contexts (\
+                chain_id, raindex_address, transaction_hash, log_index, \
+                context_index, context_value\
+             ) VALUES (?, ?, ?, ?, 0, ?)",
+        )
+        .bind(i64::from(crate::CHAIN_ID))
+        .bind(raindex)
+        .bind(&tx_hash)
+        .bind(log_index)
+        .bind(context_value)
+        .execute(&mut *transaction)
+        .await
+        .expect("context");
+        for (index, value) in signed.context.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO context_values (\
+                    chain_id, raindex_address, transaction_hash, log_index, \
+                    context_index, value_index, value\
+                 ) VALUES (?, ?, ?, ?, 0, ?, ?)",
+            )
+            .bind(i64::from(crate::CHAIN_ID))
+            .bind(raindex)
+            .bind(&tx_hash)
+            .bind(log_index)
+            .bind(i64::try_from(index).expect("context index"))
+            .bind(value.to_string())
+            .execute(&mut *transaction)
+            .await
+            .expect("context value");
+        }
+        sqlx::query(
+            "INSERT INTO target_watermarks (chain_id, raindex_address, last_block) \
+             VALUES (?, ?, ?) \
+             ON CONFLICT(chain_id, raindex_address) DO UPDATE SET last_block = excluded.last_block",
+        )
+        .bind(i64::from(crate::CHAIN_ID))
+        .bind(raindex)
+        .bind(watermark)
+        .execute(&mut *transaction)
+        .await
+        .expect("sync target");
+        transaction.commit().await.expect("source commit");
+    }
+
+    async fn seed_trade(source: &SqlitePool, key_id: &str) {
+        seed_trade_at(
+            source,
+            key_id,
+            "0x01",
+            "0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f",
+            7,
+            48_963_501,
+            48_963_501,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn attributes_confirmed_trade_and_advances_cursor_idempotently() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', ?, ?)",
+        )
+        .bind(key_id)
+        .bind("Customer")
+        .bind("customer@example.com")
+        .execute(&app)
+        .await
+        .expect("API key");
+        seed_trade(&source, key_id).await;
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let first = process_available_trades(&app, &source, signer.address(), 48_963_501, 100)
+            .await
+            .expect("first sync");
+        let second = process_available_trades(&app, &source, signer.address(), 48_963_501, 100)
+            .await
+            .expect("second sync");
+        assert_eq!(first, 1);
+        assert_eq!(second, 0);
+
+        let row: (String, String, String, String) = sqlx::query_as(
+            "SELECT transaction_hash, api_key_id, api_key_label, api_key_owner \
+             FROM attributed_trades",
+        )
+        .fetch_one(&app)
+        .await
+        .expect("attributed trade");
+        assert_eq!(
+            row.0,
+            "0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f"
+        );
+        assert_eq!(row.1, key_id);
+        assert_eq!(row.2, "Customer");
+        assert_eq!(row.3, "customer@example.com");
+
+        let cursor: (i64, i64) =
+            sqlx::query_as("SELECT start_block, last_block FROM attribution_sync_cursors")
+                .fetch_one(&app)
+                .await
+                .expect("cursor");
+        assert_eq!(cursor, (48_963_501, 48_963_501));
+
+        process_available_trades(&app, &source, signer.address(), 48_963_502, 100)
+            .await
+            .expect("raise start block");
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attributed_trades")
+            .fetch_one(&app)
+            .await
+            .expect("remaining attributed trades");
+        assert_eq!(remaining, 0);
+    }
+
+    #[tokio::test]
+    async fn ignores_trade_before_configured_start_block() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        seed_trade(&source, "customer-key").await;
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let count = process_available_trades(&app, &source, signer.address(), 48_963_502, 100)
+            .await
+            .expect("sync");
+        assert_eq!(count, 0);
+        let stored: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attributed_trades")
+            .fetch_one(&app)
+            .await
+            .expect("count");
+        assert_eq!(stored, 0);
+        let checkpoint: (i64, i64) =
+            sqlx::query_as("SELECT last_block, last_log_index FROM attribution_sync_cursors")
+                .fetch_one(&app)
+                .await
+                .expect("empty range checkpoint");
+        assert_eq!(checkpoint, (48_963_501, i64::MAX));
+
+        process_available_trades(&app, &source, signer.address(), 48_963_503, 100)
+            .await
+            .expect("changed start block resets the derived reporting cursor");
+        let reset_start: i64 =
+            sqlx::query_scalar("SELECT start_block FROM attribution_sync_cursors")
+                .fetch_one(&app)
+                .await
+                .expect("reset cursor");
+        assert_eq!(reset_start, 48_963_503);
+    }
+
+    #[tokio::test]
+    async fn partial_batch_advances_to_complete_source_watermark() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', '', '')",
+        )
+        .bind(key_id)
+        .execute(&app)
+        .await
+        .expect("API key");
+        seed_trade_at(
+            &source,
+            key_id,
+            "0x01",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            7,
+            48_963_501,
+            48_963_502,
+        )
+        .await;
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let count = process_available_trades(&app, &source, signer.address(), 48_963_501, 100)
+            .await
+            .expect("partial batch");
+        assert_eq!(count, 1);
+        let cursor: (i64, i64) =
+            sqlx::query_as("SELECT last_block, last_log_index FROM attribution_sync_cursors")
+                .fetch_one(&app)
+                .await
+                .expect("watermark cursor");
+        assert_eq!(cursor, (48_963_502, i64::MAX));
+
+        seed_trade_at(
+            &source,
+            key_id,
+            "0x02",
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+            1,
+            48_963_503,
+            48_963_503,
+        )
+        .await;
+        let next = process_available_trades(&app, &source, signer.address(), 48_963_501, 100)
+            .await
+            .expect("next complete watermark");
+        assert_eq!(next, 1);
+    }
+
+    #[tokio::test]
+    async fn attributed_rows_and_cursor_commit_atomically() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', '', '')",
+        )
+        .bind(key_id)
+        .execute(&app)
+        .await
+        .expect("API key");
+        seed_trade(&source, key_id).await;
+        sqlx::query(
+            "CREATE TRIGGER reject_attribution_cursor \
+             BEFORE INSERT ON attribution_sync_cursors \
+             BEGIN SELECT RAISE(FAIL, 'cursor rejected'); END",
+        )
+        .execute(&app)
+        .await
+        .expect("cursor trigger");
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let result =
+            process_available_trades(&app, &source, signer.address(), 48_963_501, 100).await;
+        assert!(result.is_err());
+        let trade_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attributed_trades")
+            .fetch_one(&app)
+            .await
+            .expect("trade count");
+        let cursor_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attribution_sync_cursors")
+            .fetch_one(&app)
+            .await
+            .expect("cursor count");
+        assert_eq!((trade_count, cursor_count), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn rejects_context_signed_for_a_different_orderbook_caller() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', '', '')",
+        )
+        .bind(key_id)
+        .execute(&app)
+        .await
+        .expect("API key");
+        seed_trade(&source, key_id).await;
+        sqlx::query("UPDATE derived_trades SET transaction_sender = ?")
+            .bind(Address::from([0x55; 20]).to_string())
+            .execute(&source)
+            .await
+            .expect("relayed caller");
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let count = process_available_trades(&app, &source, signer.address(), 48_963_501, 100)
+            .await
+            .expect("sync");
+        assert_eq!(count, 0);
+        let stored: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attributed_trades")
+            .fetch_one(&app)
+            .await
+            .expect("attributed count");
+        assert_eq!(stored, 0);
+    }
+
+    #[tokio::test]
+    async fn full_batches_resume_without_skipping_shared_event_positions() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', '', '')",
+        )
+        .bind(key_id)
+        .execute(&app)
+        .await
+        .expect("API key");
+        seed_trade_at(
+            &source,
+            key_id,
+            "0x01",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            7,
+            48_963_501,
+            48_963_502,
+        )
+        .await;
+        seed_trade_at(
+            &source,
+            key_id,
+            "0x02",
+            "0x0000000000000000000000000000000000000000000000000000000000000002",
+            7,
+            48_963_501,
+            48_963_502,
+        )
+        .await;
+        seed_trade_at(
+            &source,
+            key_id,
+            "0x03",
+            "0x0000000000000000000000000000000000000000000000000000000000000003",
+            1,
+            48_963_502,
+            48_963_502,
+        )
+        .await;
+        let signer = AttributionSigner::from_hex_key(TEST_KEY).expect("signer");
+
+        let first = process_available_trades(&app, &source, signer.address(), 48_963_501, 2)
+            .await
+            .expect("first batch");
+        let second = process_available_trades(&app, &source, signer.address(), 48_963_501, 2)
+            .await
+            .expect("second batch");
+        let third = process_available_trades(&app, &source, signer.address(), 48_963_501, 2)
+            .await
+            .expect("empty tail");
+        assert_eq!((first, second, third), (2, 1, 0));
+
+        let stored: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attributed_trades")
+            .fetch_one(&app)
+            .await
+            .expect("attributed count");
+        assert_eq!(stored, 3);
+        let cursor: (i64, i64) =
+            sqlx::query_as("SELECT last_block, last_log_index FROM attribution_sync_cursors")
+                .fetch_one(&app)
+                .await
+                .expect("final cursor");
+        assert_eq!(cursor, (48_963_502, i64::MAX));
+    }
+
+    #[tokio::test]
+    async fn trusts_signers_recorded_before_key_rotation() {
+        let app = app_pool().await;
+        let source = source_pool().await;
+        let key_id = "customer-key";
+        sqlx::query(
+            "INSERT INTO api_keys (key_id, secret_hash, label, owner) VALUES (?, 'hash', '', '')",
+        )
+        .bind(key_id)
+        .execute(&app)
+        .await
+        .expect("API key");
+        let old_signer = AttributionSigner::from_hex_key(TEST_KEY).expect("old signer");
+        process_available_trades(&app, &source, old_signer.address(), 48_963_501, 100)
+            .await
+            .expect("record old signer");
+        seed_trade(&source, key_id).await;
+
+        let new_signer = Address::from([0x44; 20]);
+        let count = process_available_trades(&app, &source, new_signer, 48_963_501, 100)
+            .await
+            .expect("process after rotation");
+        assert_eq!(count, 1);
+        let signer_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM attribution_signers")
+            .fetch_one(&app)
+            .await
+            .expect("trusted signer count");
+        assert_eq!(signer_count, 2);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,7 +88,11 @@ async fn create_key(
     let secret_hash =
         auth::hash_secret(&secret).map_err(|e| format!("failed to hash secret: {e}"))?;
 
-    sqlx::query(
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|e| format!("failed to begin API key transaction: {e}"))?;
+    let insert = sqlx::query(
         "INSERT INTO api_keys (key_id, secret_hash, label, owner, is_admin) VALUES (?, ?, ?, ?, ?)",
     )
     .bind(&key_id)
@@ -96,9 +100,22 @@ async fn create_key(
     .bind(label)
     .bind(owner)
     .bind(admin)
-    .execute(pool)
+    .execute(&mut *transaction)
     .await
     .map_err(|e| format!("failed to insert API key: {e}"))?;
+    crate::attribution_reporting::snapshot_api_key(
+        &mut transaction,
+        insert.last_insert_rowid(),
+        &key_id,
+        label,
+        owner,
+    )
+    .await
+    .map_err(|e| format!("failed to snapshot API key attribution identity: {e}"))?;
+    transaction
+        .commit()
+        .await
+        .map_err(|e| format!("failed to commit API key transaction: {e}"))?;
 
     tracing::info!(key_id = %key_id, label = %label, owner = %owner, admin = %admin, "API key created");
 
@@ -172,15 +189,40 @@ async fn revoke_key(pool: &DbPool, key_id: &str) -> Result<(), Box<dyn std::erro
 }
 
 async fn delete_key(pool: &DbPool, key_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut transaction = pool
+        .begin()
+        .await
+        .map_err(|e| format!("failed to begin API key deletion: {e}"))?;
+    let identity: Option<(i64, String, String)> =
+        sqlx::query_as("SELECT id, label, owner FROM api_keys WHERE key_id = ?")
+            .bind(key_id)
+            .fetch_optional(&mut *transaction)
+            .await
+            .map_err(|e| format!("failed to query API key before deletion: {e}"))?;
+    if let Some((id, label, owner)) = identity {
+        crate::attribution_reporting::snapshot_api_key(
+            &mut transaction,
+            id,
+            key_id,
+            &label,
+            &owner,
+        )
+        .await
+        .map_err(|e| format!("failed to preserve API key attribution identity: {e}"))?;
+    }
     let result = sqlx::query("DELETE FROM api_keys WHERE key_id = ?")
         .bind(key_id)
-        .execute(pool)
+        .execute(&mut *transaction)
         .await
         .map_err(|e| format!("failed to delete API key: {e}"))?;
 
     if result.rows_affected() == 0 {
         return Err(format!("API key {key_id} not found").into());
     }
+    transaction
+        .commit()
+        .await
+        .map_err(|e| format!("failed to commit API key deletion: {e}"))?;
 
     tracing::info!(key_id = %key_id, "API key deleted");
     println!("API key {key_id} deleted successfully");
@@ -265,6 +307,12 @@ mod tests {
         assert!(row.active);
         assert!(!row.is_admin);
         assert!(PasswordHash::new(&row.secret_hash).is_ok());
+        let snapshotted_key_id: String =
+            sqlx::query_scalar("SELECT api_key_id FROM attribution_api_keys")
+                .fetch_one(&pool)
+                .await
+                .expect("attribution identity");
+        assert_eq!(snapshotted_key_id, row.key_id);
     }
 
     #[tokio::test]
@@ -339,6 +387,13 @@ mod tests {
             .await
             .expect("count");
         assert_eq!(count, 0);
+        let preserved: String =
+            sqlx::query_scalar("SELECT api_key_id FROM attribution_api_keys WHERE api_key_id = ?")
+                .bind(&key_id)
+                .fetch_one(&pool)
+                .await
+                .expect("preserved attribution identity");
+        assert_eq!(preserved, key_id);
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,12 @@ pub struct Config {
     pub rate_limit_per_key_rpm: u64,
     pub docs_dir: String,
     pub local_db_path: String,
+    #[serde(default)]
+    pub attribution_start_block: Option<u64>,
+    #[serde(default = "default_attribution_sync_interval_seconds")]
+    pub attribution_sync_interval_seconds: u64,
+    #[serde(default = "default_attribution_sync_batch_size")]
+    pub attribution_sync_batch_size: u32,
     /// OTLP export target. Absent ⇒ console + file logging only (no push to the
     /// observability stack). Non-secret plaintext (tailnet endpoints).
     #[serde(default)]
@@ -35,6 +41,14 @@ pub struct TelemetryConfig {
     pub environment: String,
     pub traces_endpoint: Url,
     pub logs_endpoint: Url,
+}
+
+fn default_attribution_sync_interval_seconds() -> u64 {
+    60
+}
+
+fn default_attribution_sync_batch_size() -> u32 {
+    250
 }
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate rocket;
 mod analytics;
 mod app_state;
 mod attribution;
+mod attribution_reporting;
 mod auth;
 mod cache;
 mod catchers;
@@ -132,6 +133,8 @@ enum StartupRegistryError {
         routes::vaults::get_vaults,
         routes::vaults::get_vault_totals,
         routes::admin::put_registry,
+        routes::attribution_admin::get_attributed_executions,
+        routes::attribution_admin::get_attribution_volume,
         routes::trades::get_by_tx::get_trades_by_tx,
         routes::trades::get_by_order_hashes::get_trades_by_order_hashes,
         routes::trades::get_by_token::get_trades_by_token,
@@ -217,6 +220,7 @@ pub(crate) fn rocket(
         .mount("/v1/trades", routes::trades::routes())
         .mount("/", routes::registry::routes())
         .mount("/admin", routes::admin::routes())
+        .mount("/admin/attribution", routes::attribution_admin::routes())
         .mount("/docs", FileServer::new(docs_dir, options))
         .mount(
             "/",
@@ -461,6 +465,7 @@ async fn main() {
                 signer = %attribution_signer.address(),
                 "attribution signer loaded"
             );
+            let attribution_signer_address = attribution_signer.address();
             let attribution_state = attribution::AttributionState::new(attribution_signer);
             let app_state = app_state::ApplicationState::new(
                 registry_artifact_store,
@@ -470,7 +475,8 @@ async fn main() {
 
             let analytics = analytics::Analytics::from_env();
 
-            let rocket = match rocket(
+            let attribution_pool = pool.clone();
+            let mut rocket = match rocket(
                 pool,
                 rate_limiter,
                 shared_raindex,
@@ -486,6 +492,25 @@ async fn main() {
                     std::process::exit(1);
                 }
             };
+
+            if let Some(start_block) = cfg.attribution_start_block {
+                tracing::info!(
+                    start_block,
+                    interval_seconds = cfg.attribution_sync_interval_seconds,
+                    batch_size = cfg.attribution_sync_batch_size,
+                    "confirmed trade attribution worker enabled"
+                );
+                rocket = rocket.attach(attribution_reporting::AttributionWorker::new(
+                    attribution_pool,
+                    std::path::PathBuf::from(&cfg.local_db_path),
+                    attribution_signer_address,
+                    start_block,
+                    std::time::Duration::from_secs(cfg.attribution_sync_interval_seconds.max(1)),
+                    cfg.attribution_sync_batch_size,
+                ));
+            } else {
+                tracing::info!("confirmed trade attribution worker disabled");
+            }
 
             if let Err(e) = rocket.launch().await {
                 tracing::error!(error = %e, "Rocket launch failed");
@@ -641,6 +666,48 @@ mod tests {
             .any(|parameter| parameter["name"] == "activity_limit"));
     }
 
+    #[test]
+    fn test_openapi_documents_attribution_query_names() {
+        let openapi = serde_json::to_value(super::ApiDoc::openapi()).expect("serialize openapi");
+        let execution_parameters = openapi["paths"]["/admin/attribution/executions"]["get"]
+            ["parameters"]
+            .as_array()
+            .expect("parameters is an array");
+        let execution_names: Vec<&str> = execution_parameters
+            .iter()
+            .filter_map(|parameter| parameter["name"].as_str())
+            .collect();
+        assert!(execution_names.contains(&"apiKeyHash"));
+        assert!(execution_names.contains(&"transactionHash"));
+        assert!(execution_names.contains(&"beforeBlock"));
+        assert!(execution_names.contains(&"beforeLogIndex"));
+        assert!(execution_names.contains(&"beforeTradeId"));
+        assert!(!execution_names.contains(&"api_key_hash"));
+
+        let volume_parameters = openapi["paths"]["/admin/attribution/volume"]["get"]["parameters"]
+            .as_array()
+            .expect("parameters is an array");
+        let volume_names: Vec<&str> = volume_parameters
+            .iter()
+            .filter_map(|parameter| parameter["name"].as_str())
+            .collect();
+        assert!(volume_names.contains(&"limit"));
+        assert!(volume_names.contains(&"afterApiKeyHash"));
+        assert!(volume_names.contains(&"afterChainId"));
+        assert!(volume_names.contains(&"afterInputToken"));
+        assert!(volume_names.contains(&"afterOutputToken"));
+
+        let schemas = &openapi["components"]["schemas"];
+        assert_eq!(
+            schemas["AttributedExecution"]["properties"]["apiKeyLabel"]["description"],
+            "API key identity captured when this execution was attributed."
+        );
+        assert_eq!(
+            schemas["AttributionVolume"]["properties"]["apiKeyLabel"]["description"],
+            "Latest known identity for this API key hash, rather than an execution-time snapshot."
+        );
+    }
+
     fn test_config(
         registry_url: String,
         private_registry_path: std::path::PathBuf,
@@ -662,6 +729,9 @@ mod tests {
             docs_dir: "./docs/book".to_string(),
             local_db_path: local_db_path.to_string_lossy().into_owned(),
             telemetry: None,
+            attribution_start_block: None,
+            attribution_sync_interval_seconds: 60,
+            attribution_sync_batch_size: 250,
         }
     }
 

--- a/src/routes/attribution_admin.rs
+++ b/src/routes/attribution_admin.rs
@@ -1,0 +1,989 @@
+use crate::auth::AdminKey;
+use crate::db::DbPool;
+use crate::error::{ApiError, ApiErrorResponse};
+use crate::fairings::{GlobalRateLimit, TracingSpan};
+use alloy::primitives::{Address, B256};
+use futures::TryStreamExt;
+use rain_math_float::Float;
+use rocket::form::FromForm;
+use rocket::serde::json::Json;
+use rocket::{Route, State};
+use serde::Serialize;
+use sqlx::{FromRow, QueryBuilder, Sqlite};
+use std::ops::{Add, Sub};
+use std::str::FromStr;
+use tracing::Instrument;
+use utoipa::{IntoParams, ToSchema};
+
+#[derive(Debug, FromForm, IntoParams)]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
+pub struct AttributionVolumeParams {
+    #[field(name = "apiKeyHash")]
+    pub api_key_hash: Option<String>,
+    #[field(name = "startBlock")]
+    pub start_block: Option<u64>,
+    #[field(name = "endBlock")]
+    pub end_block: Option<u64>,
+    #[field(name = "afterApiKeyHash")]
+    pub after_api_key_hash: Option<String>,
+    #[field(name = "afterChainId")]
+    pub after_chain_id: Option<u32>,
+    #[field(name = "afterInputToken")]
+    pub after_input_token: Option<String>,
+    #[field(name = "afterOutputToken")]
+    pub after_output_token: Option<String>,
+    #[field(name = "limit")]
+    #[param(minimum = 1, maximum = 1000, default = 100)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, FromForm, IntoParams)]
+#[into_params(parameter_in = Query, rename_all = "camelCase")]
+pub struct AttributionExecutionParams {
+    #[field(name = "apiKeyHash")]
+    pub api_key_hash: Option<String>,
+    #[field(name = "startBlock")]
+    pub start_block: Option<u64>,
+    #[field(name = "endBlock")]
+    pub end_block: Option<u64>,
+    #[field(name = "transactionHash")]
+    pub transaction_hash: Option<String>,
+    #[field(name = "beforeBlock")]
+    pub before_block: Option<u64>,
+    #[field(name = "beforeLogIndex")]
+    pub before_log_index: Option<u64>,
+    #[field(name = "beforeTradeId")]
+    pub before_trade_id: Option<String>,
+    #[field(name = "limit")]
+    #[param(minimum = 1, maximum = 1000, default = 100)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributedExecution {
+    pub indexed_trade_id: String,
+    pub chain_id: u32,
+    pub raindex_address: String,
+    pub transaction_hash: String,
+    pub log_index: u64,
+    pub block_number: u64,
+    pub block_timestamp: u64,
+    pub order_hash: String,
+    pub taker: String,
+    pub api_key_hash: String,
+    /// API key identity captured when this execution was attributed.
+    pub api_key_database_id: Option<i64>,
+    /// API key identity captured when this execution was attributed.
+    pub api_key_id: Option<String>,
+    /// API key identity captured when this execution was attributed.
+    pub api_key_label: Option<String>,
+    /// API key identity captured when this execution was attributed.
+    pub api_key_owner: Option<String>,
+    pub input_token: String,
+    pub input_amount: String,
+    pub output_token: String,
+    pub output_amount: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionExecutionsResponse {
+    pub executions: Vec<AttributedExecution>,
+    pub next_cursor: Option<AttributionExecutionCursor>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionExecutionCursor {
+    pub before_block: u64,
+    pub before_log_index: u64,
+    pub before_trade_id: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionVolume {
+    pub api_key_hash: String,
+    /// Latest known identity for this API key hash, rather than an execution-time snapshot.
+    pub api_key_database_id: Option<i64>,
+    /// Latest known identity for this API key hash, rather than an execution-time snapshot.
+    pub api_key_id: Option<String>,
+    /// Latest known identity for this API key hash, rather than an execution-time snapshot.
+    pub api_key_label: Option<String>,
+    /// Latest known identity for this API key hash, rather than an execution-time snapshot.
+    pub api_key_owner: Option<String>,
+    pub chain_id: u32,
+    pub input_token: String,
+    pub output_token: String,
+    pub trade_count: u64,
+    pub total_input_amount: String,
+    pub total_output_amount: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionVolumeResponse {
+    pub volume: Vec<AttributionVolume>,
+    pub next_cursor: Option<AttributionVolumeCursor>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AttributionVolumeCursor {
+    pub after_api_key_hash: String,
+    pub after_chain_id: u32,
+    pub after_input_token: String,
+    pub after_output_token: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct AttributedTradeRow {
+    indexed_trade_id: String,
+    chain_id: i64,
+    raindex_address: String,
+    transaction_hash: String,
+    log_index: i64,
+    block_number: i64,
+    block_timestamp: i64,
+    order_hash: String,
+    taker: String,
+    api_key_hash: String,
+    api_key_database_id: Option<i64>,
+    api_key_id: Option<String>,
+    api_key_label: Option<String>,
+    api_key_owner: Option<String>,
+    input_token: String,
+    input_amount: String,
+    output_token: String,
+    output_amount: String,
+}
+
+#[derive(Debug, FromRow)]
+struct AttributionVolumeRow {
+    chain_id: i64,
+    api_key_hash: String,
+    api_key_database_id: Option<i64>,
+    api_key_id: Option<String>,
+    api_key_label: Option<String>,
+    api_key_owner: Option<String>,
+    input_token: String,
+    input_amount: String,
+    output_token: String,
+    output_amount: String,
+}
+
+#[derive(Debug)]
+struct VolumeGroup {
+    key: VolumeKey,
+    api_key_database_id: Option<i64>,
+    api_key_id: Option<String>,
+    api_key_label: Option<String>,
+    api_key_owner: Option<String>,
+    accumulator: VolumeAccumulator,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct VolumeKey {
+    api_key_hash: String,
+    chain_id: i64,
+    input_token: String,
+    output_token: String,
+}
+
+#[derive(Debug)]
+struct VolumeAccumulator {
+    trade_count: u64,
+    total_input: Float,
+    total_output: Float,
+}
+
+struct ExecutionCursorFilter<'a> {
+    block: i64,
+    log_index: i64,
+    trade_id: &'a str,
+}
+
+struct VolumeCursorFilter {
+    api_key_hash: String,
+    chain_id: i64,
+    input_token: String,
+    output_token: String,
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/attribution/executions",
+    tag = "Admin",
+    security(("basicAuth" = [])),
+    params(AttributionExecutionParams),
+    responses(
+        (status = 200, description = "Confirmed attributed executions", body = AttributionExecutionsResponse),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse),
+        (status = 422, description = "Invalid query parameters", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[get("/executions?<params..>")]
+pub async fn get_attributed_executions(
+    _global: GlobalRateLimit,
+    admin: AdminKey,
+    pool: &State<DbPool>,
+    span: TracingSpan,
+    params: AttributionExecutionParams,
+) -> Result<Json<AttributionExecutionsResponse>, ApiError> {
+    async move {
+        tracing::info!(
+            admin_key_id = %admin.0.key_id,
+            params = ?params,
+            "attribution executions request received"
+        );
+        validate_block_range(params.start_block, params.end_block)?;
+        let limit = params.limit.unwrap_or(100).clamp(1, 1000);
+        let cursor = execution_cursor_filter(&params)?;
+        let api_key_hash = normalize_hash(params.api_key_hash.as_deref(), "apiKeyHash")?;
+        let transaction_hash =
+            normalize_hash(params.transaction_hash.as_deref(), "transactionHash")?;
+        let mut rows = query_attributed_trades(
+            pool,
+            api_key_hash.as_deref(),
+            params.start_block,
+            params.end_block,
+            transaction_hash.as_deref(),
+            cursor.as_ref(),
+            limit + 1,
+        )
+        .await?;
+        let has_more = rows.len() > limit as usize;
+        if has_more {
+            rows.truncate(limit as usize);
+        }
+        let next_cursor = if has_more {
+            rows.last()
+                .map(AttributionExecutionCursor::try_from)
+                .transpose()?
+        } else {
+            None
+        };
+        let executions = rows
+            .into_iter()
+            .map(AttributedExecution::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Json(AttributionExecutionsResponse {
+            executions,
+            next_cursor,
+        }))
+    }
+    .instrument(span.0)
+    .await
+}
+
+#[utoipa::path(
+    get,
+    path = "/admin/attribution/volume",
+    tag = "Admin",
+    security(("basicAuth" = [])),
+    params(AttributionVolumeParams),
+    responses(
+        (status = 200, description = "Attributed volume grouped by API key and token pair", body = AttributionVolumeResponse),
+        (status = 400, description = "Bad request", body = ApiErrorResponse),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+        (status = 403, description = "Forbidden", body = ApiErrorResponse),
+        (status = 422, description = "Invalid query parameters", body = ApiErrorResponse),
+        (status = 500, description = "Internal server error", body = ApiErrorResponse),
+    )
+)]
+#[get("/volume?<params..>")]
+pub async fn get_attribution_volume(
+    _global: GlobalRateLimit,
+    admin: AdminKey,
+    pool: &State<DbPool>,
+    span: TracingSpan,
+    params: AttributionVolumeParams,
+) -> Result<Json<AttributionVolumeResponse>, ApiError> {
+    async move {
+        tracing::info!(
+            admin_key_id = %admin.0.key_id,
+            params = ?params,
+            "attribution volume request received"
+        );
+        validate_block_range(params.start_block, params.end_block)?;
+        let limit = params.limit.unwrap_or(100).clamp(1, 1000);
+        let cursor = volume_cursor_filter(&params)?;
+        let api_key_hash = normalize_hash(params.api_key_hash.as_deref(), "apiKeyHash")?;
+        let (volume, next_cursor) = aggregate_volume(
+            pool,
+            api_key_hash.as_deref(),
+            params.start_block,
+            params.end_block,
+            cursor.as_ref(),
+            limit,
+        )
+        .await?;
+        Ok(Json(AttributionVolumeResponse {
+            volume,
+            next_cursor,
+        }))
+    }
+    .instrument(span.0)
+    .await
+}
+
+async fn query_attributed_trades(
+    pool: &DbPool,
+    api_key_hash: Option<&str>,
+    start_block: Option<u64>,
+    end_block: Option<u64>,
+    transaction_hash: Option<&str>,
+    cursor: Option<&ExecutionCursorFilter<'_>>,
+    limit: u32,
+) -> Result<Vec<AttributedTradeRow>, ApiError> {
+    let start_block = optional_sqlite_integer(start_block, "startBlock")?;
+    let end_block = optional_sqlite_integer(end_block, "endBlock")?;
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT indexed_trade_id, chain_id, raindex_address, transaction_hash, log_index, block_number, \
+                block_timestamp, order_hash, taker, api_key_hash, api_key_database_id, api_key_id, \
+                api_key_label, api_key_owner, input_token, input_amount, output_token, output_amount \
+         FROM attributed_trades WHERE 1 = 1",
+    );
+    push_filters(
+        &mut query,
+        api_key_hash,
+        start_block,
+        end_block,
+        transaction_hash,
+    );
+    if let Some(cursor) = cursor {
+        query
+            .push(" AND (block_number < ")
+            .push_bind(cursor.block)
+            .push(" OR (block_number = ")
+            .push_bind(cursor.block)
+            .push(" AND log_index < ")
+            .push_bind(cursor.log_index)
+            .push(") OR (block_number = ")
+            .push_bind(cursor.block)
+            .push(" AND log_index = ")
+            .push_bind(cursor.log_index)
+            .push(" AND indexed_trade_id < ")
+            .push_bind(cursor.trade_id)
+            .push("))");
+    }
+    query
+        .push(" ORDER BY block_number DESC, log_index DESC, indexed_trade_id DESC LIMIT ")
+        .push_bind(i64::from(limit));
+    query
+        .build_query_as::<AttributedTradeRow>()
+        .fetch_all(pool)
+        .await
+        .map_err(query_error)
+}
+
+async fn aggregate_volume(
+    pool: &DbPool,
+    api_key_hash: Option<&str>,
+    start_block: Option<u64>,
+    end_block: Option<u64>,
+    cursor: Option<&VolumeCursorFilter>,
+    limit: u32,
+) -> Result<(Vec<AttributionVolume>, Option<AttributionVolumeCursor>), ApiError> {
+    let start_block = optional_sqlite_integer(start_block, "startBlock")?;
+    let end_block = optional_sqlite_integer(end_block, "endBlock")?;
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT trades.chain_id, trades.api_key_hash, \
+                identity.api_key_database_id, identity.api_key_id, \
+                identity.api_key_label, identity.api_key_owner, \
+                trades.input_token, trades.input_amount, \
+                trades.output_token, trades.output_amount \
+         FROM attributed_trades AS trades \
+         LEFT JOIN attribution_api_keys AS identity \
+           ON identity.api_key_hash = trades.api_key_hash \
+         WHERE 1 = 1",
+    );
+    if let Some(api_key_hash) = api_key_hash {
+        query
+            .push(" AND trades.api_key_hash = ")
+            .push_bind(api_key_hash);
+    }
+    if let Some(start_block) = start_block {
+        query
+            .push(" AND trades.block_number >= ")
+            .push_bind(start_block);
+    }
+    if let Some(end_block) = end_block {
+        query
+            .push(" AND trades.block_number <= ")
+            .push_bind(end_block);
+    }
+    if let Some(cursor) = cursor {
+        push_volume_cursor(&mut query, cursor);
+    }
+    query.push(
+        " ORDER BY trades.api_key_hash, trades.chain_id, \
+                   trades.input_token, trades.output_token",
+    );
+
+    let mut rows = query.build_query_as::<AttributionVolumeRow>().fetch(pool);
+    let mut groups = Vec::<VolumeGroup>::with_capacity(limit as usize);
+    let mut has_more = false;
+    while let Some(row) = rows.try_next().await.map_err(query_error)? {
+        let input = parse_float(&row.input_amount)?;
+        let signed_output = parse_float(&row.output_amount)?;
+        let output = Float::zero()
+            .and_then(|zero| zero.sub(signed_output))
+            .map_err(float_error)?;
+        let key = VolumeKey {
+            api_key_hash: row.api_key_hash,
+            chain_id: row.chain_id,
+            input_token: row.input_token,
+            output_token: row.output_token,
+        };
+        if let Some(group) = groups.last_mut().filter(|group| group.key == key) {
+            group.accumulator.trade_count += 1;
+            group.accumulator.total_input = group
+                .accumulator
+                .total_input
+                .add(input)
+                .map_err(float_error)?;
+            group.accumulator.total_output = group
+                .accumulator
+                .total_output
+                .add(output)
+                .map_err(float_error)?;
+        } else if groups.len() < limit as usize {
+            groups.push(VolumeGroup {
+                key,
+                api_key_database_id: row.api_key_database_id,
+                api_key_id: row.api_key_id,
+                api_key_label: row.api_key_label,
+                api_key_owner: row.api_key_owner,
+                accumulator: VolumeAccumulator {
+                    trade_count: 1,
+                    total_input: input,
+                    total_output: output,
+                },
+            });
+        } else {
+            has_more = true;
+            break;
+        }
+    }
+    drop(rows);
+
+    let next_cursor = if has_more {
+        groups
+            .last()
+            .map(|group| AttributionVolumeCursor::try_from(&group.key))
+            .transpose()?
+    } else {
+        None
+    };
+    let volume = groups
+        .into_iter()
+        .map(|group| {
+            Ok(AttributionVolume {
+                api_key_hash: group.key.api_key_hash,
+                api_key_database_id: group.api_key_database_id,
+                api_key_id: group.api_key_id,
+                api_key_label: group.api_key_label,
+                api_key_owner: group.api_key_owner,
+                chain_id: to_u32(group.key.chain_id, "chain id")?,
+                input_token: group.key.input_token,
+                output_token: group.key.output_token,
+                trade_count: group.accumulator.trade_count,
+                total_input_amount: group
+                    .accumulator
+                    .total_input
+                    .format()
+                    .map_err(float_error)?,
+                total_output_amount: group
+                    .accumulator
+                    .total_output
+                    .format()
+                    .map_err(float_error)?,
+            })
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+    Ok((volume, next_cursor))
+}
+
+fn push_volume_cursor<'args>(
+    query: &mut QueryBuilder<'args, Sqlite>,
+    cursor: &'args VolumeCursorFilter,
+) {
+    query
+        .push(" AND (trades.api_key_hash > ")
+        .push_bind(&cursor.api_key_hash)
+        .push(" OR (trades.api_key_hash = ")
+        .push_bind(&cursor.api_key_hash)
+        .push(" AND trades.chain_id > ")
+        .push_bind(cursor.chain_id)
+        .push(") OR (trades.api_key_hash = ")
+        .push_bind(&cursor.api_key_hash)
+        .push(" AND trades.chain_id = ")
+        .push_bind(cursor.chain_id)
+        .push(" AND trades.input_token > ")
+        .push_bind(&cursor.input_token)
+        .push(") OR (trades.api_key_hash = ")
+        .push_bind(&cursor.api_key_hash)
+        .push(" AND trades.chain_id = ")
+        .push_bind(cursor.chain_id)
+        .push(" AND trades.input_token = ")
+        .push_bind(&cursor.input_token)
+        .push(" AND trades.output_token > ")
+        .push_bind(&cursor.output_token)
+        .push("))");
+}
+
+fn push_filters<'args>(
+    query: &mut QueryBuilder<'args, Sqlite>,
+    api_key_hash: Option<&'args str>,
+    start_block: Option<i64>,
+    end_block: Option<i64>,
+    transaction_hash: Option<&'args str>,
+) {
+    if let Some(api_key_hash) = api_key_hash {
+        query.push(" AND api_key_hash = ").push_bind(api_key_hash);
+    }
+    if let Some(start_block) = start_block {
+        query.push(" AND block_number >= ").push_bind(start_block);
+    }
+    if let Some(end_block) = end_block {
+        query.push(" AND block_number <= ").push_bind(end_block);
+    }
+    if let Some(transaction_hash) = transaction_hash {
+        query
+            .push(" AND transaction_hash = ")
+            .push_bind(transaction_hash);
+    }
+}
+
+fn query_error(error: sqlx::Error) -> ApiError {
+    tracing::error!(%error, "failed to query attributed trades");
+    ApiError::Internal("failed to query attribution report".into())
+}
+
+impl TryFrom<AttributedTradeRow> for AttributedExecution {
+    type Error = ApiError;
+
+    fn try_from(row: AttributedTradeRow) -> Result<Self, Self::Error> {
+        let signed_output = parse_float(&row.output_amount)?;
+        let output = Float::zero()
+            .and_then(|zero| zero.sub(signed_output))
+            .and_then(Float::format)
+            .map_err(float_error)?;
+        Ok(Self {
+            indexed_trade_id: row.indexed_trade_id,
+            chain_id: to_u32(row.chain_id, "chain id")?,
+            raindex_address: row.raindex_address,
+            transaction_hash: row.transaction_hash,
+            log_index: to_u64(row.log_index, "log index")?,
+            block_number: to_u64(row.block_number, "block number")?,
+            block_timestamp: to_u64(row.block_timestamp, "block timestamp")?,
+            order_hash: row.order_hash,
+            taker: row.taker,
+            api_key_hash: row.api_key_hash,
+            api_key_database_id: row.api_key_database_id,
+            api_key_id: row.api_key_id,
+            api_key_label: row.api_key_label,
+            api_key_owner: row.api_key_owner,
+            input_token: row.input_token,
+            input_amount: parse_float(&row.input_amount)?
+                .format()
+                .map_err(float_error)?,
+            output_token: row.output_token,
+            output_amount: output,
+        })
+    }
+}
+
+impl TryFrom<&AttributedTradeRow> for AttributionExecutionCursor {
+    type Error = ApiError;
+
+    fn try_from(row: &AttributedTradeRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            before_block: to_u64(row.block_number, "block number")?,
+            before_log_index: to_u64(row.log_index, "log index")?,
+            before_trade_id: row.indexed_trade_id.clone(),
+        })
+    }
+}
+
+impl TryFrom<&VolumeKey> for AttributionVolumeCursor {
+    type Error = ApiError;
+
+    fn try_from(key: &VolumeKey) -> Result<Self, Self::Error> {
+        Ok(Self {
+            after_api_key_hash: key.api_key_hash.clone(),
+            after_chain_id: to_u32(key.chain_id, "chain id")?,
+            after_input_token: key.input_token.clone(),
+            after_output_token: key.output_token.clone(),
+        })
+    }
+}
+
+fn execution_cursor_filter(
+    params: &AttributionExecutionParams,
+) -> Result<Option<ExecutionCursorFilter<'_>>, ApiError> {
+    match (
+        params.before_block,
+        params.before_log_index,
+        params.before_trade_id.as_deref(),
+    ) {
+        (None, None, None) => Ok(None),
+        (Some(block), Some(log_index), Some(trade_id)) if !trade_id.is_empty() => {
+            Ok(Some(ExecutionCursorFilter {
+                block: i64::try_from(block)
+                    .map_err(|_| ApiError::BadRequest("beforeBlock is too large".into()))?,
+                log_index: i64::try_from(log_index)
+                    .map_err(|_| ApiError::BadRequest("beforeLogIndex is too large".into()))?,
+                trade_id,
+            }))
+        }
+        _ => Err(ApiError::BadRequest(
+            "beforeBlock, beforeLogIndex, and beforeTradeId must be provided together".into(),
+        )),
+    }
+}
+
+fn volume_cursor_filter(
+    params: &AttributionVolumeParams,
+) -> Result<Option<VolumeCursorFilter>, ApiError> {
+    match (
+        params.after_api_key_hash.as_deref(),
+        params.after_chain_id,
+        params.after_input_token.as_deref(),
+        params.after_output_token.as_deref(),
+    ) {
+        (None, None, None, None) => Ok(None),
+        (Some(api_key_hash), Some(chain_id), Some(input_token), Some(output_token)) => {
+            let api_key_hash = normalize_hash(Some(api_key_hash), "afterApiKeyHash")?
+                .ok_or_else(|| ApiError::BadRequest("afterApiKeyHash is required".into()))?;
+            Ok(Some(VolumeCursorFilter {
+                api_key_hash,
+                chain_id: i64::from(chain_id),
+                input_token: normalize_address(input_token, "afterInputToken")?,
+                output_token: normalize_address(output_token, "afterOutputToken")?,
+            }))
+        }
+        _ => Err(ApiError::BadRequest(
+            "afterApiKeyHash, afterChainId, afterInputToken, and afterOutputToken must be provided together"
+                .into(),
+        )),
+    }
+}
+
+fn parse_float(value: &str) -> Result<Float, ApiError> {
+    Float::from_hex(value).map_err(float_error)
+}
+
+fn float_error(error: impl std::fmt::Display) -> ApiError {
+    tracing::error!(%error, "invalid indexed Rain float in attribution report");
+    ApiError::Internal("invalid attributed trade amount".into())
+}
+
+fn optional_sqlite_integer(value: Option<u64>, name: &str) -> Result<Option<i64>, ApiError> {
+    value
+        .map(|value| {
+            i64::try_from(value).map_err(|_| ApiError::BadRequest(format!("{name} is too large")))
+        })
+        .transpose()
+}
+
+fn normalize_hash(value: Option<&str>, name: &str) -> Result<Option<String>, ApiError> {
+    value
+        .map(|value| {
+            B256::from_str(value)
+                .map(|value| value.to_string())
+                .map_err(|_| ApiError::BadRequest(format!("{name} must be a 32-byte hex value")))
+        })
+        .transpose()
+}
+
+fn normalize_address(value: &str, name: &str) -> Result<String, ApiError> {
+    Address::from_str(value)
+        .map(|_| value.to_string())
+        .map_err(|_| ApiError::BadRequest(format!("{name} must be a 20-byte hex address")))
+}
+
+fn validate_block_range(start: Option<u64>, end: Option<u64>) -> Result<(), ApiError> {
+    if start.zip(end).is_some_and(|(start, end)| start > end) {
+        return Err(ApiError::BadRequest(
+            "startBlock must be less than or equal to endBlock".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn to_u64(value: i64, label: &str) -> Result<u64, ApiError> {
+    u64::try_from(value).map_err(|_| {
+        tracing::error!(value, label, "negative attribution database value");
+        ApiError::Internal("invalid attribution report data".into())
+    })
+}
+
+fn to_u32(value: i64, label: &str) -> Result<u32, ApiError> {
+    u32::try_from(value).map_err(|_| {
+        tracing::error!(value, label, "invalid attribution database value");
+        ApiError::Internal("invalid attribution report data".into())
+    })
+}
+
+pub fn routes() -> Vec<Route> {
+    rocket::routes![get_attributed_executions, get_attribution_volume]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{basic_auth_header, seed_admin_key, TestClientBuilder};
+    use rocket::http::{Header, Status};
+
+    async fn insert_trade(client: &rocket::local::asynchronous::Client, indexed_trade_id: &str) {
+        let pool = client.rocket().state::<DbPool>().expect("pool");
+        let input = Float::parse("0.001".to_string()).expect("input").as_hex();
+        let output = Float::parse("-0.205184".to_string())
+            .expect("output")
+            .as_hex();
+        sqlx::query(
+            "INSERT INTO attributed_trades (\
+                chain_id, raindex_address, indexed_trade_id, transaction_hash, log_index, \
+                block_number, block_timestamp, order_hash, taker, api_key_hash, \
+                api_key_database_id, api_key_id, api_key_label, api_key_owner, \
+                input_token, input_amount, \
+                output_token, output_amount\
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(i64::from(crate::CHAIN_ID))
+        .bind("0x1111111111111111111111111111111111111111")
+        .bind(indexed_trade_id)
+        .bind("0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f")
+        .bind(7_i64)
+        .bind(48_963_501_i64)
+        .bind(1_753_000_000_i64)
+        .bind("0x7df0fb50accfab436c5cbe06bfb5e305a2acc1cd986870220510e67e5970be45")
+        .bind("0xA9d6ab42f32dC476269dB2407715D8c15A36D781")
+        .bind("0xee79738dcdfded041361028dcf0162b49eafa0a2fed61ba63d8fe275253aa8dc")
+        .bind(1_i64)
+        .bind("customer-key")
+        .bind("Customer")
+        .bind("customer@example.com")
+        .bind("0x2222222222222222222222222222222222222222")
+        .bind(input)
+        .bind("0x3333333333333333333333333333333333333333")
+        .bind(output)
+        .execute(pool)
+        .await
+        .expect("trade");
+    }
+
+    async fn set_trade_group(
+        client: &rocket::local::asynchronous::Client,
+        indexed_trade_id: &str,
+        api_key_hash: &str,
+        input_token: &str,
+        output_token: &str,
+    ) {
+        let pool = client.rocket().state::<DbPool>().expect("pool");
+        sqlx::query(
+            "UPDATE attributed_trades \
+             SET api_key_hash = ?, input_token = ?, output_token = ? \
+             WHERE indexed_trade_id = ?",
+        )
+        .bind(api_key_hash)
+        .bind(input_token)
+        .bind(output_token)
+        .bind(indexed_trade_id)
+        .execute(pool)
+        .await
+        .expect("trade group");
+    }
+
+    async fn insert_current_identity(
+        client: &rocket::local::asynchronous::Client,
+        api_key_hash: &str,
+        label: &str,
+        owner: &str,
+    ) {
+        let pool = client.rocket().state::<DbPool>().expect("pool");
+        sqlx::query(
+            "INSERT INTO attribution_api_keys (\
+                api_key_hash, api_key_database_id, api_key_id, api_key_label, api_key_owner\
+             ) VALUES (?, 2, 'customer-key', ?, ?)",
+        )
+        .bind(api_key_hash)
+        .bind(label)
+        .bind(owner)
+        .execute(pool)
+        .await
+        .expect("current identity");
+    }
+
+    #[rocket::async_test]
+    async fn admin_can_query_execution_and_exact_volume() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = seed_admin_key(&client).await;
+        insert_trade(&client, "0x01").await;
+        let auth = Header::new("Authorization", basic_auth_header(&key_id, &secret));
+
+        let response = client
+            .get(
+                "/admin/attribution/executions?startBlock=48963501&transactionHash=0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f",
+            )
+            .header(auth.clone())
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("execution body");
+        assert_eq!(body["executions"][0]["inputAmount"], "0.001");
+        assert_eq!(body["executions"][0]["outputAmount"], "0.205184");
+
+        let response = client
+            .get("/admin/attribution/volume")
+            .header(auth)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("volume body");
+        assert_eq!(body["volume"][0]["tradeCount"], 1);
+        assert_eq!(body["volume"][0]["totalInputAmount"], "0.001");
+        assert_eq!(body["volume"][0]["totalOutputAmount"], "0.205184");
+        assert!(body["nextCursor"].is_null());
+    }
+
+    #[rocket::async_test]
+    async fn executions_use_stable_keyset_pagination() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = seed_admin_key(&client).await;
+        insert_trade(&client, "0x01").await;
+        insert_trade(&client, "0x02").await;
+        let auth = Header::new("Authorization", basic_auth_header(&key_id, &secret));
+
+        let response = client
+            .get("/admin/attribution/executions?limit=1")
+            .header(auth.clone())
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("first page");
+        assert_eq!(body["executions"][0]["indexedTradeId"], "0x02");
+        assert_eq!(body["nextCursor"]["beforeBlock"], 48_963_501);
+        assert_eq!(body["nextCursor"]["beforeLogIndex"], 7);
+        assert_eq!(body["nextCursor"]["beforeTradeId"], "0x02");
+
+        let response = client
+            .get(
+                "/admin/attribution/executions?limit=1&beforeBlock=48963501&beforeLogIndex=7&beforeTradeId=0x02",
+            )
+            .header(auth.clone())
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("second page");
+        assert_eq!(body["executions"][0]["indexedTradeId"], "0x01");
+        assert!(body["nextCursor"].is_null());
+
+        let response = client
+            .get("/admin/attribution/volume")
+            .header(auth)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("grouped volume");
+        assert_eq!(body["volume"].as_array().expect("volume rows").len(), 1);
+        assert_eq!(body["volume"][0]["tradeCount"], 2);
+    }
+
+    #[rocket::async_test]
+    async fn volume_uses_bounded_keyset_pagination() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = seed_admin_key(&client).await;
+        insert_trade(&client, "0x01").await;
+        insert_trade(&client, "0x02").await;
+        let first_hash = B256::new([0x11; 32]).to_string();
+        let second_hash = B256::new([0x22; 32]).to_string();
+        let input_token = Address::new([0x33; 20]).to_string();
+        let output_token = Address::new([0x44; 20]).to_string();
+        set_trade_group(&client, "0x01", &first_hash, &input_token, &output_token).await;
+        set_trade_group(&client, "0x02", &second_hash, &input_token, &output_token).await;
+        let auth = Header::new("Authorization", basic_auth_header(&key_id, &secret));
+
+        let response = client
+            .get("/admin/attribution/volume?limit=1")
+            .header(auth.clone())
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("first volume page");
+        assert_eq!(body["volume"].as_array().expect("volume rows").len(), 1);
+        assert_eq!(body["volume"][0]["apiKeyHash"], first_hash);
+        assert_eq!(body["nextCursor"]["afterApiKeyHash"], first_hash);
+
+        let next_url = format!(
+            "/admin/attribution/volume?limit=1&afterApiKeyHash={}&afterChainId={}&afterInputToken={}&afterOutputToken={}",
+            body["nextCursor"]["afterApiKeyHash"]
+                .as_str()
+                .expect("cursor API key hash"),
+            body["nextCursor"]["afterChainId"]
+                .as_u64()
+                .expect("cursor chain ID"),
+            body["nextCursor"]["afterInputToken"]
+                .as_str()
+                .expect("cursor input token"),
+            body["nextCursor"]["afterOutputToken"]
+                .as_str()
+                .expect("cursor output token"),
+        );
+        let response = client.get(next_url).header(auth).dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("second volume page");
+        assert_eq!(body["volume"].as_array().expect("volume rows").len(), 1);
+        assert_eq!(body["volume"][0]["apiKeyHash"], second_hash);
+        assert!(body["nextCursor"].is_null());
+    }
+
+    #[rocket::async_test]
+    async fn volume_uses_current_identity_while_executions_keep_snapshot() {
+        let client = TestClientBuilder::new().build().await;
+        let (key_id, secret) = seed_admin_key(&client).await;
+        insert_trade(&client, "0x01").await;
+        let api_key_hash = "0xee79738dcdfded041361028dcf0162b49eafa0a2fed61ba63d8fe275253aa8dc";
+        insert_current_identity(
+            &client,
+            api_key_hash,
+            "Current Customer",
+            "current@example.com",
+        )
+        .await;
+        let auth = Header::new("Authorization", basic_auth_header(&key_id, &secret));
+
+        let response = client
+            .get("/admin/attribution/executions")
+            .header(auth.clone())
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("execution");
+        assert_eq!(body["executions"][0]["apiKeyLabel"], "Customer");
+        assert_eq!(body["executions"][0]["apiKeyOwner"], "customer@example.com");
+
+        let response = client
+            .get("/admin/attribution/volume")
+            .header(auth)
+            .dispatch()
+            .await;
+        assert_eq!(response.status(), Status::Ok);
+        let body: serde_json::Value = response.into_json().await.expect("volume");
+        assert_eq!(body["volume"][0]["apiKeyLabel"], "Current Customer");
+        assert_eq!(body["volume"][0]["apiKeyOwner"], "current@example.com");
+    }
+
+    #[rocket::async_test]
+    async fn attribution_routes_require_admin_key() {
+        let client = TestClientBuilder::new().build().await;
+        let response = client.get("/admin/attribution/executions").dispatch().await;
+        assert_eq!(response.status(), Status::Unauthorized);
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod attribution_admin;
 pub mod health;
 pub mod order;
 pub mod orders;


### PR DESCRIPTION
## Chained PR

- Requires #160 (`feat: embed API key attribution in swap calldata`) to merge first.
- This is the only reporting PR in the stack.

## Motivation

#160 makes generated swap calldata attributable, but we still need to determine which signed calls were actually executed and how much customer volume they produced. Generated quotes and unused calldata must not count.

The reporting data must remain private, survive delayed execution and API-key or signer rotation, and start from an explicit rollout block instead of indexing historical volume from genesis.

## Solution

- Run a single-replica Rocket background worker every 60 seconds, starting at Base block `48963501` and processing at most 250 indexed trades per target per interval.
- Read confirmed `TakeOrderV3` trades and emitted signed contexts from the existing Raindex SQLite database. This avoids redundant RPC transaction fetches because the indexed event already contains the canonical signer, signature, context, transaction, order, taker, tokens, and executed amounts.
- Read each Raindex watermark and batch in one SQLite snapshot, then advance a stable `(block_number, log_index, trade_id)` cursor atomically with attributed-trade writes.
- Verify the signed versioned frame against the trusted REST signer, event taker, and exact order hash before accepting the API-key hash.
- Preserve previously observed signer addresses and API-key hash-to-customer tombstones so delayed executions remain attributable after signer rotation or hard key deletion. No generated calldata is stored.
- Store only confirmed attributed executions, exact Rain float amounts, customer identity snapshots, and sync cursors in the private application database.
- Add admin-only reporting endpoints:
  - `GET /admin/attribution/executions` with block, API-key hash, transaction hash, limit, and stable keyset pagination filters.
  - `GET /admin/attribution/volume` grouped exactly by API-key hash, chain, and token pair.
- Reset and safely rescan derived attribution data when the configured start block changes.
- Join the worker cleanly during Rocket shutdown and keep OpenAPI parameter names aligned with the camel-case REST contract.

## Privacy and deployment

- Uses the existing `ST0X_GATING_SIGNER_KEY`; no signer environment variable is added.
- RPC URLs and credentials remain in the existing private registry configuration.
- The API key secret and signer private key are never stored in reporting rows or returned by the endpoints.
- Preview and production are configured to start at block `48963501`, which includes the known staging execution.
- Service-only deployments compare the installed attribution settings with the checked-out environment config as well as checking the signer unit. Missing or stale settings automatically trigger the required system deployment before the service deploy.

## Regression coverage

- Verifies attribution signature recovery and the exact signed-context layout shared with #160.
- Processes the known staging transaction fixture (`0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f`) at block `48963501`, including the `0.001` input and `0.205184` output amounts.
- Covers idempotent retries, empty-tail checkpoints, exact-full and partial batches, shared block/log positions, start-block changes, signer rotation, atomic API-key tombstones, exact volume aggregation, admin authorization, transaction filtering, stable pagination, and OpenAPI query names.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test` (311 passed)
- `nix develop -c git diff --check`
- Three-angle simplification review; actionable findings fixed.
- Two-reviewer staged local review plus one focused second pass; actionable findings fixed and retested.

## Preview verification

- Preview service deployment: https://github.com/ST0x-Technology/st0x.rest.api/actions/runs/29917111920
- Preview system-config deployment: https://github.com/ST0x-Technology/st0x.rest.api/actions/runs/29918959899
- The live worker registered signer `0x385817222DBb0Ee011B8c1722479C2A462b4cE2E` and advanced from start block `48963501` to the current Raindex watermark.
- `GET /admin/attribution/executions` returned the exact known transaction `0x48f6ed8a67769c007491262e72b78eb934a0a53bc0d67506081fc9a1c35c276f`, API-key hash `0xee79738dcdfded041361028dcf0162b49eafa0a2fed61ba63d8fe275253aa8dc`, label `bruno-preview`, and owner `Arda`.
- `GET /admin/attribution/volume` returned one trade with total input `0.001` and total output `0.2051844466600199401794616151545363908275174476570289132602193419741`.
- A short-lived admin credential was used only for the live endpoint checks, then deleted; both its API-key row and empty attribution-directory row were verified absent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added attribution reporting worker for confirmed trades with periodic, cursor-based synchronization and signed-context validation.
  * Added admin endpoints for querying attributed executions and aggregated attribution volume with stable filtering/pagination.
  * Added persistence for attributed trades, signers, attribution API key metadata, and sync cursors.
  * Added attribution configuration for start block, sync interval, and batch size (with safer defaults).

* **Bug Fixes**
  * Improved deployment gating to verify both service prerequisites and that remote attribution configuration matches expected values.
  * Ensured attribution identity snapshots are preserved during API key create/delete.

* **Chores**
  * Added SQL migrations and supporting indexes for the new attribution storage and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->