### PR TITLE
refactor: separate attribution storage responsibilities

### DIFF
--- a/src/attribution_reporting.rs
+++ b/src/attribution_reporting.rs
@@ -1,30 +1,24 @@
 //! Background attribution of confirmed trades indexed by the local Raindex database.
 
-use crate::attribution::{
-    compute_api_key_hash, verify_signed_attribution, ATTRIBUTION_CONTEXT_WORDS,
-};
-use crate::db::DbPool;
+use crate::attribution::{compute_api_key_hash, verify_signed_attribution};
+use crate::db::{attribution as attribution_db, DbPool};
 use alloy::primitives::{Address, Bytes, B256};
 use rain_orderbook_bindings::IRaindexV6::SignedContextV1;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::{Orbit, Rocket};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
-use sqlx::{FromRow, SqlitePool};
+use source::{BatchCursor, IndexedSignedContext, IndexedTrade, SyncTarget};
+use sqlx::SqlitePool;
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
-const SUPPORTED_RAINDEX_SCHEMA_VERSION: u32 = 5;
 const WORKER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-const _: () = assert!(
-    rain_orderbook_app_settings::local_db_manifest::DB_SCHEMA_VERSION
-        == SUPPORTED_RAINDEX_SCHEMA_VERSION,
-    "Raindex local database schema changed; review the attribution queries"
-);
+pub(crate) mod report;
+mod source;
 
 #[derive(Debug, Clone)]
 pub(crate) struct AttributionWorker {
@@ -68,7 +62,7 @@ impl Fairing for AttributionWorker {
     }
 
     async fn on_liftoff(&self, rocket: &Rocket<Orbit>) {
-        if let Err(error) = record_attribution_signer(&self.app_pool, self.signer).await {
+        if let Err(error) = attribution_db::record_signer(&self.app_pool, self.signer).await {
             tracing::error!(%error, "failed to record current attribution signer at startup");
         }
         let worker = self.clone();
@@ -83,8 +77,7 @@ impl Fairing for AttributionWorker {
                         tracing::info!("attribution worker shutting down");
                         break;
                     }
-                    _ = interval.tick() => {
-                    }
+                    _ = interval.tick() => {}
                 }
 
                 let sync = run_sync_iteration(&worker);
@@ -127,7 +120,7 @@ async fn finish_worker_task(mut handle: JoinHandle<()>, timeout: Duration) {
 }
 
 async fn run_sync_iteration(worker: &AttributionWorker) {
-    match open_raindex_pool(&worker.raindex_db_path).await {
+    match source::open_pool(&worker.raindex_db_path).await {
         Ok(source_pool) => {
             let result = process_available_trades(
                 &worker.app_pool,
@@ -160,88 +153,6 @@ pub(crate) enum AttributionReportingError {
     StartBlockOverflow,
 }
 
-async fn open_raindex_pool(path: &Path) -> Result<SqlitePool, sqlx::Error> {
-    let options = SqliteConnectOptions::new()
-        .filename(path)
-        .read_only(true)
-        .busy_timeout(Duration::from_secs(5));
-    SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect_with(options)
-        .await
-}
-
-#[derive(Debug, FromRow)]
-struct SyncTarget {
-    chain_id: i64,
-    raindex_address: String,
-    last_indexed_block: i64,
-}
-
-#[derive(Debug, FromRow)]
-struct CursorRow {
-    start_block: i64,
-    last_block: i64,
-    last_log_index: i64,
-    last_trade_id: String,
-}
-
-#[derive(Debug, Clone, FromRow)]
-struct IndexedContextRow {
-    chain_id: i64,
-    raindex_address: String,
-    trade_id: String,
-    transaction_hash: String,
-    log_index: i64,
-    block_number: i64,
-    block_timestamp: i64,
-    transaction_sender: String,
-    order_hash: String,
-    input_token: String,
-    input_delta: String,
-    output_token: String,
-    output_delta: String,
-    context_index: Option<i64>,
-    context_value: Option<String>,
-    value_0: Option<String>,
-    value_1: Option<String>,
-    value_2: Option<String>,
-    value_3: Option<String>,
-    value_count: i64,
-}
-
-#[derive(Debug)]
-struct IndexedTrade {
-    chain_id: i64,
-    raindex_address: String,
-    trade_id: String,
-    transaction_hash: String,
-    log_index: i64,
-    block_number: i64,
-    block_timestamp: i64,
-    transaction_sender: String,
-    order_hash: String,
-    input_token: String,
-    input_delta: String,
-    output_token: String,
-    output_delta: String,
-    contexts: Vec<IndexedSignedContext>,
-}
-
-#[derive(Debug)]
-struct IndexedSignedContext {
-    encoded_signer_and_signature: String,
-    values: [String; ATTRIBUTION_CONTEXT_WORDS],
-}
-
-#[derive(Debug, Clone, FromRow)]
-struct ApiKeyIdentity {
-    id: i64,
-    key_id: String,
-    label: String,
-    owner: String,
-}
-
 pub(crate) async fn process_available_trades(
     app_pool: &DbPool,
     source_pool: &SqlitePool,
@@ -251,33 +162,21 @@ pub(crate) async fn process_available_trades(
 ) -> Result<u64, AttributionReportingError> {
     let start_block =
         i64::try_from(start_block).map_err(|_| AttributionReportingError::StartBlockOverflow)?;
-    record_attribution_signer(app_pool, signer).await?;
-    let targets = sqlx::query_as::<_, SyncTarget>(
-        "SELECT chain_id, raindex_address, last_block AS last_indexed_block \
-         FROM target_watermarks WHERE chain_id = ? ORDER BY raindex_address",
-    )
-    .bind(i64::from(crate::CHAIN_ID))
-    .fetch_all(source_pool)
-    .await?;
-    snapshot_current_api_keys(app_pool).await?;
-    let identities = load_api_key_identities(app_pool).await?;
-    let identity_by_hash: HashMap<B256, ApiKeyIdentity> = identities
+    attribution_db::record_signer(app_pool, signer).await?;
+    let targets = source::list_targets(source_pool, crate::CHAIN_ID).await?;
+    attribution_db::snapshot_current_api_keys(app_pool).await?;
+    let identities = attribution_db::load_api_key_identities(app_pool).await?;
+    let identity_by_hash: HashMap<B256, attribution_db::ApiKeyIdentity> = identities
         .into_iter()
         .map(|identity| (compute_api_key_hash(&identity.key_id), identity))
         .collect();
 
     let mut attributed_count = 0;
-    let trusted_signers = load_attribution_signers(app_pool).await?;
+    let trusted_signers = attribution_db::load_signers(app_pool).await?;
     for mut target in targets {
         let mut source_transaction = source_pool.begin().await?;
-        let Some(last_indexed_block) = sqlx::query_scalar::<_, i64>(
-            "SELECT last_block FROM target_watermarks \
-             WHERE chain_id = ? AND raindex_address = ?",
-        )
-        .bind(target.chain_id)
-        .bind(&target.raindex_address)
-        .fetch_optional(&mut *source_transaction)
-        .await?
+        let Some(last_indexed_block) =
+            source::refresh_watermark(&mut source_transaction, &target).await?
         else {
             source_transaction.commit().await?;
             continue;
@@ -298,105 +197,6 @@ pub(crate) async fn process_available_trades(
     Ok(attributed_count)
 }
 
-async fn load_api_key_identities(app_pool: &DbPool) -> Result<Vec<ApiKeyIdentity>, sqlx::Error> {
-    sqlx::query_as::<_, ApiKeyIdentity>(
-        "SELECT api_key_database_id AS id, api_key_id AS key_id, \
-                api_key_label AS label, api_key_owner AS owner \
-         FROM attribution_api_keys ORDER BY api_key_id",
-    )
-    .fetch_all(app_pool)
-    .await
-}
-
-async fn snapshot_current_api_keys(app_pool: &DbPool) -> Result<(), sqlx::Error> {
-    let identities = sqlx::query_as::<_, ApiKeyIdentity>(
-        "SELECT id, key_id, label, owner FROM api_keys ORDER BY id",
-    )
-    .fetch_all(app_pool)
-    .await?;
-    let mut transaction = app_pool.begin().await?;
-    for identity in identities {
-        upsert_api_key_identity(&mut transaction, &identity).await?;
-    }
-    transaction.commit().await
-}
-
-async fn upsert_api_key_identity(
-    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
-    identity: &ApiKeyIdentity,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "INSERT INTO attribution_api_keys (\
-            api_key_hash, api_key_database_id, api_key_id, api_key_label, api_key_owner\
-         ) VALUES (?, ?, ?, ?, ?) \
-         ON CONFLICT(api_key_hash) DO UPDATE SET \
-            api_key_database_id = excluded.api_key_database_id, \
-            api_key_id = excluded.api_key_id, \
-            api_key_label = excluded.api_key_label, \
-            api_key_owner = excluded.api_key_owner, \
-            updated_at = datetime('now') \
-         WHERE api_key_database_id IS NOT excluded.api_key_database_id \
-            OR api_key_id IS NOT excluded.api_key_id \
-            OR api_key_label IS NOT excluded.api_key_label \
-            OR api_key_owner IS NOT excluded.api_key_owner",
-    )
-    .bind(compute_api_key_hash(&identity.key_id).to_string())
-    .bind(identity.id)
-    .bind(&identity.key_id)
-    .bind(&identity.label)
-    .bind(&identity.owner)
-    .execute(&mut **transaction)
-    .await?;
-    Ok(())
-}
-
-pub(crate) async fn snapshot_api_key(
-    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
-    id: i64,
-    key_id: &str,
-    label: &str,
-    owner: &str,
-) -> Result<(), sqlx::Error> {
-    upsert_api_key_identity(
-        transaction,
-        &ApiKeyIdentity {
-            id,
-            key_id: key_id.to_string(),
-            label: label.to_string(),
-            owner: owner.to_string(),
-        },
-    )
-    .await
-}
-
-async fn record_attribution_signer(app_pool: &DbPool, signer: Address) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "INSERT INTO attribution_signers (address) VALUES (?) \
-         ON CONFLICT(address) DO NOTHING",
-    )
-    .bind(signer.to_string())
-    .execute(app_pool)
-    .await?;
-    Ok(())
-}
-
-async fn load_attribution_signers(app_pool: &DbPool) -> Result<Vec<Address>, sqlx::Error> {
-    let values: Vec<String> =
-        sqlx::query_scalar("SELECT address FROM attribution_signers ORDER BY first_seen_at")
-            .fetch_all(app_pool)
-            .await?;
-    Ok(values
-        .into_iter()
-        .filter_map(|value| match Address::from_str(&value) {
-            Ok(address) => Some(address),
-            Err(error) => {
-                tracing::error!(%error, address = %value, "invalid trusted attribution signer");
-                None
-            }
-        })
-        .collect())
-}
-
 async fn process_target(
     app_pool: &DbPool,
     source_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
@@ -404,48 +204,41 @@ async fn process_target(
     configured_start_block: i64,
     batch_size: u32,
     target: &SyncTarget,
-    identities: &HashMap<B256, ApiKeyIdentity>,
+    identities: &HashMap<B256, attribution_db::ApiKeyIdentity>,
 ) -> Result<u64, AttributionReportingError> {
     // The cursor read, attributed-trade upserts, and cursor update share one transaction.
     // A concurrent worker therefore cannot commit a cursor derived from stale progress.
     let mut transaction = app_pool.begin().await?;
-    let mut stored_cursor = sqlx::query_as::<_, CursorRow>(
-        "SELECT start_block, last_block, last_log_index, last_trade_id \
-         FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?",
-    )
-    .bind(target.chain_id)
-    .bind(&target.raindex_address)
-    .fetch_optional(&mut *transaction)
-    .await?;
+    let mut stored_cursor =
+        attribution_db::load_cursor(&mut transaction, target.chain_id, &target.raindex_address)
+            .await?;
 
     let start_block_reset = stored_cursor
         .as_ref()
         .is_some_and(|cursor| cursor.start_block != configured_start_block);
     if start_block_reset {
-        reset_target_start_block(&mut transaction, target, configured_start_block).await?;
+        attribution_db::reset_target(
+            &mut transaction,
+            target.chain_id,
+            &target.raindex_address,
+            configured_start_block,
+        )
+        .await?;
         stored_cursor = None;
     }
-    let cursor = stored_cursor;
-    let last_block = cursor.as_ref().map_or(0, |cursor| cursor.last_block);
-    let last_log_index = cursor.as_ref().map_or(-1, |cursor| cursor.last_log_index);
-    let last_trade_id = cursor
-        .as_ref()
-        .map_or_else(String::new, |cursor| cursor.last_trade_id.clone());
-    let has_cursor = cursor.is_some();
-    let mut attributed_count = 0;
-
-    let rows = fetch_batch(
+    let batch_cursor = stored_cursor.as_ref().map(|cursor| BatchCursor {
+        block: cursor.last_block,
+        log_index: cursor.last_log_index,
+        trade_id: &cursor.last_trade_id,
+    });
+    let trades = source::fetch_batch(
         source_transaction,
         target,
         configured_start_block,
-        has_cursor,
-        last_block,
-        last_log_index,
-        &last_trade_id,
+        batch_cursor,
         batch_size,
     )
     .await?;
-    let trades = group_context_rows(rows);
     // Raindex materializes all derived rows through a target's watermark before advancing
     // target_watermarks in the same source transaction. Because this function rereads the
     // watermark and the rows from one source snapshot, a partial batch proves that every
@@ -463,70 +256,47 @@ async fn process_target(
         )
     };
 
-    for trade in &trades {
+    let mut attributed_trades = Vec::with_capacity(trades.len());
+    for trade in trades {
         let Some(api_key_hash) = trade
             .contexts
             .iter()
-            .find_map(|context| verify_context(context, trade, trusted_signers))
+            .find_map(|context| verify_context(context, &trade, trusted_signers))
         else {
             continue;
         };
-        let identity = identities.get(&api_key_hash);
-        sqlx::query(
-            "INSERT INTO attributed_trades (\
-                    chain_id, raindex_address, indexed_trade_id, transaction_hash, log_index, \
-                    block_number, block_timestamp, order_hash, taker, api_key_hash, \
-                    api_key_database_id, api_key_id, api_key_label, api_key_owner, \
-                    input_token, input_amount, \
-                    output_token, output_amount\
-                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
-                 ON CONFLICT(chain_id, raindex_address, indexed_trade_id) DO UPDATE SET \
-                    api_key_database_id = excluded.api_key_database_id, \
-                    api_key_id = excluded.api_key_id, \
-                    api_key_label = excluded.api_key_label, \
-                    api_key_owner = excluded.api_key_owner, \
-                    updated_at = datetime('now')",
-        )
-        .bind(trade.chain_id)
-        .bind(&trade.raindex_address)
-        .bind(&trade.trade_id)
-        .bind(&trade.transaction_hash)
-        .bind(trade.log_index)
-        .bind(trade.block_number)
-        .bind(trade.block_timestamp)
-        .bind(&trade.order_hash)
-        .bind(&trade.transaction_sender)
-        .bind(api_key_hash.to_string())
-        .bind(identity.map(|value| value.id))
-        .bind(identity.map(|value| value.key_id.as_str()))
-        .bind(identity.map(|value| value.label.as_str()))
-        .bind(identity.map(|value| value.owner.as_str()))
-        .bind(&trade.input_token)
-        .bind(&trade.input_delta)
-        .bind(&trade.output_token)
-        .bind(&trade.output_delta)
-        .execute(&mut *transaction)
-        .await?;
-        attributed_count += 1;
+        attributed_trades.push(attribution_db::NewAttributedTrade {
+            chain_id: trade.chain_id,
+            raindex_address: trade.raindex_address,
+            indexed_trade_id: trade.trade_id,
+            transaction_hash: trade.transaction_hash,
+            log_index: trade.log_index,
+            block_number: trade.block_number,
+            block_timestamp: trade.block_timestamp,
+            order_hash: trade.order_hash,
+            taker: trade.transaction_sender,
+            api_key_hash,
+            identity: identities.get(&api_key_hash),
+            input_token: trade.input_token,
+            input_amount: trade.input_delta,
+            output_token: trade.output_token,
+            output_amount: trade.output_delta,
+        });
     }
-    sqlx::query(
-        "INSERT INTO attribution_sync_cursors (\
-                chain_id, raindex_address, start_block, last_block, last_log_index, last_trade_id\
-             ) VALUES (?, ?, ?, ?, ?, ?) \
-             ON CONFLICT(chain_id, raindex_address) DO UPDATE SET \
-                start_block = excluded.start_block, \
-                last_block = excluded.last_block, \
-                last_log_index = excluded.last_log_index, \
-                last_trade_id = excluded.last_trade_id, \
-                updated_at = datetime('now')",
+    let attributed_count = u64::try_from(attributed_trades.len())
+        .map_err(|_| sqlx::Error::Protocol("attributed trade count does not fit u64".into()))?;
+    attribution_db::store_batch(
+        &mut transaction,
+        target.chain_id,
+        &target.raindex_address,
+        configured_start_block,
+        attribution_db::CursorPosition {
+            block: next_cursor.0,
+            log_index: next_cursor.1,
+            trade_id: &next_cursor.2,
+        },
+        &attributed_trades,
     )
-    .bind(target.chain_id)
-    .bind(&target.raindex_address)
-    .bind(configured_start_block)
-    .bind(next_cursor.0)
-    .bind(next_cursor.1)
-    .bind(&next_cursor.2)
-    .execute(&mut *transaction)
     .await?;
     transaction.commit().await?;
 
@@ -548,145 +318,6 @@ async fn process_target(
         );
     }
     Ok(attributed_count)
-}
-
-async fn reset_target_start_block(
-    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
-    target: &SyncTarget,
-    configured_start_block: i64,
-) -> Result<(), sqlx::Error> {
-    sqlx::query(
-        "DELETE FROM attributed_trades \
-         WHERE chain_id = ? AND raindex_address = ? AND block_number < ?",
-    )
-    .bind(target.chain_id)
-    .bind(&target.raindex_address)
-    .bind(configured_start_block)
-    .execute(&mut **transaction)
-    .await?;
-    sqlx::query("DELETE FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?")
-        .bind(target.chain_id)
-        .bind(&target.raindex_address)
-        .execute(&mut **transaction)
-        .await?;
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn fetch_batch(
-    source_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
-    target: &SyncTarget,
-    start_block: i64,
-    has_cursor: bool,
-    last_block: i64,
-    last_log_index: i64,
-    last_trade_id: &str,
-    batch_size: u32,
-) -> Result<Vec<IndexedContextRow>, sqlx::Error> {
-    sqlx::query_as::<_, IndexedContextRow>(
-        "WITH batch AS (\
-            SELECT chain_id, raindex_address, trade_id, transaction_hash, log_index, \
-                   block_number, block_timestamp, transaction_sender, order_hash, \
-                   input_token, input_delta, output_token, output_delta \
-            FROM derived_trades \
-            WHERE trade_kind = 'take' \
-              AND chain_id = ? AND raindex_address = ? \
-              AND block_number >= ? AND block_number <= ? \
-              AND (? = 0 OR block_number > ? \
-                   OR (block_number = ? AND log_index > ?) \
-                   OR (block_number = ? AND log_index = ? AND trade_id > ?)) \
-            ORDER BY block_number, log_index, trade_id \
-            LIMIT ?\
-         ) \
-         SELECT b.*, c.context_index, c.context_value, \
-                MAX(CASE WHEN v.value_index = 0 THEN v.value END) AS value_0, \
-                MAX(CASE WHEN v.value_index = 1 THEN v.value END) AS value_1, \
-                MAX(CASE WHEN v.value_index = 2 THEN v.value END) AS value_2, \
-                MAX(CASE WHEN v.value_index = 3 THEN v.value END) AS value_3, \
-                COUNT(v.value_index) AS value_count \
-         FROM batch b \
-         LEFT JOIN take_order_contexts c \
-           ON c.chain_id = b.chain_id \
-          AND c.raindex_address = b.raindex_address \
-          AND c.transaction_hash = b.transaction_hash \
-          AND c.log_index = b.log_index \
-         LEFT JOIN context_values v \
-           ON v.chain_id = c.chain_id \
-          AND v.raindex_address = c.raindex_address \
-          AND v.transaction_hash = c.transaction_hash \
-          AND v.log_index = c.log_index \
-          AND v.context_index = c.context_index \
-         GROUP BY b.chain_id, b.raindex_address, b.trade_id, b.transaction_hash, b.log_index, \
-                  b.block_number, b.block_timestamp, b.transaction_sender, b.order_hash, \
-                  b.input_token, b.input_delta, b.output_token, b.output_delta, \
-                  c.context_index, c.context_value \
-         ORDER BY b.block_number, b.log_index, b.trade_id, c.context_index",
-    )
-    .bind(target.chain_id)
-    .bind(&target.raindex_address)
-    .bind(start_block)
-    .bind(target.last_indexed_block)
-    .bind(has_cursor)
-    .bind(last_block)
-    .bind(last_block)
-    .bind(last_log_index)
-    .bind(last_block)
-    .bind(last_log_index)
-    .bind(last_trade_id)
-    .bind(i64::from(batch_size))
-    .fetch_all(&mut **source_transaction)
-    .await
-}
-
-fn group_context_rows(rows: Vec<IndexedContextRow>) -> Vec<IndexedTrade> {
-    let mut trades: Vec<IndexedTrade> = Vec::new();
-    for row in rows {
-        let is_new_trade = trades.last().is_none_or(|trade| {
-            trade.chain_id != row.chain_id
-                || trade.raindex_address != row.raindex_address
-                || trade.trade_id != row.trade_id
-        });
-        if is_new_trade {
-            trades.push(IndexedTrade {
-                chain_id: row.chain_id,
-                raindex_address: row.raindex_address.clone(),
-                trade_id: row.trade_id.clone(),
-                transaction_hash: row.transaction_hash.clone(),
-                log_index: row.log_index,
-                block_number: row.block_number,
-                block_timestamp: row.block_timestamp,
-                transaction_sender: row.transaction_sender.clone(),
-                order_hash: row.order_hash.clone(),
-                input_token: row.input_token.clone(),
-                input_delta: row.input_delta.clone(),
-                output_token: row.output_token.clone(),
-                output_delta: row.output_delta.clone(),
-                contexts: Vec::new(),
-            });
-        }
-
-        let values = match (
-            row.value_0,
-            row.value_1,
-            row.value_2,
-            row.value_3,
-            row.value_count,
-        ) {
-            (Some(v0), Some(v1), Some(v2), Some(v3), 4) => Some([v0, v1, v2, v3]),
-            _ => None,
-        };
-        if row.context_index.is_some() {
-            if let (Some(context_value), Some(values), Some(trade)) =
-                (row.context_value, values, trades.last_mut())
-            {
-                trade.contexts.push(IndexedSignedContext {
-                    encoded_signer_and_signature: context_value,
-                    values,
-                });
-            }
-        }
-    }
-    trades
 }
 
 fn verify_context(
@@ -736,6 +367,7 @@ mod tests {
     use crate::attribution::{Attribution, AttributionSigner};
     use alloy::primitives::address;
     use rain_math_float::Float;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::sync::atomic::{AtomicBool, Ordering};
     use tempfile::NamedTempFile;
 

--- a/src/attribution_reporting/fetch_batch.sql
+++ b/src/attribution_reporting/fetch_batch.sql
@@ -1,0 +1,68 @@
+WITH batch AS (
+    SELECT
+        chain_id,
+        raindex_address,
+        trade_id,
+        transaction_hash,
+        log_index,
+        block_number,
+        block_timestamp,
+        transaction_sender,
+        order_hash,
+        input_token,
+        input_delta,
+        output_token,
+        output_delta
+    FROM derived_trades
+    WHERE trade_kind = 'take'
+      AND chain_id = ?
+      AND raindex_address = ?
+      AND block_number >= ?
+      AND block_number <= ?
+      AND (
+          ? = 0
+          OR block_number > ?
+          OR (block_number = ? AND log_index > ?)
+          OR (block_number = ? AND log_index = ? AND trade_id > ?)
+      )
+    ORDER BY block_number, log_index, trade_id
+    LIMIT ?
+)
+SELECT
+    b.*,
+    c.context_index,
+    c.context_value,
+    MAX(CASE WHEN v.value_index = 0 THEN v.value END) AS value_0,
+    MAX(CASE WHEN v.value_index = 1 THEN v.value END) AS value_1,
+    MAX(CASE WHEN v.value_index = 2 THEN v.value END) AS value_2,
+    MAX(CASE WHEN v.value_index = 3 THEN v.value END) AS value_3,
+    COUNT(v.value_index) AS value_count
+FROM batch b
+LEFT JOIN take_order_contexts c
+  ON c.chain_id = b.chain_id
+ AND c.raindex_address = b.raindex_address
+ AND c.transaction_hash = b.transaction_hash
+ AND c.log_index = b.log_index
+LEFT JOIN context_values v
+  ON v.chain_id = c.chain_id
+ AND v.raindex_address = c.raindex_address
+ AND v.transaction_hash = c.transaction_hash
+ AND v.log_index = c.log_index
+ AND v.context_index = c.context_index
+GROUP BY
+    b.chain_id,
+    b.raindex_address,
+    b.trade_id,
+    b.transaction_hash,
+    b.log_index,
+    b.block_number,
+    b.block_timestamp,
+    b.transaction_sender,
+    b.order_hash,
+    b.input_token,
+    b.input_delta,
+    b.output_token,
+    b.output_delta,
+    c.context_index,
+    c.context_value
+ORDER BY b.block_number, b.log_index, b.trade_id, c.context_index

--- a/src/attribution_reporting/report.rs
+++ b/src/attribution_reporting/report.rs
@@ -1,0 +1,123 @@
+//! Attribution report aggregation over persisted execution rows.
+
+use crate::db::{attribution as attribution_db, DbPool};
+use rain_math_float::{Float, FloatError};
+use std::ops::{Add, Sub};
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum AttributionReportError {
+    #[error("database query failed: {0}")]
+    Database(#[from] sqlx::Error),
+    #[error("invalid attributed trade amount: {0}")]
+    InvalidAmount(#[from] FloatError),
+}
+
+#[derive(Debug)]
+pub(crate) struct AttributionVolumeRecord {
+    pub(crate) api_key_hash: String,
+    pub(crate) api_key_database_id: Option<i64>,
+    pub(crate) api_key_id: Option<String>,
+    pub(crate) api_key_label: Option<String>,
+    pub(crate) api_key_owner: Option<String>,
+    pub(crate) chain_id: i64,
+    pub(crate) input_token: String,
+    pub(crate) output_token: String,
+    pub(crate) trade_count: u64,
+    pub(crate) total_input: Float,
+    pub(crate) total_output: Float,
+}
+
+pub(crate) struct AttributionVolumePage {
+    pub(crate) records: Vec<AttributionVolumeRecord>,
+    pub(crate) has_more: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct VolumeKey {
+    api_key_hash: String,
+    chain_id: i64,
+    input_token: String,
+    output_token: String,
+}
+
+struct VolumeAccumulator {
+    trade_count: u64,
+    total_input: Float,
+    total_output: Float,
+}
+
+struct VolumeGroup {
+    key: VolumeKey,
+    api_key_database_id: Option<i64>,
+    api_key_id: Option<String>,
+    api_key_label: Option<String>,
+    api_key_owner: Option<String>,
+    accumulator: VolumeAccumulator,
+}
+
+pub(crate) async fn aggregate_volume(
+    pool: &DbPool,
+    filter: attribution_db::AttributionFilter<'_>,
+    cursor: Option<attribution_db::VolumeCursor<'_>>,
+    limit: u32,
+) -> Result<AttributionVolumePage, AttributionReportError> {
+    let mut groups = Vec::<VolumeGroup>::with_capacity(limit as usize);
+    let mut has_more = false;
+    attribution_db::visit_volume_rows(pool, filter, cursor, |row| {
+        let input = Float::from_hex(&row.input_amount)?;
+        let output = Float::zero()?.sub(Float::from_hex(&row.output_amount)?)?;
+        let key = VolumeKey {
+            api_key_hash: row.api_key_hash,
+            chain_id: row.chain_id,
+            input_token: row.input_token,
+            output_token: row.output_token,
+        };
+        if let Some(group) = groups.last_mut().filter(|group| group.key == key) {
+            group.accumulator.trade_count += 1;
+            group.accumulator.total_input = group.accumulator.total_input.add(input)?;
+            group.accumulator.total_output = group.accumulator.total_output.add(output)?;
+        } else if groups.len() < limit as usize {
+            groups.push(VolumeGroup {
+                key,
+                api_key_database_id: row.api_key_database_id,
+                api_key_id: row.api_key_id,
+                api_key_label: row.api_key_label,
+                api_key_owner: row.api_key_owner,
+                accumulator: VolumeAccumulator {
+                    trade_count: 1,
+                    total_input: input,
+                    total_output: output,
+                },
+            });
+        } else {
+            has_more = true;
+            return Ok(false);
+        }
+        Ok(true)
+    })
+    .await
+    .map_err(|error| match error {
+        attribution_db::VisitRowsError::Database(error) => AttributionReportError::Database(error),
+        attribution_db::VisitRowsError::Visitor(error) => {
+            AttributionReportError::InvalidAmount(error)
+        }
+    })?;
+
+    let records = groups
+        .into_iter()
+        .map(|group| AttributionVolumeRecord {
+            api_key_hash: group.key.api_key_hash,
+            api_key_database_id: group.api_key_database_id,
+            api_key_id: group.api_key_id,
+            api_key_label: group.api_key_label,
+            api_key_owner: group.api_key_owner,
+            chain_id: group.key.chain_id,
+            input_token: group.key.input_token,
+            output_token: group.key.output_token,
+            trade_count: group.accumulator.trade_count,
+            total_input: group.accumulator.total_input,
+            total_output: group.accumulator.total_output,
+        })
+        .collect();
+    Ok(AttributionVolumePage { records, has_more })
+}

--- a/src/attribution_reporting/source.rs
+++ b/src/attribution_reporting/source.rs
@@ -1,0 +1,193 @@
+//! Read-only access to attribution inputs in the Raindex local database.
+
+use crate::attribution::ATTRIBUTION_CONTEXT_WORDS;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{FromRow, Sqlite, SqlitePool, Transaction};
+use std::path::Path;
+use std::time::Duration;
+
+const FETCH_BATCH_SQL: &str = include_str!("fetch_batch.sql");
+const SUPPORTED_RAINDEX_SCHEMA_VERSION: u32 = 5;
+const _: () = assert!(
+    rain_orderbook_app_settings::local_db_manifest::DB_SCHEMA_VERSION
+        == SUPPORTED_RAINDEX_SCHEMA_VERSION,
+    "Raindex local database schema changed; review the attribution queries"
+);
+
+#[derive(Debug, FromRow)]
+pub(crate) struct SyncTarget {
+    pub(crate) chain_id: i64,
+    pub(crate) raindex_address: String,
+    pub(crate) last_indexed_block: i64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct IndexedContextRow {
+    chain_id: i64,
+    raindex_address: String,
+    trade_id: String,
+    transaction_hash: String,
+    log_index: i64,
+    block_number: i64,
+    block_timestamp: i64,
+    transaction_sender: String,
+    order_hash: String,
+    input_token: String,
+    input_delta: String,
+    output_token: String,
+    output_delta: String,
+    context_index: Option<i64>,
+    context_value: Option<String>,
+    value_0: Option<String>,
+    value_1: Option<String>,
+    value_2: Option<String>,
+    value_3: Option<String>,
+    value_count: i64,
+}
+
+#[derive(Debug)]
+pub(crate) struct IndexedTrade {
+    pub(crate) chain_id: i64,
+    pub(crate) raindex_address: String,
+    pub(crate) trade_id: String,
+    pub(crate) transaction_hash: String,
+    pub(crate) log_index: i64,
+    pub(crate) block_number: i64,
+    pub(crate) block_timestamp: i64,
+    pub(crate) transaction_sender: String,
+    pub(crate) order_hash: String,
+    pub(crate) input_token: String,
+    pub(crate) input_delta: String,
+    pub(crate) output_token: String,
+    pub(crate) output_delta: String,
+    pub(crate) contexts: Vec<IndexedSignedContext>,
+}
+
+#[derive(Debug)]
+pub(crate) struct IndexedSignedContext {
+    pub(crate) encoded_signer_and_signature: String,
+    pub(crate) values: [String; ATTRIBUTION_CONTEXT_WORDS],
+}
+
+pub(crate) struct BatchCursor<'a> {
+    pub(crate) block: i64,
+    pub(crate) log_index: i64,
+    pub(crate) trade_id: &'a str,
+}
+
+pub(crate) async fn open_pool(path: &Path) -> Result<SqlitePool, sqlx::Error> {
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .read_only(true)
+        .busy_timeout(Duration::from_secs(5));
+    SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await
+}
+
+pub(crate) async fn list_targets(
+    pool: &SqlitePool,
+    chain_id: u32,
+) -> Result<Vec<SyncTarget>, sqlx::Error> {
+    sqlx::query_as::<_, SyncTarget>(
+        "SELECT chain_id, raindex_address, last_block AS last_indexed_block \
+         FROM target_watermarks WHERE chain_id = ? ORDER BY raindex_address",
+    )
+    .bind(i64::from(chain_id))
+    .fetch_all(pool)
+    .await
+}
+
+pub(crate) async fn refresh_watermark(
+    transaction: &mut Transaction<'_, Sqlite>,
+    target: &SyncTarget,
+) -> Result<Option<i64>, sqlx::Error> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT last_block FROM target_watermarks \
+         WHERE chain_id = ? AND raindex_address = ?",
+    )
+    .bind(target.chain_id)
+    .bind(&target.raindex_address)
+    .fetch_optional(&mut **transaction)
+    .await
+}
+
+pub(crate) async fn fetch_batch(
+    transaction: &mut Transaction<'_, Sqlite>,
+    target: &SyncTarget,
+    start_block: i64,
+    cursor: Option<BatchCursor<'_>>,
+    batch_size: u32,
+) -> Result<Vec<IndexedTrade>, sqlx::Error> {
+    let cursor_block = cursor.as_ref().map_or(0, |cursor| cursor.block);
+    let cursor_log_index = cursor.as_ref().map_or(-1, |cursor| cursor.log_index);
+    let cursor_trade_id = cursor.as_ref().map_or("", |cursor| cursor.trade_id);
+    let rows = sqlx::query_as::<_, IndexedContextRow>(FETCH_BATCH_SQL)
+        .bind(target.chain_id)
+        .bind(&target.raindex_address)
+        .bind(start_block)
+        .bind(target.last_indexed_block)
+        .bind(cursor.is_some())
+        .bind(cursor_block)
+        .bind(cursor_block)
+        .bind(cursor_log_index)
+        .bind(cursor_block)
+        .bind(cursor_log_index)
+        .bind(cursor_trade_id)
+        .bind(i64::from(batch_size))
+        .fetch_all(&mut **transaction)
+        .await?;
+    Ok(group_context_rows(rows))
+}
+
+fn group_context_rows(rows: Vec<IndexedContextRow>) -> Vec<IndexedTrade> {
+    let mut trades: Vec<IndexedTrade> = Vec::new();
+    for row in rows {
+        let is_new_trade = trades.last().is_none_or(|trade| {
+            trade.chain_id != row.chain_id
+                || trade.raindex_address != row.raindex_address
+                || trade.trade_id != row.trade_id
+        });
+        if is_new_trade {
+            trades.push(IndexedTrade {
+                chain_id: row.chain_id,
+                raindex_address: row.raindex_address.clone(),
+                trade_id: row.trade_id.clone(),
+                transaction_hash: row.transaction_hash.clone(),
+                log_index: row.log_index,
+                block_number: row.block_number,
+                block_timestamp: row.block_timestamp,
+                transaction_sender: row.transaction_sender.clone(),
+                order_hash: row.order_hash.clone(),
+                input_token: row.input_token.clone(),
+                input_delta: row.input_delta.clone(),
+                output_token: row.output_token.clone(),
+                output_delta: row.output_delta.clone(),
+                contexts: Vec::new(),
+            });
+        }
+
+        let values = match (
+            row.value_0,
+            row.value_1,
+            row.value_2,
+            row.value_3,
+            row.value_count,
+        ) {
+            (Some(v0), Some(v1), Some(v2), Some(v3), 4) => Some([v0, v1, v2, v3]),
+            _ => None,
+        };
+        if row.context_index.is_some() {
+            if let (Some(context_value), Some(values), Some(trade)) =
+                (row.context_value, values, trades.last_mut())
+            {
+                trade.contexts.push(IndexedSignedContext {
+                    encoded_signer_and_signature: context_value,
+                    values,
+                });
+            }
+        }
+    }
+    trades
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,7 @@ async fn create_key(
     .execute(&mut *transaction)
     .await
     .map_err(|e| format!("failed to insert API key: {e}"))?;
-    crate::attribution_reporting::snapshot_api_key(
+    crate::db::attribution::snapshot_api_key(
         &mut transaction,
         insert.last_insert_rowid(),
         &key_id,
@@ -200,15 +200,9 @@ async fn delete_key(pool: &DbPool, key_id: &str) -> Result<(), Box<dyn std::erro
             .await
             .map_err(|e| format!("failed to query API key before deletion: {e}"))?;
     if let Some((id, label, owner)) = identity {
-        crate::attribution_reporting::snapshot_api_key(
-            &mut transaction,
-            id,
-            key_id,
-            &label,
-            &owner,
-        )
-        .await
-        .map_err(|e| format!("failed to preserve API key attribution identity: {e}"))?;
+        crate::db::attribution::snapshot_api_key(&mut transaction, id, key_id, &label, &owner)
+            .await
+            .map_err(|e| format!("failed to preserve API key attribution identity: {e}"))?;
     }
     let result = sqlx::query("DELETE FROM api_keys WHERE key_id = ?")
         .bind(key_id)

--- a/src/db/attribution.rs
+++ b/src/db/attribution.rs
@@ -1,0 +1,454 @@
+//! Persistence for confirmed trade attribution and reporting.
+
+use super::DbPool;
+use crate::attribution::compute_api_key_hash;
+use alloy::primitives::{Address, B256};
+use futures::TryStreamExt;
+use sqlx::{FromRow, QueryBuilder, Sqlite, Transaction};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, FromRow)]
+pub(crate) struct ApiKeyIdentity {
+    pub(crate) id: i64,
+    pub(crate) key_id: String,
+    pub(crate) label: String,
+    pub(crate) owner: String,
+}
+
+#[derive(Debug, FromRow)]
+pub(crate) struct AttributionCursor {
+    pub(crate) start_block: i64,
+    pub(crate) last_block: i64,
+    pub(crate) last_log_index: i64,
+    pub(crate) last_trade_id: String,
+}
+
+pub(crate) struct CursorPosition<'a> {
+    pub(crate) block: i64,
+    pub(crate) log_index: i64,
+    pub(crate) trade_id: &'a str,
+}
+
+pub(crate) struct NewAttributedTrade<'a> {
+    pub(crate) chain_id: i64,
+    pub(crate) raindex_address: String,
+    pub(crate) indexed_trade_id: String,
+    pub(crate) transaction_hash: String,
+    pub(crate) log_index: i64,
+    pub(crate) block_number: i64,
+    pub(crate) block_timestamp: i64,
+    pub(crate) order_hash: String,
+    pub(crate) taker: String,
+    pub(crate) api_key_hash: B256,
+    pub(crate) identity: Option<&'a ApiKeyIdentity>,
+    pub(crate) input_token: String,
+    pub(crate) input_amount: String,
+    pub(crate) output_token: String,
+    pub(crate) output_amount: String,
+}
+
+pub(crate) async fn snapshot_current_api_keys(pool: &DbPool) -> Result<(), sqlx::Error> {
+    let identities = sqlx::query_as::<_, ApiKeyIdentity>(
+        "SELECT id, key_id, label, owner FROM api_keys ORDER BY id",
+    )
+    .fetch_all(pool)
+    .await?;
+    let mut transaction = pool.begin().await?;
+    for identity in identities {
+        upsert_api_key_identity(&mut transaction, &identity).await?;
+    }
+    transaction.commit().await
+}
+
+pub(crate) async fn snapshot_api_key(
+    transaction: &mut Transaction<'_, Sqlite>,
+    id: i64,
+    key_id: &str,
+    label: &str,
+    owner: &str,
+) -> Result<(), sqlx::Error> {
+    upsert_api_key_identity(
+        transaction,
+        &ApiKeyIdentity {
+            id,
+            key_id: key_id.to_string(),
+            label: label.to_string(),
+            owner: owner.to_string(),
+        },
+    )
+    .await
+}
+
+async fn upsert_api_key_identity(
+    transaction: &mut Transaction<'_, Sqlite>,
+    identity: &ApiKeyIdentity,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO attribution_api_keys (\
+            api_key_hash, api_key_database_id, api_key_id, api_key_label, api_key_owner\
+         ) VALUES (?, ?, ?, ?, ?) \
+         ON CONFLICT(api_key_hash) DO UPDATE SET \
+            api_key_database_id = excluded.api_key_database_id, \
+            api_key_id = excluded.api_key_id, \
+            api_key_label = excluded.api_key_label, \
+            api_key_owner = excluded.api_key_owner, \
+            updated_at = datetime('now') \
+         WHERE api_key_database_id IS NOT excluded.api_key_database_id \
+            OR api_key_id IS NOT excluded.api_key_id \
+            OR api_key_label IS NOT excluded.api_key_label \
+            OR api_key_owner IS NOT excluded.api_key_owner",
+    )
+    .bind(compute_api_key_hash(&identity.key_id).to_string())
+    .bind(identity.id)
+    .bind(&identity.key_id)
+    .bind(&identity.label)
+    .bind(&identity.owner)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn load_api_key_identities(
+    pool: &DbPool,
+) -> Result<Vec<ApiKeyIdentity>, sqlx::Error> {
+    sqlx::query_as::<_, ApiKeyIdentity>(
+        "SELECT api_key_database_id AS id, api_key_id AS key_id, \
+                api_key_label AS label, api_key_owner AS owner \
+         FROM attribution_api_keys ORDER BY api_key_id",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+pub(crate) async fn record_signer(pool: &DbPool, signer: Address) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO attribution_signers (address) VALUES (?) \
+         ON CONFLICT(address) DO NOTHING",
+    )
+    .bind(signer.to_string())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn load_signers(pool: &DbPool) -> Result<Vec<Address>, sqlx::Error> {
+    let values: Vec<String> =
+        sqlx::query_scalar("SELECT address FROM attribution_signers ORDER BY first_seen_at")
+            .fetch_all(pool)
+            .await?;
+    Ok(values
+        .into_iter()
+        .filter_map(|value| match Address::from_str(&value) {
+            Ok(address) => Some(address),
+            Err(error) => {
+                tracing::error!(%error, address = %value, "invalid trusted attribution signer");
+                None
+            }
+        })
+        .collect())
+}
+
+pub(crate) async fn load_cursor(
+    transaction: &mut Transaction<'_, Sqlite>,
+    chain_id: i64,
+    raindex_address: &str,
+) -> Result<Option<AttributionCursor>, sqlx::Error> {
+    sqlx::query_as::<_, AttributionCursor>(
+        "SELECT start_block, last_block, last_log_index, last_trade_id \
+         FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?",
+    )
+    .bind(chain_id)
+    .bind(raindex_address)
+    .fetch_optional(&mut **transaction)
+    .await
+}
+
+pub(crate) async fn store_batch(
+    transaction: &mut Transaction<'_, Sqlite>,
+    chain_id: i64,
+    raindex_address: &str,
+    start_block: i64,
+    next_cursor: CursorPosition<'_>,
+    trades: &[NewAttributedTrade<'_>],
+) -> Result<(), sqlx::Error> {
+    for trade in trades {
+        let identity = trade.identity.as_ref();
+        sqlx::query(
+            "INSERT INTO attributed_trades (\
+                chain_id, raindex_address, indexed_trade_id, transaction_hash, log_index, \
+                block_number, block_timestamp, order_hash, taker, api_key_hash, \
+                api_key_database_id, api_key_id, api_key_label, api_key_owner, \
+                input_token, input_amount, output_token, output_amount\
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) \
+             ON CONFLICT(chain_id, raindex_address, indexed_trade_id) DO UPDATE SET \
+                api_key_database_id = excluded.api_key_database_id, \
+                api_key_id = excluded.api_key_id, \
+                api_key_label = excluded.api_key_label, \
+                api_key_owner = excluded.api_key_owner, \
+                updated_at = datetime('now')",
+        )
+        .bind(trade.chain_id)
+        .bind(&trade.raindex_address)
+        .bind(&trade.indexed_trade_id)
+        .bind(&trade.transaction_hash)
+        .bind(trade.log_index)
+        .bind(trade.block_number)
+        .bind(trade.block_timestamp)
+        .bind(&trade.order_hash)
+        .bind(&trade.taker)
+        .bind(trade.api_key_hash.to_string())
+        .bind(identity.map(|value| value.id))
+        .bind(identity.map(|value| value.key_id.as_str()))
+        .bind(identity.map(|value| value.label.as_str()))
+        .bind(identity.map(|value| value.owner.as_str()))
+        .bind(&trade.input_token)
+        .bind(&trade.input_amount)
+        .bind(&trade.output_token)
+        .bind(&trade.output_amount)
+        .execute(&mut **transaction)
+        .await?;
+    }
+    sqlx::query(
+        "INSERT INTO attribution_sync_cursors (\
+            chain_id, raindex_address, start_block, last_block, last_log_index, last_trade_id\
+         ) VALUES (?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(chain_id, raindex_address) DO UPDATE SET \
+            start_block = excluded.start_block, \
+            last_block = excluded.last_block, \
+            last_log_index = excluded.last_log_index, \
+            last_trade_id = excluded.last_trade_id, \
+            updated_at = datetime('now')",
+    )
+    .bind(chain_id)
+    .bind(raindex_address)
+    .bind(start_block)
+    .bind(next_cursor.block)
+    .bind(next_cursor.log_index)
+    .bind(next_cursor.trade_id)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+pub(crate) async fn reset_target(
+    transaction: &mut Transaction<'_, Sqlite>,
+    chain_id: i64,
+    raindex_address: &str,
+    configured_start_block: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "DELETE FROM attributed_trades \
+         WHERE chain_id = ? AND raindex_address = ? AND block_number < ?",
+    )
+    .bind(chain_id)
+    .bind(raindex_address)
+    .bind(configured_start_block)
+    .execute(&mut **transaction)
+    .await?;
+    sqlx::query("DELETE FROM attribution_sync_cursors WHERE chain_id = ? AND raindex_address = ?")
+        .bind(chain_id)
+        .bind(raindex_address)
+        .execute(&mut **transaction)
+        .await?;
+    Ok(())
+}
+
+#[derive(Debug, FromRow)]
+pub(crate) struct AttributedTradeRow {
+    pub(crate) indexed_trade_id: String,
+    pub(crate) chain_id: i64,
+    pub(crate) raindex_address: String,
+    pub(crate) transaction_hash: String,
+    pub(crate) log_index: i64,
+    pub(crate) block_number: i64,
+    pub(crate) block_timestamp: i64,
+    pub(crate) order_hash: String,
+    pub(crate) taker: String,
+    pub(crate) api_key_hash: String,
+    pub(crate) api_key_database_id: Option<i64>,
+    pub(crate) api_key_id: Option<String>,
+    pub(crate) api_key_label: Option<String>,
+    pub(crate) api_key_owner: Option<String>,
+    pub(crate) input_token: String,
+    pub(crate) input_amount: String,
+    pub(crate) output_token: String,
+    pub(crate) output_amount: String,
+}
+
+pub(crate) struct AttributionFilter<'a> {
+    pub(crate) api_key_hash: Option<&'a str>,
+    pub(crate) start_block: Option<i64>,
+    pub(crate) end_block: Option<i64>,
+    pub(crate) transaction_hash: Option<&'a str>,
+}
+
+pub(crate) struct ExecutionCursor<'a> {
+    pub(crate) block: i64,
+    pub(crate) log_index: i64,
+    pub(crate) trade_id: &'a str,
+}
+
+pub(crate) async fn list_attributed_trades(
+    pool: &DbPool,
+    filter: AttributionFilter<'_>,
+    cursor: Option<ExecutionCursor<'_>>,
+    limit: u32,
+) -> Result<Vec<AttributedTradeRow>, sqlx::Error> {
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT indexed_trade_id, chain_id, raindex_address, transaction_hash, log_index, block_number, \
+                block_timestamp, order_hash, taker, api_key_hash, api_key_database_id, api_key_id, \
+                api_key_label, api_key_owner, input_token, input_amount, output_token, output_amount \
+         FROM attributed_trades WHERE 1 = 1",
+    );
+    push_filters(&mut query, filter);
+    if let Some(cursor) = cursor {
+        query
+            .push(" AND (block_number < ")
+            .push_bind(cursor.block)
+            .push(" OR (block_number = ")
+            .push_bind(cursor.block)
+            .push(" AND log_index < ")
+            .push_bind(cursor.log_index)
+            .push(") OR (block_number = ")
+            .push_bind(cursor.block)
+            .push(" AND log_index = ")
+            .push_bind(cursor.log_index)
+            .push(" AND indexed_trade_id < ")
+            .push_bind(cursor.trade_id)
+            .push("))");
+    }
+    query
+        .push(" ORDER BY block_number DESC, log_index DESC, indexed_trade_id DESC LIMIT ")
+        .push_bind(i64::from(limit));
+    query
+        .build_query_as::<AttributedTradeRow>()
+        .fetch_all(pool)
+        .await
+}
+
+#[derive(Debug, FromRow)]
+pub(crate) struct AttributionVolumeRow {
+    pub(crate) chain_id: i64,
+    pub(crate) api_key_hash: String,
+    pub(crate) api_key_database_id: Option<i64>,
+    pub(crate) api_key_id: Option<String>,
+    pub(crate) api_key_label: Option<String>,
+    pub(crate) api_key_owner: Option<String>,
+    pub(crate) input_token: String,
+    pub(crate) input_amount: String,
+    pub(crate) output_token: String,
+    pub(crate) output_amount: String,
+}
+
+pub(crate) struct VolumeCursor<'a> {
+    pub(crate) api_key_hash: &'a str,
+    pub(crate) chain_id: i64,
+    pub(crate) input_token: &'a str,
+    pub(crate) output_token: &'a str,
+}
+
+pub(crate) enum VisitRowsError<E> {
+    Database(sqlx::Error),
+    Visitor(E),
+}
+
+pub(crate) async fn visit_volume_rows<E, F>(
+    pool: &DbPool,
+    filter: AttributionFilter<'_>,
+    cursor: Option<VolumeCursor<'_>>,
+    mut visitor: F,
+) -> Result<(), VisitRowsError<E>>
+where
+    F: FnMut(AttributionVolumeRow) -> Result<bool, E>,
+{
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT trades.chain_id, trades.api_key_hash, \
+                identity.api_key_database_id, identity.api_key_id, \
+                identity.api_key_label, identity.api_key_owner, \
+                trades.input_token, trades.input_amount, \
+                trades.output_token, trades.output_amount \
+         FROM attributed_trades AS trades \
+         LEFT JOIN attribution_api_keys AS identity \
+           ON identity.api_key_hash = trades.api_key_hash \
+         WHERE 1 = 1",
+    );
+    push_volume_filters(&mut query, filter);
+    if let Some(cursor) = cursor {
+        query
+            .push(" AND (trades.api_key_hash > ")
+            .push_bind(cursor.api_key_hash)
+            .push(" OR (trades.api_key_hash = ")
+            .push_bind(cursor.api_key_hash)
+            .push(" AND trades.chain_id > ")
+            .push_bind(cursor.chain_id)
+            .push(") OR (trades.api_key_hash = ")
+            .push_bind(cursor.api_key_hash)
+            .push(" AND trades.chain_id = ")
+            .push_bind(cursor.chain_id)
+            .push(" AND trades.input_token > ")
+            .push_bind(cursor.input_token)
+            .push(") OR (trades.api_key_hash = ")
+            .push_bind(cursor.api_key_hash)
+            .push(" AND trades.chain_id = ")
+            .push_bind(cursor.chain_id)
+            .push(" AND trades.input_token = ")
+            .push_bind(cursor.input_token)
+            .push(" AND trades.output_token > ")
+            .push_bind(cursor.output_token)
+            .push("))");
+    }
+    query.push(
+        " ORDER BY trades.api_key_hash, trades.chain_id, \
+                   trades.input_token, trades.output_token",
+    );
+    let mut rows = query.build_query_as::<AttributionVolumeRow>().fetch(pool);
+    while let Some(row) = rows.try_next().await.map_err(VisitRowsError::Database)? {
+        if !visitor(row).map_err(VisitRowsError::Visitor)? {
+            break;
+        }
+    }
+    Ok(())
+}
+
+fn push_volume_filters<'args>(
+    query: &mut QueryBuilder<'args, Sqlite>,
+    filter: AttributionFilter<'args>,
+) {
+    if let Some(api_key_hash) = filter.api_key_hash {
+        query
+            .push(" AND trades.api_key_hash = ")
+            .push_bind(api_key_hash);
+    }
+    if let Some(start_block) = filter.start_block {
+        query
+            .push(" AND trades.block_number >= ")
+            .push_bind(start_block);
+    }
+    if let Some(end_block) = filter.end_block {
+        query
+            .push(" AND trades.block_number <= ")
+            .push_bind(end_block);
+    }
+    if let Some(transaction_hash) = filter.transaction_hash {
+        query
+            .push(" AND trades.transaction_hash = ")
+            .push_bind(transaction_hash);
+    }
+}
+
+fn push_filters<'args>(query: &mut QueryBuilder<'args, Sqlite>, filter: AttributionFilter<'args>) {
+    if let Some(api_key_hash) = filter.api_key_hash {
+        query.push(" AND api_key_hash = ").push_bind(api_key_hash);
+    }
+    if let Some(start_block) = filter.start_block {
+        query.push(" AND block_number >= ").push_bind(start_block);
+    }
+    if let Some(end_block) = filter.end_block {
+        query.push(" AND block_number <= ").push_bind(end_block);
+    }
+    if let Some(transaction_hash) = filter.transaction_hash {
+        query
+            .push(" AND transaction_hash = ")
+            .push_bind(transaction_hash);
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod attribution;
 mod migrate;
 mod pool;
 pub(crate) mod registry_history;

--- a/src/routes/attribution_admin.rs
+++ b/src/routes/attribution_admin.rs
@@ -1,16 +1,15 @@
+use crate::attribution_reporting::report as attribution_report;
 use crate::auth::AdminKey;
-use crate::db::DbPool;
+use crate::db::{attribution as attribution_db, DbPool};
 use crate::error::{ApiError, ApiErrorResponse};
 use crate::fairings::{GlobalRateLimit, TracingSpan};
 use alloy::primitives::{Address, B256};
-use futures::TryStreamExt;
 use rain_math_float::Float;
 use rocket::form::FromForm;
 use rocket::serde::json::Json;
 use rocket::{Route, State};
 use serde::Serialize;
-use sqlx::{FromRow, QueryBuilder, Sqlite};
-use std::ops::{Add, Sub};
+use std::ops::Sub;
 use std::str::FromStr;
 use tracing::Instrument;
 use utoipa::{IntoParams, ToSchema};
@@ -137,80 +136,12 @@ pub struct AttributionVolumeCursor {
     pub after_output_token: String,
 }
 
-#[derive(Debug, Clone, FromRow)]
-struct AttributedTradeRow {
-    indexed_trade_id: String,
-    chain_id: i64,
-    raindex_address: String,
-    transaction_hash: String,
-    log_index: i64,
-    block_number: i64,
-    block_timestamp: i64,
-    order_hash: String,
-    taker: String,
-    api_key_hash: String,
-    api_key_database_id: Option<i64>,
-    api_key_id: Option<String>,
-    api_key_label: Option<String>,
-    api_key_owner: Option<String>,
-    input_token: String,
-    input_amount: String,
-    output_token: String,
-    output_amount: String,
-}
-
-#[derive(Debug, FromRow)]
-struct AttributionVolumeRow {
-    chain_id: i64,
-    api_key_hash: String,
-    api_key_database_id: Option<i64>,
-    api_key_id: Option<String>,
-    api_key_label: Option<String>,
-    api_key_owner: Option<String>,
-    input_token: String,
-    input_amount: String,
-    output_token: String,
-    output_amount: String,
-}
-
-#[derive(Debug)]
-struct VolumeGroup {
-    key: VolumeKey,
-    api_key_database_id: Option<i64>,
-    api_key_id: Option<String>,
-    api_key_label: Option<String>,
-    api_key_owner: Option<String>,
-    accumulator: VolumeAccumulator,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct VolumeKey {
-    api_key_hash: String,
-    chain_id: i64,
-    input_token: String,
-    output_token: String,
-}
-
-#[derive(Debug)]
-struct VolumeAccumulator {
-    trade_count: u64,
-    total_input: Float,
-    total_output: Float,
-}
-
-struct ExecutionCursorFilter<'a> {
-    block: i64,
-    log_index: i64,
-    trade_id: &'a str,
-}
-
 struct VolumeCursorFilter {
     api_key_hash: String,
     chain_id: i64,
     input_token: String,
     output_token: String,
 }
-
 #[utoipa::path(
     get,
     path = "/admin/attribution/executions",
@@ -337,48 +268,28 @@ async fn query_attributed_trades(
     start_block: Option<u64>,
     end_block: Option<u64>,
     transaction_hash: Option<&str>,
-    cursor: Option<&ExecutionCursorFilter<'_>>,
+    cursor: Option<&attribution_db::ExecutionCursor<'_>>,
     limit: u32,
-) -> Result<Vec<AttributedTradeRow>, ApiError> {
+) -> Result<Vec<attribution_db::AttributedTradeRow>, ApiError> {
     let start_block = optional_sqlite_integer(start_block, "startBlock")?;
     let end_block = optional_sqlite_integer(end_block, "endBlock")?;
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT indexed_trade_id, chain_id, raindex_address, transaction_hash, log_index, block_number, \
-                block_timestamp, order_hash, taker, api_key_hash, api_key_database_id, api_key_id, \
-                api_key_label, api_key_owner, input_token, input_amount, output_token, output_amount \
-         FROM attributed_trades WHERE 1 = 1",
-    );
-    push_filters(
-        &mut query,
-        api_key_hash,
-        start_block,
-        end_block,
-        transaction_hash,
-    );
-    if let Some(cursor) = cursor {
-        query
-            .push(" AND (block_number < ")
-            .push_bind(cursor.block)
-            .push(" OR (block_number = ")
-            .push_bind(cursor.block)
-            .push(" AND log_index < ")
-            .push_bind(cursor.log_index)
-            .push(") OR (block_number = ")
-            .push_bind(cursor.block)
-            .push(" AND log_index = ")
-            .push_bind(cursor.log_index)
-            .push(" AND indexed_trade_id < ")
-            .push_bind(cursor.trade_id)
-            .push("))");
-    }
-    query
-        .push(" ORDER BY block_number DESC, log_index DESC, indexed_trade_id DESC LIMIT ")
-        .push_bind(i64::from(limit));
-    query
-        .build_query_as::<AttributedTradeRow>()
-        .fetch_all(pool)
-        .await
-        .map_err(query_error)
+    attribution_db::list_attributed_trades(
+        pool,
+        attribution_db::AttributionFilter {
+            api_key_hash,
+            start_block,
+            end_block,
+            transaction_hash,
+        },
+        cursor.map(|cursor| attribution_db::ExecutionCursor {
+            block: cursor.block,
+            log_index: cursor.log_index,
+            trade_id: cursor.trade_id,
+        }),
+        limit,
+    )
+    .await
+    .map_err(query_error)
 }
 
 async fn aggregate_volume(
@@ -391,172 +302,58 @@ async fn aggregate_volume(
 ) -> Result<(Vec<AttributionVolume>, Option<AttributionVolumeCursor>), ApiError> {
     let start_block = optional_sqlite_integer(start_block, "startBlock")?;
     let end_block = optional_sqlite_integer(end_block, "endBlock")?;
-    let mut query = QueryBuilder::<Sqlite>::new(
-        "SELECT trades.chain_id, trades.api_key_hash, \
-                identity.api_key_database_id, identity.api_key_id, \
-                identity.api_key_label, identity.api_key_owner, \
-                trades.input_token, trades.input_amount, \
-                trades.output_token, trades.output_amount \
-         FROM attributed_trades AS trades \
-         LEFT JOIN attribution_api_keys AS identity \
-           ON identity.api_key_hash = trades.api_key_hash \
-         WHERE 1 = 1",
-    );
-    if let Some(api_key_hash) = api_key_hash {
-        query
-            .push(" AND trades.api_key_hash = ")
-            .push_bind(api_key_hash);
-    }
-    if let Some(start_block) = start_block {
-        query
-            .push(" AND trades.block_number >= ")
-            .push_bind(start_block);
-    }
-    if let Some(end_block) = end_block {
-        query
-            .push(" AND trades.block_number <= ")
-            .push_bind(end_block);
-    }
-    if let Some(cursor) = cursor {
-        push_volume_cursor(&mut query, cursor);
-    }
-    query.push(
-        " ORDER BY trades.api_key_hash, trades.chain_id, \
-                   trades.input_token, trades.output_token",
-    );
-
-    let mut rows = query.build_query_as::<AttributionVolumeRow>().fetch(pool);
-    let mut groups = Vec::<VolumeGroup>::with_capacity(limit as usize);
-    let mut has_more = false;
-    while let Some(row) = rows.try_next().await.map_err(query_error)? {
-        let input = parse_float(&row.input_amount)?;
-        let signed_output = parse_float(&row.output_amount)?;
-        let output = Float::zero()
-            .and_then(|zero| zero.sub(signed_output))
-            .map_err(float_error)?;
-        let key = VolumeKey {
-            api_key_hash: row.api_key_hash,
-            chain_id: row.chain_id,
-            input_token: row.input_token,
-            output_token: row.output_token,
-        };
-        if let Some(group) = groups.last_mut().filter(|group| group.key == key) {
-            group.accumulator.trade_count += 1;
-            group.accumulator.total_input = group
-                .accumulator
-                .total_input
-                .add(input)
-                .map_err(float_error)?;
-            group.accumulator.total_output = group
-                .accumulator
-                .total_output
-                .add(output)
-                .map_err(float_error)?;
-        } else if groups.len() < limit as usize {
-            groups.push(VolumeGroup {
-                key,
-                api_key_database_id: row.api_key_database_id,
-                api_key_id: row.api_key_id,
-                api_key_label: row.api_key_label,
-                api_key_owner: row.api_key_owner,
-                accumulator: VolumeAccumulator {
-                    trade_count: 1,
-                    total_input: input,
-                    total_output: output,
-                },
-            });
-        } else {
-            has_more = true;
-            break;
-        }
-    }
-    drop(rows);
-
-    let next_cursor = if has_more {
-        groups
+    let page = attribution_report::aggregate_volume(
+        pool,
+        attribution_db::AttributionFilter {
+            api_key_hash,
+            start_block,
+            end_block,
+            transaction_hash: None,
+        },
+        cursor.map(|cursor| attribution_db::VolumeCursor {
+            api_key_hash: &cursor.api_key_hash,
+            chain_id: cursor.chain_id,
+            input_token: &cursor.input_token,
+            output_token: &cursor.output_token,
+        }),
+        limit,
+    )
+    .await
+    .map_err(attribution_read_error)?;
+    let volume = page
+        .records
+        .into_iter()
+        .map(|record| {
+            Ok(AttributionVolume {
+                api_key_hash: record.api_key_hash,
+                api_key_database_id: record.api_key_database_id,
+                api_key_id: record.api_key_id,
+                api_key_label: record.api_key_label,
+                api_key_owner: record.api_key_owner,
+                chain_id: to_u32(record.chain_id, "chain id")?,
+                input_token: record.input_token,
+                output_token: record.output_token,
+                trade_count: record.trade_count,
+                total_input_amount: record.total_input.format().map_err(float_error)?,
+                total_output_amount: record.total_output.format().map_err(float_error)?,
+            })
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+    let next_cursor = if page.has_more {
+        volume
             .last()
-            .map(|group| AttributionVolumeCursor::try_from(&group.key))
+            .map(AttributionVolumeCursor::try_from)
             .transpose()?
     } else {
         None
     };
-    let volume = groups
-        .into_iter()
-        .map(|group| {
-            Ok(AttributionVolume {
-                api_key_hash: group.key.api_key_hash,
-                api_key_database_id: group.api_key_database_id,
-                api_key_id: group.api_key_id,
-                api_key_label: group.api_key_label,
-                api_key_owner: group.api_key_owner,
-                chain_id: to_u32(group.key.chain_id, "chain id")?,
-                input_token: group.key.input_token,
-                output_token: group.key.output_token,
-                trade_count: group.accumulator.trade_count,
-                total_input_amount: group
-                    .accumulator
-                    .total_input
-                    .format()
-                    .map_err(float_error)?,
-                total_output_amount: group
-                    .accumulator
-                    .total_output
-                    .format()
-                    .map_err(float_error)?,
-            })
-        })
-        .collect::<Result<Vec<_>, ApiError>>()?;
     Ok((volume, next_cursor))
 }
 
-fn push_volume_cursor<'args>(
-    query: &mut QueryBuilder<'args, Sqlite>,
-    cursor: &'args VolumeCursorFilter,
-) {
-    query
-        .push(" AND (trades.api_key_hash > ")
-        .push_bind(&cursor.api_key_hash)
-        .push(" OR (trades.api_key_hash = ")
-        .push_bind(&cursor.api_key_hash)
-        .push(" AND trades.chain_id > ")
-        .push_bind(cursor.chain_id)
-        .push(") OR (trades.api_key_hash = ")
-        .push_bind(&cursor.api_key_hash)
-        .push(" AND trades.chain_id = ")
-        .push_bind(cursor.chain_id)
-        .push(" AND trades.input_token > ")
-        .push_bind(&cursor.input_token)
-        .push(") OR (trades.api_key_hash = ")
-        .push_bind(&cursor.api_key_hash)
-        .push(" AND trades.chain_id = ")
-        .push_bind(cursor.chain_id)
-        .push(" AND trades.input_token = ")
-        .push_bind(&cursor.input_token)
-        .push(" AND trades.output_token > ")
-        .push_bind(&cursor.output_token)
-        .push("))");
-}
-
-fn push_filters<'args>(
-    query: &mut QueryBuilder<'args, Sqlite>,
-    api_key_hash: Option<&'args str>,
-    start_block: Option<i64>,
-    end_block: Option<i64>,
-    transaction_hash: Option<&'args str>,
-) {
-    if let Some(api_key_hash) = api_key_hash {
-        query.push(" AND api_key_hash = ").push_bind(api_key_hash);
-    }
-    if let Some(start_block) = start_block {
-        query.push(" AND block_number >= ").push_bind(start_block);
-    }
-    if let Some(end_block) = end_block {
-        query.push(" AND block_number <= ").push_bind(end_block);
-    }
-    if let Some(transaction_hash) = transaction_hash {
-        query
-            .push(" AND transaction_hash = ")
-            .push_bind(transaction_hash);
+fn attribution_read_error(error: attribution_report::AttributionReportError) -> ApiError {
+    match error {
+        attribution_report::AttributionReportError::Database(error) => query_error(error),
+        attribution_report::AttributionReportError::InvalidAmount(error) => float_error(error),
     }
 }
 
@@ -565,10 +362,10 @@ fn query_error(error: sqlx::Error) -> ApiError {
     ApiError::Internal("failed to query attribution report".into())
 }
 
-impl TryFrom<AttributedTradeRow> for AttributedExecution {
+impl TryFrom<attribution_db::AttributedTradeRow> for AttributedExecution {
     type Error = ApiError;
 
-    fn try_from(row: AttributedTradeRow) -> Result<Self, Self::Error> {
+    fn try_from(row: attribution_db::AttributedTradeRow) -> Result<Self, Self::Error> {
         let signed_output = parse_float(&row.output_amount)?;
         let output = Float::zero()
             .and_then(|zero| zero.sub(signed_output))
@@ -599,10 +396,10 @@ impl TryFrom<AttributedTradeRow> for AttributedExecution {
     }
 }
 
-impl TryFrom<&AttributedTradeRow> for AttributionExecutionCursor {
+impl TryFrom<&attribution_db::AttributedTradeRow> for AttributionExecutionCursor {
     type Error = ApiError;
 
-    fn try_from(row: &AttributedTradeRow) -> Result<Self, Self::Error> {
+    fn try_from(row: &attribution_db::AttributedTradeRow) -> Result<Self, Self::Error> {
         Ok(Self {
             before_block: to_u64(row.block_number, "block number")?,
             before_log_index: to_u64(row.log_index, "log index")?,
@@ -611,22 +408,22 @@ impl TryFrom<&AttributedTradeRow> for AttributionExecutionCursor {
     }
 }
 
-impl TryFrom<&VolumeKey> for AttributionVolumeCursor {
+impl TryFrom<&AttributionVolume> for AttributionVolumeCursor {
     type Error = ApiError;
 
-    fn try_from(key: &VolumeKey) -> Result<Self, Self::Error> {
+    fn try_from(volume: &AttributionVolume) -> Result<Self, Self::Error> {
         Ok(Self {
-            after_api_key_hash: key.api_key_hash.clone(),
-            after_chain_id: to_u32(key.chain_id, "chain id")?,
-            after_input_token: key.input_token.clone(),
-            after_output_token: key.output_token.clone(),
+            after_api_key_hash: volume.api_key_hash.clone(),
+            after_chain_id: volume.chain_id,
+            after_input_token: volume.input_token.clone(),
+            after_output_token: volume.output_token.clone(),
         })
     }
 }
 
 fn execution_cursor_filter(
     params: &AttributionExecutionParams,
-) -> Result<Option<ExecutionCursorFilter<'_>>, ApiError> {
+) -> Result<Option<attribution_db::ExecutionCursor<'_>>, ApiError> {
     match (
         params.before_block,
         params.before_log_index,
@@ -634,7 +431,7 @@ fn execution_cursor_filter(
     ) {
         (None, None, None) => Ok(None),
         (Some(block), Some(log_index), Some(trade_id)) if !trade_id.is_empty() => {
-            Ok(Some(ExecutionCursorFilter {
+            Ok(Some(attribution_db::ExecutionCursor {
                 block: i64::try_from(block)
                     .map_err(|_| ApiError::BadRequest("beforeBlock is too large".into()))?,
                 log_index: i64::try_from(log_index)


### PR DESCRIPTION
## Chained PR

- Requires #161 (`feat: report customer volume from attributed trades`) to merge first.
- This PR is a behavior-preserving organization pass over the attribution reporting implementation.

## Motivation

#161 intentionally prioritizes getting private, execution-backed customer volume reporting in place. Its first implementation leaves Raindex reads, application-database persistence, report aggregation, worker orchestration, and HTTP concerns too close together, making future query and schema changes harder to review safely.

## Solution

- Put all read-only Raindex access behind a dedicated source adapter, including the compile-time schema-version guard and stable batch cursor.
- Move the large static attribution query into a formatted `fetch_batch.sql` file while preserving its bindings and ordering.
- Centralize application-database attribution persistence, cursor updates, API-key snapshots, signer history, and admin query construction in `db::attribution`.
- Move exact Rain-float parsing and volume aggregation into a reporting-domain module.
- Keep the background worker responsible for orchestration and signature verification only.
- Keep admin routes responsible for authorization, request validation, error mapping, and response serialization only.
- Replace the batch cursor's boolean-plus-sentinel representation with `Option<BatchCursor>` so invalid cursor states cannot be constructed.
- Borrow API-key identity data while persisting a batch and preallocate trade rows to avoid repeated per-trade string cloning and reallocations.

## Intentionally unchanged

- No REST API, OpenAPI, configuration, migration, or database-schema changes.
- No attribution signature, query filtering, pagination, transaction, retry, or report semantics changes.
- No new environment variables or secrets.

## Checks

- `nix develop -c cargo check`
- `nix develop -c cargo test attribution` (12 passed)
- `nix develop -c cargo test cli::tests` (10 passed)
- `nix develop -c cargo nextest run --workspace --status-level fail --final-status-level pass` (311 passed)
- `nix develop -c cargo test --features oracle-integration-tests test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution`
- `nix develop -c rainix-rs-static`
- `nix build .#st0x-docs --no-link`
- `nix develop -c git diff --cached --check`
- Three-angle simplification pass; all actionable findings fixed.
- Two independent staged local reviews; no actionable findings.

## Local build note

`nix build --impure .#st0x-rest-api --no-link` reaches the existing `libusb1-sys` build script and fails on this macOS host because `sw_vers` is unavailable inside the Nix sandbox, before the project crate is built. The pull-request Linux build remains the authoritative package-build check.
