### PR TITLE
fix: unblock attribution credential deployment

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -93,3 +93,30 @@ jobs:
       - name: Deploy system and service
         if: (inputs.deploy_scope || 'service') == 'all'
         run: nix run .#deployAll
+      - name: Verify attribution-enabled service
+        run: |
+          invocation_id=$(ssh "root@$HOST_IP" \
+            'systemctl show --property=InvocationID --value rest-api.service')
+          if [[ ! "$invocation_id" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "Unable to identify the deployed rest-api invocation" >&2
+            exit 1
+          fi
+
+          for _ in $(seq 1 30); do
+            if ssh "root@$HOST_IP" \
+              "journalctl _SYSTEMD_INVOCATION_ID=$invocation_id --no-pager | grep -Fq 'attribution signer loaded'" \
+              && curl --fail --silent --max-time 3 \
+                https://api.st0x.io/health >/dev/null \
+              && ssh "root@$HOST_IP" \
+                'systemctl is-active --quiet rest-api.service'; then
+              exit 0
+            fi
+            sleep 2
+          done
+
+          ssh "root@$HOST_IP" \
+            'systemctl status rest-api.service --no-pager' || true
+          ssh "root@$HOST_IP" \
+            "journalctl _SYSTEMD_INVOCATION_ID=$invocation_id --no-pager" || true
+          echo "Attribution-enabled service verification timed out" >&2
+          exit 1

--- a/os.nix
+++ b/os.nix
@@ -198,6 +198,12 @@ in {
 
   environment.etc."st0x-rest-api/config.toml".source = env.configFile;
 
+  # Preserve the D-Bus implementation already running in production. Switching
+  # implementations requires a reboot and blocks an otherwise safe deployment.
+  services.dbus = lib.mkIf (env.name == "prod") {
+    implementation = "dbus";
+  };
+
   services.logrotate = {
     enable = true;
     settings."${env.dataDir}/logs/*.log" = {


### PR DESCRIPTION
## Motivation

The production attribution release needs the existing REST API service to receive the signer key through its native systemd credential. The prerequisite NixOS activation was blocked because the current configuration also attempted an unrelated live migration from D-Bus to `dbus-broker`.

A pre-merge deployment also confirmed that writing a compatibility drop-in beneath NixOS-managed `/etc/systemd/system` is not viable because that path is read-only.

## Solution

- Keep the existing native NixOS `LoadCredential` configuration and prerequisite deployment flow.
- Preserve production's currently running D-Bus implementation so NixOS does not attempt the unrelated `dbus` to `dbus-broker` migration.
- Scope that compatibility pin to production; preview retains its existing `dbus-broker` configuration.
- After every deployment scope, identify the new `rest-api.service` invocation and retry until:
  - that exact invocation logs `attribution signer loaded`;
  - the public health endpoint responds successfully; and
  - the service remains active.
- Print invocation-specific service diagnostics if verification times out.

No application behavior, API contract, database schema, migration, query, or secret value changes are included.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c rainix-rs-static`
- `nix develop -c pre-commit run yamlfmt --files .github/workflows/cd.yaml`
- `nix develop -c nix eval --raw .#nixosConfigurations.st0x-rest-api-prod.config.services.dbus.implementation` → `dbus`
- `nix develop -c nix eval --raw .#nixosConfigurations.st0x-rest-api-preview.config.services.dbus.implementation` → `broker`
- `nix develop -c git diff --cached --check`
- Staged local deployment-safety review: no remaining findings

## Deployment context

- Initial safely rolled-back production run: https://github.com/ST0x-Technology/st0x.rest.api/actions/runs/29986582947
- Failed pre-merge compatibility-drop-in test: https://github.com/ST0x-Technology/st0x.rest.api/actions/runs/30009935164
- The failed pre-merge run stopped before preparation or service deployment and did not change the application or database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated post-deployment verification for service startup, health, and attribution logging.
  * Preserved the existing D-Bus implementation in production environments to support deployments without requiring a reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->