### PR TITLE
fix: retain daily application logs

### DIFF
--- a/os.nix
+++ b/os.nix
@@ -208,18 +208,6 @@ in {
     implementation = "dbus";
   };
 
-  services.logrotate = {
-    enable = true;
-    settings."${env.dataDir}/logs/*.log" = {
-      su = "root st0x";
-      rotate = 14;
-      weekly = true;
-      compress = true;
-      missingok = true;
-      notifempty = true;
-    };
-  };
-
   systemd.tmpfiles.rules = [
     "d ${env.dataDir} 0775 root st0x -"
     "d ${env.dataDir}/logs 0775 root st0x -"

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,60 +1,121 @@
-use std::sync::Once;
+use std::sync::Mutex;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_appender::rolling::{InitError, RollingFileAppender, Rotation};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-static TELEMETRY_INIT: Once = Once::new();
+static TELEMETRY_INITIALIZED: Mutex<bool> = Mutex::new(false);
+const LOG_FILE_PREFIX: &str = "st0x-rest-api.log";
+const MAX_LOG_FILES: usize = 14;
+
+fn build_file_appender(log_dir: &str) -> Result<RollingFileAppender, InitError> {
+    RollingFileAppender::builder()
+        .rotation(Rotation::DAILY)
+        .filename_prefix(LOG_FILE_PREFIX)
+        .max_log_files(MAX_LOG_FILES)
+        .build(log_dir)
+}
 
 pub fn init(log_dir: &str) -> Result<WorkerGuard, String> {
-    let mut guard_slot: Option<WorkerGuard> = None;
-    let log_dir = log_dir.to_string();
+    let mut initialized = TELEMETRY_INITIALIZED
+        .lock()
+        .map_err(|_| "telemetry initialization lock poisoned".to_string())?;
+    if *initialized {
+        return Err("telemetry::init() called more than once".to_string());
+    }
 
-    TELEMETRY_INIT.call_once(|| {
-        let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|e| {
-            eprintln!("invalid RUST_LOG filter, using default: {e}");
-            EnvFilter::new("st0x_rest_api=info,rocket=warn,warn")
-        });
-        let file_appender = tracing_appender::rolling::daily(&log_dir, "st0x-rest-api.log");
-        let (file_writer, file_guard) = tracing_appender::non_blocking(file_appender);
-
-        let init_result = tracing_subscriber::registry()
-            .with(env_filter)
-            .with(fmt::layer().json().with_current_span(false))
-            .with(
-                fmt::layer()
-                    .json()
-                    .with_current_span(false)
-                    .with_writer(file_writer),
-            )
-            .try_init();
-
-        if let Err(err) = init_result {
-            eprintln!("failed to initialize tracing subscriber: {err}");
-            std::process::exit(1);
-        }
-
-        std::panic::set_hook(Box::new(|info| {
-            let message = info
-                .payload()
-                .downcast_ref::<&str>()
-                .map(|s| s.to_string())
-                .or_else(|| info.payload().downcast_ref::<String>().cloned())
-                .unwrap_or_else(|| "unknown panic".to_string());
-
-            if let Some(loc) = info.location() {
-                tracing::error!(
-                    panic.message = %message,
-                    panic.file = loc.file(),
-                    panic.line = loc.line(),
-                    panic.column = loc.column(),
-                    "panic occurred"
-                );
-            } else {
-                tracing::error!(panic.message = %message, "panic occurred");
-            }
-        }));
-
-        guard_slot = Some(file_guard);
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|e| {
+        eprintln!("invalid RUST_LOG filter, using default: {e}");
+        EnvFilter::new("st0x_rest_api=info,rocket=warn,warn")
     });
+    let file_appender = build_file_appender(log_dir)
+        .map_err(|err| format!("failed to initialize rolling file appender: {err}"))?;
+    let (file_writer, file_guard) = tracing_appender::non_blocking(file_appender);
 
-    guard_slot.ok_or_else(|| "telemetry::init() called more than once".to_string())
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt::layer().json().with_current_span(false))
+        .with(
+            fmt::layer()
+                .json()
+                .with_current_span(false)
+                .with_writer(file_writer),
+        )
+        .try_init()
+        .map_err(|err| format!("failed to initialize tracing subscriber: {err}"))?;
+
+    std::panic::set_hook(Box::new(|info| {
+        let message = info
+            .payload()
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| info.payload().downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "unknown panic".to_string());
+
+        if let Some(loc) = info.location() {
+            tracing::error!(
+                panic.message = %message,
+                panic.file = loc.file(),
+                panic.line = loc.line(),
+                panic.column = loc.column(),
+                "panic occurred"
+            );
+        } else {
+            tracing::error!(panic.message = %message, "panic occurred");
+        }
+    }));
+
+    *initialized = true;
+    Ok(file_guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+
+    #[test]
+    fn file_appender_retains_only_fourteen_daily_logs() {
+        let dir = tempfile::tempdir().expect("temporary log directory");
+        for day in 1..=15 {
+            File::create(
+                dir.path()
+                    .join(format!("{LOG_FILE_PREFIX}.2000-01-{day:02}")),
+            )
+            .expect("seed daily log");
+        }
+        let unrelated = dir.path().join("unrelated.log");
+        File::create(&unrelated).expect("seed unrelated file");
+
+        let appender =
+            build_file_appender(&dir.path().to_string_lossy()).expect("build file appender");
+        drop(appender);
+
+        let retained = fs::read_dir(dir.path())
+            .expect("read log directory")
+            .filter_map(Result::ok)
+            .filter(|entry| {
+                entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(LOG_FILE_PREFIX)
+            })
+            .count();
+
+        assert_eq!(retained, MAX_LOG_FILES);
+        assert!(unrelated.exists());
+    }
+
+    #[test]
+    fn init_returns_file_appender_errors() {
+        let dir = tempfile::tempdir().expect("temporary directory");
+        let invalid_log_dir = dir.path().join("not-a-directory");
+        File::create(&invalid_log_dir).expect("seed file at log directory path");
+
+        let error = match init(&invalid_log_dir.to_string_lossy()) {
+            Ok(_) => panic!("telemetry initialization should fail"),
+            Err(error) => error,
+        };
+
+        assert!(error.starts_with("failed to initialize rolling file appender:"));
+    }
 }


### PR DESCRIPTION
## Motivation

Production writes one application log per day as `st0x-rest-api.log.YYYY-MM-DD`, but the NixOS logrotate rule only matches files ending in `.log`. Because `missingok` suppresses that mismatch, no files were compressed or removed: 153 logs accumulated to 3.2 GB and filled the data volume, interrupting file and database logging.

## Solution

- Configure the existing daily `RollingFileAppender` through its builder with a 14-file retention limit.
- Preserve the current filename format so existing dated logs are recognized and pruned when the service starts.
- Continue pruning on each daily rollover, bounding application log growth without a separate rotation process.
- Remove the ineffective NixOS logrotate rule.
- Add a regression test that seeds excess daily logs, verifies only 14 are retained, and confirms unrelated files are untouched.

## Checks

- `nix develop -c cargo fmt --all`
- `nix develop -c cargo test telemetry::tests::file_appender_retains_only_fourteen_daily_logs`
- `nix develop -c rainix-rs-static`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787494411&installation_model_id=19370&pr_number=165&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F165&signature=623f8a62eb1c6f4505f52ddcd87d0d5ae1289612a151a655a3204fcc1dfb0728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated application log rotation to daily rolling log files with a capped retention count.
  - Improved failure handling during log/telemetry setup by returning a clear error instead of terminating.
- **Reliability**
  - Added protection against repeated initialization attempts, surfacing them as an error.
  - Validated log cleanup preserves unrelated files while enforcing the configured retention cap.
- **Tests**
  - Added unit tests covering daily retention behavior and handling of an invalid log directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->