### PR TITLE
feat(analytics): emit swap failure events and reject same-token pairs

### DIFF
--- a/docs/posthog-instrumentation-design.md
+++ b/docs/posthog-instrumentation-design.md
@@ -1,34 +1,37 @@
 # PostHog server-side instrumentation for the st0x REST API
 
-**Date:** 2026-07-14
-**Status:** Approved (design), implementing
-**Author:** Alastair Ong + Claude
+**Date:** 2026-07-14 **Status:** Approved (design), implementing **Author:**
+Alastair Ong + Claude
 
 ## Goal
 
-Instrument the REST API (Rust / Rocket) with PostHog so we can understand, per API
-client, **how much trade volume flows through the API** and **who the unique traders
-are across venues** (site vs. third-party integrators). This is the server-side other
-half of the picture to the frontend PostHog instrumentation on the st0x site.
+Instrument the REST API (Rust / Rocket) with PostHog so we can understand, per
+API client, **how much trade volume flows through the API** and **who the unique
+traders are across venues** (site vs. third-party integrators). This is the
+server-side other half of the picture to the frontend PostHog instrumentation on
+the st0x site.
 
-Events go to the **same PostHog project as the site** (project 122548, EU cloud) so
-site + API data live in one place. The API uses the **project token**
-(`POSTHOG_PROJECT_TOKEN`) for that same project. PostHog's public event-ingestion
-API identifies the destination project with this token; it does not use a personal
-or project-secret API key.
+Events go to the **same PostHog project as the site** (project 122548, EU cloud)
+so site + API data live in one place. The API uses the **project token**
+(`POSTHOG_PROJECT_TOKEN`) for that same project. PostHog's public
+event-ingestion API identifies the destination project with this token; it does
+not use a personal or project-secret API key.
 
 ## Key facts about the codebase
 
 - **Stack:** Rust, Rocket 0.5, SQLite (sqlx), `reqwest` already a dependency.
-- **Auth:** HTTP Basic (`key_id:secret`, Argon2). Every key row carries `label` and
-  `owner` — so each request is already attributable to a named client. The st0x site
-  is one key; each integrator has its own. `AuthenticatedKey` is available in handlers.
-- **Cross-cutting hook:** the existing `UsageLogger` fairing already runs on every
-  authenticated response. We add a sibling `AnalyticsFairing` for the generic event.
-- **Value endpoints:** `POST /v1/swap/quote` and `/v1/swap/calldata` (+`/v2`). The
-  calldata request carries `taker: Address` — the end-user wallet.
-- **Order-deploy endpoints (`/v1/order/dca`, `/solver`) are `todo!()` stubs today** —
-  instrumentation for TVL-creation is deferred until they are implemented.
+- **Auth:** HTTP Basic (`key_id:secret`, Argon2). Every key row carries `label`
+  and `owner` — so each request is already attributable to a named client. The
+  st0x site is one key; each integrator has its own. `AuthenticatedKey` is
+  available in handlers.
+- **Cross-cutting hook:** the existing `UsageLogger` fairing already runs on
+  every authenticated response. We add a sibling `AnalyticsFairing` for the
+  generic event.
+- **Value endpoints:** `POST /v1/swap/quote` and `/v1/swap/calldata` (+`/v2`).
+  The calldata request carries `taker: Address` — the end-user wallet.
+- **Order-deploy endpoints (`/v1/order/dca`, `/solver`) are `todo!()` stubs
+  today** — instrumentation for TVL-creation is deferred until they are
+  implemented.
 
 ## Design
 
@@ -38,61 +41,81 @@ or project-secret API key.
   — synchronous, fire-and-forget from the caller's perspective.
 - `AnalyticsEvent { event: &'static str, distinct_id: String, properties: Map }`.
 - Implementations:
-  - `PostHogSink` — holds a `reqwest::Client` (3s timeout), posts to `{host}/i/v0/e/`,
-    spawns a bounded (semaphore-capped) tokio task per event. Failures are logged at
-    `warn` and **never** affect the request. Drops events if saturated (same pattern as
-    `UsageLogger`).
-  - Disabled analytics holds no sink. When `POSTHOG_PROJECT_TOKEN` is unset, request
-    attribution and event construction are skipped.
-  - `RecordingSink` (test-only) — records events into a `Mutex<Vec<_>>` for assertions.
+  - `PostHogSink` — holds a `reqwest::Client` (3s timeout), posts to
+    `{host}/i/v0/e/`, spawns a bounded (semaphore-capped) tokio task per event.
+    Failures are logged at `warn` and **never** affect the request. Drops events
+    if saturated (same pattern as `UsageLogger`).
+  - Disabled analytics holds no sink. When `POSTHOG_PROJECT_TOKEN` is unset,
+    request attribution and event construction are skipped.
+  - `RecordingSink` (test-only) — records events into a `Mutex<Vec<_>>` for
+    assertions.
 - `Analytics(Option<Arc<dyn AnalyticsSink>>)` is Rocket-managed state, built via
   `Analytics::from_env()`. Host defaults to `https://eu.i.posthog.com`.
 
 ### Identity / attribution
 
-- Auth caches `AuthClientInfo { key_id, label, owner }` in request-local state so the
-  fairing (which has no `AuthenticatedKey`) can attribute the generic event.
-- Every event carries `api_client_key_id`, `api_client_label`, `api_client_owner`.
-  "Site vs. integrator" is defined **in PostHog** by filtering on `api_client_owner`
-  (avoids hardcoding a client identity in the API).
+- Auth caches `AuthClientInfo { key_id, label, owner }` in request-local state
+  so the fairing (which has no `AuthenticatedKey`) can attribute the generic
+  event.
+- Every event carries `api_client_key_id`, `api_client_label`,
+  `api_client_owner`. "Site vs. integrator" is defined **in PostHog** by
+  filtering on `api_client_owner` (avoids hardcoding a client identity in the
+  API).
 - `distinct_id`:
   - Trader-bearing event (`swap_calldata_generated`): the **lowercased `taker`
-    wallet** — the *same* identifier the site uses in `posthog.identify()`, so one human
-    is one PostHog person across the site and every integrator (cross-venue uniqueness).
-  - Client-scoped events (`api_request`, `swap_quoted`): `client:{key_id}`.
+    wallet** — the _same_ identifier the site uses in `posthog.identify()`, so
+    one human is one PostHog person across the site and every integrator
+    (cross-venue uniqueness).
+  - Client-scoped events (`api_request`, `swap_quoted`, `swap_quote_failed`,
+    `swap_calldata_failed`): `client:{key_id}`. Quote events never include the
+    optional taker wallet. Calldata failure events retain it as an event
+    property for parity with successful calldata generation.
 
 ### Events
 
-| Event | Source | distinct_id | Properties |
-|---|---|---|---|
-| `api_request` | `AnalyticsFairing` (every auth'd response) | `client:{key_id}` | `method`, `endpoint` (normalized), `status_code`, `latency_ms`, client attribution |
-| `swap_quoted` | `POST /v1/swap/quote` (on 200) | `client:{key_id}` | `input_token`, `output_token`, `denomination`, `estimated_input`, `estimated_output`, `estimated_io_ratio`, client attribution |
-| `swap_calldata_generated` | `POST /v1/swap/calldata` + `/v2` (on 200) | lowercased `taker` | `taker`, `input_token`, `output_token`, `denomination`, `estimated_input`, `value`, `api_version`, (`mode` for v2), client attribution |
+| Event                     | Source                                                                   | distinct_id        | Properties                                                                                                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------ | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api_request`             | `AnalyticsFairing` (every auth'd response)                               | `client:{key_id}`  | `method`, `endpoint` (normalized), `status_code`, `latency_ms`, client attribution                                                                                                                        |
+| `swap_quoted`             | `POST /v1/swap/quote` + `/v2` (on 200)                                   | `client:{key_id}`  | `input_token`, `output_token`, `denomination`, `estimated_input`, `estimated_output`, `estimated_io_ratio`, `api_version`, optional v2 `mode`, client attribution                                         |
+| `swap_quote_failed`       | `POST /v1/swap/quote` + `/v2` (after body parsing and authentication)    | `client:{key_id}`  | `input_token`, `output_token`, numeric `requested_amount` when safe to capture, `denomination`, `api_version`, optional v2 `mode`, `error_code`, `status_code`, `same_token`, client attribution          |
+| `swap_calldata_generated` | `POST /v1/swap/calldata` + `/v2` (on 200)                                | lowercased `taker` | `taker`, `input_token`, `output_token`, `denomination`, `estimated_input`, `value`, `api_version`, (`mode` for v2), client attribution                                                                    |
+| `swap_calldata_failed`    | `POST /v1/swap/calldata` + `/v2` (after body parsing and authentication) | `client:{key_id}`  | `taker`, `input_token`, `output_token`, numeric `requested_amount` when safe to capture, `denomination`, `api_version`, optional v2 `mode`, `error_code`, `status_code`, `same_token`, client attribution |
 
 `endpoint` normalization collapses `0x…` addresses/hashes and numeric ids to
 placeholders (`/v1/tokens/{address}/details`) to keep cardinality bounded.
 
+Failure events begin after Rocket has parsed the request body. Malformed JSON
+that the JSON guard rejects with 422 therefore appears only as an `api_request`
+event. Success-rate monitoring for swap endpoints must pair the swap success and
+failure events with an `api_request` alert for `status_code >= 400` so malformed
+requests are not mistaken for absent traffic.
+
 ### Volume & privacy semantics (documented, not enforced)
 
-- The API observes **requests**, not on-chain settlement. "Volume" = swaps quoted /
-  calldata generated; on-chain truth stays in the subgraph.
-- Volume is captured as **raw token amounts + token addresses** (no price dependency);
-  USD is derivable downstream.
+- The API observes **requests**, not on-chain settlement. "Volume" = swaps
+  quoted / calldata generated; on-chain truth stays in the subgraph.
+- Volume is captured as **raw token amounts + token addresses** (no price
+  dependency); USD is derivable downstream.
+- Failure amounts are accepted by the API as strings, so analytics includes
+  `requested_amount` only when it is a valid numeric value no longer than 128
+  bytes. Arbitrary malformed request text is never forwarded to PostHog.
+
 ### Config, secrets, deployment
 
-- `POSTHOG_PROJECT_TOKEN` and optional `POSTHOG_HOST` are read from **environment** and
-  documented in `.env.example`. The production NixOS configuration injects the public
-  PostHog project token and explicit EU capture host into the systemd service. Preview
-  does not configure a token and therefore keeps analytics disabled. When the project
-  token is unset, analytics is disabled.
+- `POSTHOG_PROJECT_TOKEN` and optional `POSTHOG_HOST` are read from
+  **environment** and documented in `.env.example`. The production NixOS
+  configuration injects the public PostHog project token and explicit EU capture
+  host into the systemd service. Preview does not configure a token and
+  therefore keeps analytics disabled. When the project token is unset, analytics
+  is disabled.
 
 ### Testing
 
-- Unit tests: path normalization, client-attribution props, distinct_id selection,
-  event property construction, and the disabled/no-op path.
-- Integration tests: `TestClientBuilder` injects a `RecordingSink`; assert that a
-  `swap_quoted` / `swap_calldata_generated` / `api_request` event is captured with the
-  expected `distinct_id` and properties.
+- Unit tests: path normalization, client-attribution props, distinct_id
+  selection, event property construction, and the disabled/no-op path.
+- Integration tests: `TestClientBuilder` injects a `RecordingSink`; assert that
+  success and failure swap events plus `api_request` are captured with the
+  expected `distinct_id`, privacy boundaries, and properties.
 
 ### Out of scope (this PR)
 

--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -45,6 +45,7 @@ unexpected failures outside those boundaries.
 
 | HTTP Status | Code                     | Description                                   |
 | ----------- | ------------------------ | --------------------------------------------- |
+| 400         | `SWAP_SAME_TOKEN`        | Input and output swap tokens are identical    |
 | 400         | `SWAP_UNSUPPORTED_TOKEN` | One or both swap tokens are unsupported       |
 | 404         | `SWAP_NO_LIQUIDITY`      | No executable liquidity is available          |
 | 500         | `SWAP_QUOTE_FAILED`      | Quote generation failed unexpectedly          |

--- a/src/analytics/events.rs
+++ b/src/analytics/events.rs
@@ -6,11 +6,16 @@
 
 use super::AnalyticsEvent;
 use crate::auth::{AuthClientInfo, AuthenticatedKey};
+use crate::error::ApiError;
 use crate::types::swap::{SwapCalldataResponse, SwapQuoteResponse, SwapQuoteV2Response};
 use alloy::primitives::Address;
+use rain_math_float::Float;
 use serde_json::{Map, Value};
 
-/// Which swap-calldata API version produced an event.
+const MAX_ANALYTICS_AMOUNT_LENGTH: usize = 128;
+
+/// Which swap API version produced an event.
+#[derive(Clone, Copy)]
 pub(crate) enum ApiVersion {
     V1,
     V2,
@@ -107,6 +112,7 @@ pub(crate) fn swap_quoted_event(
         "estimated_io_ratio".to_string(),
         resp.estimated_io_ratio.clone().into(),
     );
+    props.insert("api_version".to_string(), ApiVersion::V1.as_str().into());
     AnalyticsEvent {
         event: "swap_quoted",
         distinct_id: client_distinct_id(&info),
@@ -155,6 +161,7 @@ pub(crate) fn swap_quoted_v2_event(
         "resolved_price_cap".to_string(),
         resp.resolved_price_cap.clone().into(),
     );
+    props.insert("api_version".to_string(), ApiVersion::V2.as_str().into());
     AnalyticsEvent {
         event: "swap_quoted",
         distinct_id: client_distinct_id(&info),
@@ -198,6 +205,105 @@ pub(crate) fn swap_calldata_generated_event(
         distinct_id: taker_id,
         properties: props,
     }
+}
+
+/// What a caller asked for on a swap request that then failed.
+///
+/// The success events describe a *response*, so they can only ever describe requests
+/// that worked — a client failing 100% of the time is indistinguishable from one
+/// sending no traffic at all. This carries the *request* instead, captured before it
+/// is consumed, so a failure reports the pair and size that produced it.
+pub(crate) struct SwapFailure<'a> {
+    pub input_token: Address,
+    pub output_token: Address,
+    /// The requested amount, verbatim. Which side it denominates depends on the
+    /// endpoint (v1 quote takes an output amount, v2 an amount plus a mode), so it
+    /// is reported as-is alongside `api_version` rather than being reinterpreted.
+    pub requested_amount: &'a str,
+    pub denomination: Value,
+    pub api_version: ApiVersion,
+    pub mode: Option<Value>,
+    /// Present only on calldata requests, which carry an end-user wallet.
+    pub taker: Option<Address>,
+}
+
+/// Failed swap quote. Attributed to the client: a failing quote is an integration
+/// problem, so the useful grouping is "which client", not "which wallet".
+pub(crate) fn swap_quote_failed_event(
+    key: &AuthenticatedKey,
+    failure: SwapFailure<'_>,
+    error: &ApiError,
+) -> AnalyticsEvent {
+    swap_failed_event("swap_quote_failed", key, failure, error)
+}
+
+/// Failed swap calldata. Attributed to the client for the same reason as
+/// [`swap_quote_failed_event`]; the wallet is still reported as a `taker` property.
+pub(crate) fn swap_calldata_failed_event(
+    key: &AuthenticatedKey,
+    failure: SwapFailure<'_>,
+    error: &ApiError,
+) -> AnalyticsEvent {
+    swap_failed_event("swap_calldata_failed", key, failure, error)
+}
+
+fn swap_failed_event(
+    event: &'static str,
+    key: &AuthenticatedKey,
+    failure: SwapFailure<'_>,
+    error: &ApiError,
+) -> AnalyticsEvent {
+    let info = key.client_info();
+    let code = error.code();
+    let mut props = base_props(&info);
+    props.insert(
+        "input_token".to_string(),
+        token_str(failure.input_token).into(),
+    );
+    props.insert(
+        "output_token".to_string(),
+        token_str(failure.output_token).into(),
+    );
+    if analytics_requested_amount(failure.requested_amount) {
+        props.insert(
+            "requested_amount".to_string(),
+            failure.requested_amount.into(),
+        );
+    }
+    props.insert("denomination".to_string(), failure.denomination);
+    props.insert(
+        "api_version".to_string(),
+        failure.api_version.as_str().into(),
+    );
+    props.insert("error_code".to_string(), code.as_str().into());
+    props.insert("status_code".to_string(), code.status().code.into());
+    // Precomputed because it is the failure mode that is invisible in aggregate:
+    // a same-token pair is always a caller bug, and grouping on two address columns
+    // to notice it is exactly the step nobody takes.
+    props.insert(
+        "same_token".to_string(),
+        (failure.input_token == failure.output_token).into(),
+    );
+    if let Some(mode) = failure.mode {
+        props.insert("mode".to_string(), mode);
+    }
+    if let Some(taker) = failure.taker {
+        props.insert("taker".to_string(), token_str(taker).into());
+    }
+    AnalyticsEvent {
+        event,
+        distinct_id: client_distinct_id(&info),
+        properties: props,
+    }
+}
+
+/// Keep arbitrary request text out of PostHog while preserving valid trade sizes.
+///
+/// Swap amount fields deserialize as strings and failure events include parse errors,
+/// so a failed request is not proof that the value is numeric. The length bound also
+/// keeps an authenticated caller from creating oversized analytics properties.
+fn analytics_requested_amount(amount: &str) -> bool {
+    amount.len() <= MAX_ANALYTICS_AMOUNT_LENGTH && Float::parse(amount.to_string()).is_ok()
 }
 
 /// Lowercased `0x…` address string. Matches the site's `posthog.identify()` form so
@@ -263,9 +369,102 @@ mod tests {
         assert_eq!(event.event, "swap_quoted");
         assert_eq!(event.distinct_id, "client:site-key");
         assert_eq!(event.properties["estimated_input"], Value::from("1250.75"));
+        assert_eq!(event.properties["api_version"], Value::from("v1"));
         assert_eq!(
             event.properties["api_client_label"],
             Value::from("St0x Website")
+        );
+    }
+
+    #[test]
+    fn swap_quote_failed_event_reports_the_request_and_the_wire_error() {
+        let event = swap_quote_failed_event(
+            &test_key(),
+            SwapFailure {
+                input_token: addr(1),
+                output_token: addr(2),
+                requested_amount: "0.01",
+                denomination: Value::from("wrapped"),
+                api_version: ApiVersion::V1,
+                mode: None,
+                taker: None,
+            },
+            &crate::error::ApiError::coded(
+                crate::error::ApiErrorCode::SwapNoLiquidity,
+                "no executable liquidity is available for this pair",
+            ),
+        );
+
+        assert_eq!(event.event, "swap_quote_failed");
+        // Client-scoped: a failing quote is an integration problem, not a wallet one.
+        assert_eq!(event.distinct_id, "client:site-key");
+        assert_eq!(event.properties["requested_amount"], Value::from("0.01"));
+        assert_eq!(
+            event.properties["error_code"],
+            Value::from("SWAP_NO_LIQUIDITY")
+        );
+        // Mirrors the HTTP status the caller actually received.
+        assert_eq!(event.properties["status_code"], Value::from(404));
+        assert_eq!(event.properties["same_token"], Value::from(false));
+        assert!(event.properties.get("taker").is_none());
+        assert!(event.properties.get("mode").is_none());
+    }
+
+    #[test]
+    fn swap_failure_omits_non_numeric_requested_amount() {
+        let event = swap_quote_failed_event(
+            &test_key(),
+            SwapFailure {
+                input_token: addr(1),
+                output_token: addr(2),
+                requested_amount: "customer@example.com",
+                denomination: Value::from("wrapped"),
+                api_version: ApiVersion::V1,
+                mode: None,
+                taker: None,
+            },
+            &crate::error::ApiError::BadRequest("invalid output_amount".into()),
+        );
+
+        assert!(event.properties.get("requested_amount").is_none());
+    }
+
+    #[test]
+    fn analytics_requested_amount_enforces_length_boundary() {
+        assert!(analytics_requested_amount(&format!("{}1", "0".repeat(127))));
+        assert!(!analytics_requested_amount(&format!(
+            "{}1",
+            "0".repeat(128)
+        )));
+    }
+
+    #[test]
+    fn swap_failure_flags_a_same_token_pair() {
+        let event = swap_calldata_failed_event(
+            &test_key(),
+            SwapFailure {
+                input_token: addr(7),
+                output_token: addr(7),
+                requested_amount: "100",
+                denomination: Value::from("wrapped"),
+                api_version: ApiVersion::V2,
+                mode: Some(Value::from("spendExact")),
+                taker: Some(addr(0xAB)),
+            },
+            &crate::error::ApiError::coded(
+                crate::error::ApiErrorCode::SwapSameToken,
+                "inputToken and outputToken must be different tokens",
+            ),
+        );
+
+        assert_eq!(event.event, "swap_calldata_failed");
+        assert_eq!(event.properties["same_token"], Value::from(true));
+        assert_eq!(event.properties["status_code"], Value::from(400));
+        assert_eq!(event.properties["api_version"], Value::from("v2"));
+        assert_eq!(event.properties["mode"], Value::from("spendExact"));
+        assert_eq!(
+            event.properties["taker"],
+            Value::from(addr(0xAB).to_string().to_lowercase())
         );
     }
 

--- a/src/analytics/mod.rs
+++ b/src/analytics/mod.rs
@@ -15,8 +15,8 @@ mod posthog;
 mod recording;
 
 pub(crate) use events::{
-    api_request_event, swap_calldata_generated_event, swap_quoted_event, swap_quoted_v2_event,
-    ApiVersion,
+    api_request_event, swap_calldata_failed_event, swap_calldata_generated_event,
+    swap_quote_failed_event, swap_quoted_event, swap_quoted_v2_event, ApiVersion, SwapFailure,
 };
 pub(crate) use posthog::PostHogSink;
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ pub enum ApiErrorCode {
     RateLimited,
     NotYetIndexed,
     SwapUnsupportedToken,
+    SwapSameToken,
     SwapNoLiquidity,
     SwapQuoteFailed,
     SwapPreflightFailed,
@@ -39,6 +40,7 @@ impl ApiErrorCode {
             Self::RateLimited => "RATE_LIMITED",
             Self::NotYetIndexed => "NOT_YET_INDEXED",
             Self::SwapUnsupportedToken => "SWAP_UNSUPPORTED_TOKEN",
+            Self::SwapSameToken => "SWAP_SAME_TOKEN",
             Self::SwapNoLiquidity => "SWAP_NO_LIQUIDITY",
             Self::SwapQuoteFailed => "SWAP_QUOTE_FAILED",
             Self::SwapPreflightFailed => "SWAP_PREFLIGHT_FAILED",
@@ -50,9 +52,10 @@ impl ApiErrorCode {
 
     pub const fn status(self) -> Status {
         match self {
-            Self::BadRequest | Self::SwapUnsupportedToken | Self::SwapPreflightFailed => {
-                Status::BadRequest
-            }
+            Self::BadRequest
+            | Self::SwapUnsupportedToken
+            | Self::SwapSameToken
+            | Self::SwapPreflightFailed => Status::BadRequest,
             Self::UnprocessableEntity => Status::UnprocessableEntity,
             Self::Unauthorized => Status::Unauthorized,
             Self::Forbidden => Status::Forbidden,
@@ -119,23 +122,45 @@ impl ApiError {
             public_message,
         }
     }
+
+    /// The stable error code this error is reported as.
+    ///
+    /// Shared by the HTTP responder and by analytics so a failure carries the same
+    /// code in PostHog as the caller saw on the wire — otherwise the two drift and
+    /// a dashboard can disagree with the client about what actually happened.
+    pub fn code(&self) -> ApiErrorCode {
+        match self {
+            ApiError::BadRequest(_) => ApiErrorCode::BadRequest,
+            ApiError::Unauthorized(_) => ApiErrorCode::Unauthorized,
+            ApiError::Forbidden(_) => ApiErrorCode::Forbidden,
+            ApiError::NotFound(_) => ApiErrorCode::NotFound,
+            ApiError::Internal(_) => ApiErrorCode::InternalError,
+            ApiError::RateLimited(_) => ApiErrorCode::RateLimited,
+            ApiError::NotYetIndexed(_) => ApiErrorCode::NotYetIndexed,
+            ApiError::Coded { code, .. } => *code,
+        }
+    }
+
+    /// The message returned to the caller. Public by construction — every variant
+    /// holds text already destined for the response body, so this never leaks
+    /// internal detail that `respond_to` would have withheld.
+    pub fn public_message(&self) -> String {
+        match self {
+            ApiError::BadRequest(msg)
+            | ApiError::Unauthorized(msg)
+            | ApiError::Forbidden(msg)
+            | ApiError::NotFound(msg)
+            | ApiError::Internal(msg)
+            | ApiError::RateLimited(msg)
+            | ApiError::NotYetIndexed(msg) => msg.clone(),
+            ApiError::Coded { public_message, .. } => (*public_message).to_string(),
+        }
+    }
 }
 
 impl<'r> Responder<'r, 'static> for ApiError {
     fn respond_to(self, req: &'r Request<'_>) -> rocket::response::Result<'static> {
-        let (code, message) = match &self {
-            ApiError::BadRequest(msg) => (ApiErrorCode::BadRequest, msg.clone()),
-            ApiError::Unauthorized(msg) => (ApiErrorCode::Unauthorized, msg.clone()),
-            ApiError::Forbidden(msg) => (ApiErrorCode::Forbidden, msg.clone()),
-            ApiError::NotFound(msg) => (ApiErrorCode::NotFound, msg.clone()),
-            ApiError::Internal(msg) => (ApiErrorCode::InternalError, msg.clone()),
-            ApiError::RateLimited(msg) => (ApiErrorCode::RateLimited, msg.clone()),
-            ApiError::NotYetIndexed(msg) => (ApiErrorCode::NotYetIndexed, msg.clone()),
-            ApiError::Coded {
-                code,
-                public_message,
-            } => (*code, (*public_message).to_string()),
-        };
+        let (code, message) = (self.code(), self.public_message());
         let status = code.status();
         let span = request_span_for(req);
         span.in_scope(|| {
@@ -292,10 +317,32 @@ mod tests {
     }
 
     #[test]
+    fn test_code_and_message_cover_coded_and_representative_errors() {
+        let cases: [(ApiError, ApiErrorCode, &str); 2] = [
+            (
+                ApiError::BadRequest("bad".into()),
+                ApiErrorCode::BadRequest,
+                "bad",
+            ),
+            (
+                ApiError::coded(ApiErrorCode::SwapSameToken, "same token"),
+                ApiErrorCode::SwapSameToken,
+                "same token",
+            ),
+        ];
+
+        for (error, expected_code, expected_message) in cases {
+            assert_eq!(error.code(), expected_code);
+            assert_eq!(error.public_message(), expected_message);
+        }
+    }
+
+    #[test]
     fn test_catalog_serializes_stable_codes() {
         let cases = [
             (ApiErrorCode::BadRequest, "\"BAD_REQUEST\""),
             (ApiErrorCode::SwapQuoteFailed, "\"SWAP_QUOTE_FAILED\""),
+            (ApiErrorCode::SwapSameToken, "\"SWAP_SAME_TOKEN\""),
             (
                 ApiErrorCode::UpstreamUnavailable,
                 "\"UPSTREAM_UNAVAILABLE\"",
@@ -311,6 +358,7 @@ mod tests {
     fn test_trade_catalog_uses_expected_http_statuses() {
         let cases = [
             (ApiErrorCode::SwapUnsupportedToken, Status::BadRequest),
+            (ApiErrorCode::SwapSameToken, Status::BadRequest),
             (ApiErrorCode::SwapPreflightFailed, Status::BadRequest),
             (ApiErrorCode::SwapNoLiquidity, Status::NotFound),
             (ApiErrorCode::SwapQuoteFailed, Status::InternalServerError),

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1,5 +1,10 @@
-use super::{RaindexSwapDataSource, SwapDataSource};
-use crate::analytics::{swap_calldata_generated_event, Analytics, ApiVersion};
+use super::{
+    capture_swap_outcome, ensure_distinct_tokens, snapshot_swap_context, RaindexSwapDataSource,
+    SwapAnalyticsContext, SwapDataSource,
+};
+use crate::analytics::{
+    swap_calldata_failed_event, swap_calldata_generated_event, Analytics, ApiVersion,
+};
 use crate::app_state::ApplicationState;
 use crate::attribution::{attribution_message_hash, Attribution, AttributionSigner};
 use crate::auth::AuthenticatedKey;
@@ -151,33 +156,42 @@ async fn handle_swap_calldata(
     attribution: &Attribution,
     req: SwapCalldataRequest,
 ) -> Result<SwapCalldataResponse, ApiError> {
-    let analytics_context = analytics.is_enabled().then(|| {
-        (
-            req.taker,
-            req.input_token,
-            req.output_token,
-            serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
-        )
+    let taker = req.taker;
+    let analytics_context = snapshot_swap_context(analytics, || SwapAnalyticsContext {
+        taker: Some(taker),
+        input_token: req.input_token,
+        output_token: req.output_token,
+        requested_amount: req.output_amount.clone(),
+        denomination: serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
+        api_version: ApiVersion::V1,
+        mode: None,
     });
-    let mut response = process_swap_calldata(ds, req).await?;
-    embed_and_validate_attribution(&mut response, signer, attribution).await?;
 
-    if let Some((taker, input_token, output_token, denomination)) = analytics_context {
-        analytics.capture(|| {
+    // Attribution failures are calldata failures too — the caller ends up with no
+    // calldata either way — so both fallible steps feed the same failure event.
+    capture_swap_outcome(
+        analytics,
+        analytics_context,
+        async {
+            let mut response = process_swap_calldata(ds, req).await?;
+            embed_and_validate_attribution(&mut response, signer, attribution).await?;
+            Ok(response)
+        },
+        |context, error| swap_calldata_failed_event(key, context.failure(), error),
+        |context, response| {
             swap_calldata_generated_event(
                 key,
                 taker,
-                input_token,
-                output_token,
-                denomination,
-                ApiVersion::V1,
-                None,
-                &response,
+                context.input_token,
+                context.output_token,
+                context.denomination.clone(),
+                context.api_version,
+                context.mode.clone(),
+                response,
             )
-        });
-    }
-
-    Ok(response)
+        },
+    )
+    .await
 }
 
 async fn handle_swap_calldata_v2(
@@ -188,34 +202,40 @@ async fn handle_swap_calldata_v2(
     attribution: &Attribution,
     req: SwapCalldataV2Request,
 ) -> Result<SwapCalldataV2Response, ApiError> {
-    let analytics_context = analytics.is_enabled().then(|| {
-        (
-            req.taker,
-            req.input_token,
-            req.output_token,
-            serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
-            serde_json::to_value(req.mode).ok(),
-        )
+    let taker = req.taker;
+    let analytics_context = snapshot_swap_context(analytics, || SwapAnalyticsContext {
+        taker: Some(taker),
+        input_token: req.input_token,
+        output_token: req.output_token,
+        requested_amount: req.amount.clone(),
+        denomination: serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
+        api_version: ApiVersion::V2,
+        mode: serde_json::to_value(req.mode).ok(),
     });
-    let mut response = process_swap_calldata_v2(ds, req).await?;
-    embed_and_validate_attribution(&mut response.calldata, signer, attribution).await?;
 
-    if let Some((taker, input_token, output_token, denomination, mode)) = analytics_context {
-        analytics.capture(|| {
+    capture_swap_outcome(
+        analytics,
+        analytics_context,
+        async {
+            let mut response = process_swap_calldata_v2(ds, req).await?;
+            embed_and_validate_attribution(&mut response.calldata, signer, attribution).await?;
+            Ok(response)
+        },
+        |context, error| swap_calldata_failed_event(key, context.failure(), error),
+        |context, response| {
             swap_calldata_generated_event(
                 key,
                 taker,
-                input_token,
-                output_token,
-                denomination,
-                ApiVersion::V2,
-                mode,
+                context.input_token,
+                context.output_token,
+                context.denomination.clone(),
+                context.api_version,
+                context.mode.clone(),
                 &response.calldata,
             )
-        });
-    }
-
-    Ok(response)
+        },
+    )
+    .await
 }
 
 async fn embed_and_validate_attribution(
@@ -446,6 +466,7 @@ async fn process_swap_calldata_v2(
     ds: &dyn SwapDataSource,
     req: SwapCalldataV2Request,
 ) -> Result<SwapCalldataV2Response, ApiError> {
+    ensure_distinct_tokens(req.input_token, req.output_token)?;
     let result = process_swap_calldata_build(ds, req.try_into()?).await?;
     Ok(SwapCalldataV2Response {
         calldata: result.calldata,
@@ -457,6 +478,8 @@ async fn process_swap_calldata_build(
     ds: &dyn SwapDataSource,
     req: SwapCalldataBuildRequest,
 ) -> Result<SwapCalldataBuildResult, ApiError> {
+    ensure_distinct_tokens(req.input_token, req.output_token)?;
+
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await
         .map_err(map_calldata_boundary_error)?;
@@ -997,6 +1020,165 @@ mod tests {
             .expect("swap_calldata_generated event");
         assert_eq!(event.properties["api_version"], "v2");
         assert_eq!(event.properties["mode"], "spendExact");
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_calldata_captures_v1_failure_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("failed to generate calldata".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+        let key = test_key();
+        let attribution_state = test_attribution_state();
+        let attribution = attribution_state.for_api_key(&key.key_id, TAKER);
+
+        let result = handle_swap_calldata(
+            &ds,
+            &key,
+            &analytics,
+            &attribution_state.signer,
+            &attribution,
+            calldata_request("100", "2.5"),
+        )
+        .await;
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
+
+        let events = recording.events();
+        let event = events
+            .iter()
+            .find(|event| event.event == "swap_calldata_failed")
+            .expect("swap_calldata_failed event");
+        assert_eq!(event.distinct_id, "client:test-client");
+        assert_eq!(event.properties["requested_amount"], "100");
+        assert_eq!(event.properties["api_version"], "v1");
+        assert_eq!(event.properties["taker"], TAKER.to_string().to_lowercase());
+        assert_eq!(event.properties["error_code"], "SWAP_CALLDATA_FAILED");
+        assert_eq!(event.properties["status_code"], 500);
+        assert!(!events
+            .iter()
+            .any(|event| event.event == "swap_calldata_generated"));
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_calldata_v2_captures_attribution_failure_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            // Deliberately invalid ABI: processing succeeds, attribution embedding fails.
+            calldata_result: Ok(ready_response()),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+        let key = test_key();
+        let attribution_state = test_attribution_state();
+        let attribution = attribution_state.for_api_key(&key.key_id, TAKER);
+
+        let result = handle_swap_calldata_v2(
+            &ds,
+            &key,
+            &analytics,
+            &attribution_state.signer,
+            &attribution,
+            calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2.5"),
+        )
+        .await;
+        assert!(matches!(result, Err(ApiError::Internal(_))));
+
+        let events = recording.events();
+        let event = events
+            .iter()
+            .find(|event| event.event == "swap_calldata_failed")
+            .expect("swap_calldata_failed event");
+        assert_eq!(event.properties["requested_amount"], "100");
+        assert_eq!(event.properties["api_version"], "v2");
+        assert_eq!(event.properties["mode"], "spendExact");
+        assert_eq!(event.properties["taker"], TAKER.to_string().to_lowercase());
+        assert_eq!(event.properties["error_code"], "INTERNAL_ERROR");
+        assert_eq!(event.properties["status_code"], 500);
+        assert!(!events
+            .iter()
+            .any(|event| event.event == "swap_calldata_generated"));
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_calldata_rejects_same_token_before_data_source_and_captures_failure()
+    {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::Internal("data source must not be reached".into())),
+            orders: Err(ApiError::Internal("data source must not be reached".into())),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("data source must not be reached".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+        let key = test_key();
+        let attribution_state = test_attribution_state();
+        let attribution = attribution_state.for_api_key(&key.key_id, TAKER);
+        let mut request = calldata_request("100", "2.5");
+        request.output_token = request.input_token;
+
+        let result = handle_swap_calldata(
+            &ds,
+            &key,
+            &analytics,
+            &attribution_state.signer,
+            &attribution,
+            request,
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapSameToken);
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_calldata_failed")
+            .expect("swap_calldata_failed event");
+        assert_eq!(event.properties["api_version"], "v1");
+        assert_eq!(event.properties["same_token"], true);
+        assert_eq!(event.properties["error_code"], "SWAP_SAME_TOKEN");
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_calldata_v2_same_token_precedes_price_limit_validation() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::Internal("data source must not be reached".into())),
+            orders: Err(ApiError::Internal("data source must not be reached".into())),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("data source must not be reached".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+        let key = test_key();
+        let attribution_state = test_attribution_state();
+        let attribution = attribution_state.for_api_key(&key.key_id, TAKER);
+        let mut request = calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2.5");
+        request.output_token = request.input_token;
+        request.price_cap = None;
+
+        let result = handle_swap_calldata_v2(
+            &ds,
+            &key,
+            &analytics,
+            &attribution_state.signer,
+            &attribution,
+            request,
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapSameToken);
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_calldata_failed")
+            .expect("swap_calldata_failed event");
+        assert_eq!(event.properties["api_version"], "v2");
+        assert_eq!(event.properties["same_token"], true);
+        assert_eq!(event.properties["error_code"], "SWAP_SAME_TOKEN");
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -3,6 +3,7 @@ mod denomination;
 mod quote;
 mod slippage;
 
+use crate::analytics::{Analytics, AnalyticsEvent, ApiVersion, SwapFailure};
 use crate::cache::RouteResponseCaches;
 use crate::db::DbPool;
 use crate::error::{ApiError, ApiErrorCode};
@@ -26,6 +27,61 @@ use rain_orderbook_common::take_orders::{
 };
 use rocket::Route;
 use std::collections::HashMap;
+use std::future::Future;
+
+struct SwapAnalyticsContext {
+    input_token: Address,
+    output_token: Address,
+    requested_amount: String,
+    denomination: serde_json::Value,
+    api_version: ApiVersion,
+    mode: Option<serde_json::Value>,
+    taker: Option<Address>,
+}
+
+impl SwapAnalyticsContext {
+    fn failure(&self) -> SwapFailure<'_> {
+        SwapFailure {
+            input_token: self.input_token,
+            output_token: self.output_token,
+            requested_amount: &self.requested_amount,
+            denomination: self.denomination.clone(),
+            api_version: self.api_version,
+            mode: self.mode.clone(),
+            taker: self.taker,
+        }
+    }
+}
+
+fn snapshot_swap_context(
+    analytics: &Analytics,
+    build: impl FnOnce() -> SwapAnalyticsContext,
+) -> Option<SwapAnalyticsContext> {
+    analytics.is_enabled().then(build)
+}
+
+async fn capture_swap_outcome<T>(
+    analytics: &Analytics,
+    context: Option<SwapAnalyticsContext>,
+    operation: impl Future<Output = Result<T, ApiError>>,
+    build_failure: impl FnOnce(&SwapAnalyticsContext, &ApiError) -> AnalyticsEvent,
+    build_success: impl FnOnce(&SwapAnalyticsContext, &T) -> AnalyticsEvent,
+) -> Result<T, ApiError> {
+    match operation.await {
+        Ok(response) => {
+            if let Some(context) = context.as_ref() {
+                analytics.capture(|| build_success(context, &response));
+            }
+            Ok(response)
+        }
+        Err(error) => {
+            if let Some(context) = context.as_ref() {
+                analytics.capture(|| build_failure(context, &error));
+            }
+            Err(error)
+        }
+    }
+}
 
 #[async_trait]
 pub(crate) trait SwapDataSource: Send + Sync {
@@ -265,6 +321,36 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
     }
 }
 
+/// Reject a swap whose input and output token are the same, before any order lookup.
+///
+/// Such a request is always a caller bug, but it is not a *cheap* one: the token is
+/// individually supported, so `validate_supported_tokens` passes, and the pair matches
+/// every order holding that token. For a stablecoin leg that is the entire book, which
+/// then gets quoted over RPC before the simulation finds no executable leg and returns
+/// "no liquidity" — a ~15s round trip to deliver a misleading answer to a malformed
+/// question. Failing fast makes the error self-explanatory and stops one request from
+/// costing a full-book RPC sweep.
+pub(crate) fn ensure_distinct_tokens(
+    input_token: Address,
+    output_token: Address,
+) -> Result<(), ApiError> {
+    if input_token != output_token {
+        return Ok(());
+    }
+    tracing::warn!(
+        token = %input_token,
+        "swap request rejected: input and output token are identical"
+    );
+    Err(same_token_error())
+}
+
+fn same_token_error() -> ApiError {
+    ApiError::coded(
+        ApiErrorCode::SwapSameToken,
+        "inputToken and outputToken must be different tokens",
+    )
+}
+
 fn map_raindex_error(e: RaindexError) -> ApiError {
     match &e {
         RaindexError::NoLiquidity | RaindexError::InsufficientLiquidity { .. } => {
@@ -274,8 +360,14 @@ fn map_raindex_error(e: RaindexError) -> ApiError {
                 "no executable liquidity is available for this pair",
             )
         }
-        RaindexError::SameTokenPair
-        | RaindexError::NonPositiveAmount
+        // Kept distinct from the generic bucket below: `ensure_distinct_tokens` should
+        // catch this at the edge, so reaching it here means a same-token pair slipped
+        // past the guard and the caller still deserves to be told which mistake it was.
+        RaindexError::SameTokenPair => {
+            tracing::warn!(error = %e, "same-token pair reached the raindex layer");
+            same_token_error()
+        }
+        RaindexError::NonPositiveAmount
         | RaindexError::NegativePriceCap
         | RaindexError::FromHexError(_)
         | RaindexError::Float(_) => {
@@ -340,19 +432,58 @@ pub fn routes_v2() -> Vec<Route> {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_raindex_error, swap_candidates_cache_key, swap_chain_ids};
+    use super::{
+        ensure_distinct_tokens, map_raindex_error, snapshot_swap_context,
+        swap_candidates_cache_key, swap_chain_ids,
+    };
+    use crate::analytics::Analytics;
     use crate::error::{ApiError, ApiErrorCode};
     use alloy::primitives::address;
     use rain_orderbook_common::raindex_client::orders::RaindexOrder;
     use rain_orderbook_common::raindex_client::RaindexError;
     use rain_orderbook_common::rpc_client::RpcClientError;
     use serde_json::json;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     fn mock_order(chain_id: u32, order_hash: &str) -> RaindexOrder {
         let mut value = crate::test_helpers::order_json();
         value["chainId"] = json!(chain_id);
         value["orderHash"] = json!(order_hash);
         serde_json::from_value(value).expect("deserialize mock order")
+    }
+
+    #[test]
+    fn test_ensure_distinct_tokens_accepts_distinct_and_rejects_equal_tokens() {
+        let usdc = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
+        let weth = address!("4200000000000000000000000000000000000006");
+        assert!(ensure_distinct_tokens(usdc, weth).is_ok());
+        assert!(matches!(
+            ensure_distinct_tokens(usdc, usdc),
+            Err(ApiError::Coded { code, .. }) if code == ApiErrorCode::SwapSameToken
+        ));
+    }
+
+    #[test]
+    fn test_disabled_analytics_skips_swap_context_snapshot() {
+        let built = AtomicBool::new(false);
+
+        let context = snapshot_swap_context(&Analytics::disabled(), || {
+            built.store(true, Ordering::Relaxed);
+            unreachable!("disabled analytics must not build a swap context")
+        });
+
+        assert!(context.is_none());
+        assert!(!built.load(Ordering::Relaxed));
+    }
+
+    /// A same-token pair that somehow reaches the raindex layer must still surface as
+    /// `SWAP_SAME_TOKEN`, not be flattened into the generic invalid-parameters bucket.
+    #[test]
+    fn test_same_token_pair_from_raindex_keeps_its_code() {
+        assert!(matches!(
+            map_raindex_error(RaindexError::SameTokenPair),
+            ApiError::Coded { code, .. } if code == ApiErrorCode::SwapSameToken
+        ));
     }
 
     #[test]

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -1,5 +1,10 @@
-use super::{RaindexSwapDataSource, SwapDataSource};
-use crate::analytics::{swap_quoted_event, swap_quoted_v2_event, Analytics};
+use super::{
+    capture_swap_outcome, ensure_distinct_tokens, snapshot_swap_context, RaindexSwapDataSource,
+    SwapAnalyticsContext, SwapDataSource,
+};
+use crate::analytics::{
+    swap_quote_failed_event, swap_quoted_event, swap_quoted_v2_event, Analytics, ApiVersion,
+};
 use crate::app_state::ApplicationState;
 use crate::auth::AuthenticatedKey;
 use crate::db::DbPool;
@@ -127,19 +132,32 @@ async fn handle_swap_quote(
     analytics: &Analytics,
     req: SwapQuoteRequest,
 ) -> Result<SwapQuoteResponse, ApiError> {
-    let response = process_swap_quote(ds, req).await?;
-
-    analytics.capture(|| {
-        swap_quoted_event(
-            key,
-            response.input_token,
-            response.output_token,
-            serde_json::to_value(response.denomination).unwrap_or(serde_json::Value::Null),
-            &response,
-        )
+    let analytics_context = snapshot_swap_context(analytics, || SwapAnalyticsContext {
+        input_token: req.input_token,
+        output_token: req.output_token,
+        requested_amount: req.output_amount.clone(),
+        denomination: serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
+        api_version: ApiVersion::V1,
+        mode: None,
+        taker: None,
     });
 
-    Ok(response)
+    capture_swap_outcome(
+        analytics,
+        analytics_context,
+        process_swap_quote(ds, req),
+        |context, error| swap_quote_failed_event(key, context.failure(), error),
+        |_context, response| {
+            swap_quoted_event(
+                key,
+                response.input_token,
+                response.output_token,
+                serde_json::to_value(response.denomination).unwrap_or(serde_json::Value::Null),
+                response,
+            )
+        },
+    )
+    .await
 }
 
 async fn handle_swap_quote_v2(
@@ -148,17 +166,32 @@ async fn handle_swap_quote_v2(
     analytics: &Analytics,
     req: SwapQuoteV2Request,
 ) -> Result<SwapQuoteV2Response, ApiError> {
-    let response = process_swap_quote_v2(ds, req).await?;
+    let analytics_context = snapshot_swap_context(analytics, || SwapAnalyticsContext {
+        input_token: req.input_token,
+        output_token: req.output_token,
+        requested_amount: req.amount.clone(),
+        denomination: serde_json::to_value(req.denomination).unwrap_or(serde_json::Value::Null),
+        api_version: ApiVersion::V2,
+        mode: serde_json::to_value(req.mode).ok(),
+        taker: None,
+    });
 
-    analytics.capture(|| swap_quoted_v2_event(key, &response));
-
-    Ok(response)
+    capture_swap_outcome(
+        analytics,
+        analytics_context,
+        process_swap_quote_v2(ds, req),
+        |context, error| swap_quote_failed_event(key, context.failure(), error),
+        |_context, response| swap_quoted_v2_event(key, response),
+    )
+    .await
 }
 
 async fn process_swap_quote(
     ds: &dyn SwapDataSource,
     req: SwapQuoteRequest,
 ) -> Result<SwapQuoteResponse, ApiError> {
+    ensure_distinct_tokens(req.input_token, req.output_token)?;
+
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await
         .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
@@ -246,6 +279,9 @@ async fn process_swap_quote_v2(
     ds: &dyn SwapDataSource,
     req: SwapQuoteV2Request,
 ) -> Result<SwapQuoteV2Response, ApiError> {
+    ensure_distinct_tokens(req.input_token, req.output_token)?;
+    let price_limit = validate_quote_v2_price_limit(&req)?;
+
     ds.validate_supported_tokens(req.input_token, req.output_token)
         .await
         .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
@@ -288,14 +324,10 @@ async fn process_swap_quote_v2(
         return Err(no_liquidity_error());
     }
 
-    let price_cap = match (
-        req.price_cap.as_ref(),
-        req.slippage_bps,
-        req.reference_io_ratio.as_ref(),
-    ) {
-        (Some(price_cap), None, None) => {
+    let price_cap = match price_limit {
+        QuoteV2PriceLimit::Fixed(price_cap) => {
             let normalized = normalize_calldata_price_cap(
-                price_cap.clone(),
+                price_cap.to_string(),
                 "price_cap",
                 req.denomination,
                 req.input_token,
@@ -307,19 +339,14 @@ async fn process_swap_quote_v2(
                 ApiError::BadRequest("invalid price_cap".into())
             })?
         }
-        (Some(_), None, Some(_)) => {
-            tracing::warn!(
-                "swap quote rejected because reference_io_ratio was provided without slippage_bps"
-            );
-            return Err(ApiError::BadRequest(
-                "reference_io_ratio requires slippage_bps".into(),
-            ));
-        }
-        (None, Some(slippage_bps @ 1..=5000), reference_io_ratio) => {
+        QuoteV2PriceLimit::Slippage {
+            slippage_bps,
+            reference_io_ratio,
+        } => {
             let reference_io_ratio = reference_io_ratio
                 .map(|reference_io_ratio| {
                     normalize_calldata_price_cap(
-                        reference_io_ratio.clone(),
+                        reference_io_ratio.to_string(),
                         "reference_io_ratio",
                         req.denomination,
                         req.input_token,
@@ -344,18 +371,6 @@ async fn process_swap_quote_v2(
                 slippage_bps,
                 reference_io_ratio,
             )?
-        }
-        (None, Some(_), _) => {
-            tracing::warn!("swap quote rejected for out-of-range slippage_bps");
-            return Err(ApiError::BadRequest(
-                "slippage_bps must be between 1 and 5000".into(),
-            ));
-        }
-        _ => {
-            tracing::warn!("swap quote rejected without exactly one price limit");
-            return Err(ApiError::BadRequest(
-                "provide exactly one of price_cap or slippage_bps".into(),
-            ));
         }
     };
 
@@ -430,6 +445,52 @@ async fn process_swap_quote_v2(
     })
 }
 
+enum QuoteV2PriceLimit<'a> {
+    Fixed(&'a str),
+    Slippage {
+        slippage_bps: u16,
+        reference_io_ratio: Option<&'a str>,
+    },
+}
+
+fn validate_quote_v2_price_limit(
+    req: &SwapQuoteV2Request,
+) -> Result<QuoteV2PriceLimit<'_>, ApiError> {
+    match (
+        req.price_cap.as_deref(),
+        req.slippage_bps,
+        req.reference_io_ratio.as_deref(),
+    ) {
+        (Some(price_cap), None, None) => Ok(QuoteV2PriceLimit::Fixed(price_cap)),
+        (Some(_), None, Some(_)) => {
+            tracing::warn!(
+                "swap quote rejected because reference_io_ratio was provided without slippage_bps"
+            );
+            Err(ApiError::BadRequest(
+                "reference_io_ratio requires slippage_bps".into(),
+            ))
+        }
+        (None, Some(slippage_bps @ 1..=5000), reference_io_ratio) => {
+            Ok(QuoteV2PriceLimit::Slippage {
+                slippage_bps,
+                reference_io_ratio,
+            })
+        }
+        (None, Some(_), _) => {
+            tracing::warn!("swap quote rejected for out-of-range slippage_bps");
+            Err(ApiError::BadRequest(
+                "slippage_bps must be between 1 and 5000".into(),
+            ))
+        }
+        _ => {
+            tracing::warn!("swap quote rejected without exactly one price limit");
+            Err(ApiError::BadRequest(
+                "provide exactly one of price_cap or slippage_bps".into(),
+            ))
+        }
+    }
+}
+
 fn no_liquidity_error() -> ApiError {
     ApiError::coded(
         ApiErrorCode::SwapNoLiquidity,
@@ -475,6 +536,7 @@ mod tests {
 
     const USDC: alloy::primitives::Address = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
     const WETH: alloy::primitives::Address = address!("4200000000000000000000000000000000000006");
+    const TAKER: alloy::primitives::Address = address!("1111111111111111111111111111111111111111");
 
     fn test_key() -> AuthenticatedKey {
         AuthenticatedKey {
@@ -793,10 +855,10 @@ mod tests {
     #[rocket::async_test]
     async fn test_process_swap_quote_v2_validates_price_limit_options() {
         let ds = MockSwapDataSource {
-            supported_tokens: Ok(()),
-            orders: Ok(vec![mock_order()]),
-            candidates: vec![mock_candidate("5", "1")],
-            calldata_result: Err(ApiError::Internal("unused".into())),
+            supported_tokens: Err(ApiError::Internal("data source must not be reached".into())),
+            orders: Err(ApiError::Internal("data source must not be reached".into())),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("data source must not be reached".into())),
         };
 
         let mut both = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
@@ -862,6 +924,7 @@ mod tests {
         assert_eq!(event.distinct_id, "client:test-client");
         assert_eq!(event.properties["estimated_output"], "5");
         assert_eq!(event.properties["fully_filled"], true);
+        assert_eq!(event.properties["api_version"], "v2");
     }
 
     #[rocket::async_test]
@@ -888,6 +951,125 @@ mod tests {
         assert_eq!(event.distinct_id, "client:test-client");
         assert_eq!(event.properties["estimated_input"], "150");
         assert_eq!(event.properties["api_client_owner"], "test-owner");
+        assert_eq!(event.properties["api_version"], "v1");
+    }
+
+    /// A failing quote must still report the pair that failed. Without this the only
+    /// signal is an `api_request` 404 with no tokens on it, which is what made a
+    /// 100%-failing integrator indistinguishable from one sending no traffic.
+    #[rocket::async_test]
+    async fn test_handle_swap_quote_captures_failure_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![]), // no orders for the pair -> SWAP_NO_LIQUIDITY
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+
+        let result = handle_swap_quote(&ds, &test_key(), &analytics, quote_request("100")).await;
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
+
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_quote_failed")
+            .expect("swap_quote_failed event");
+        assert_eq!(event.distinct_id, "client:test-client");
+        assert_eq!(event.properties["api_client_owner"], "test-owner");
+        assert_eq!(
+            event.properties["input_token"],
+            USDC.to_string().to_lowercase()
+        );
+        assert_eq!(
+            event.properties["output_token"],
+            WETH.to_string().to_lowercase()
+        );
+        assert_eq!(event.properties["requested_amount"], "100");
+        assert_eq!(event.properties["error_code"], "SWAP_NO_LIQUIDITY");
+        assert_eq!(event.properties["status_code"], 404);
+        assert_eq!(event.properties["same_token"], false);
+        assert_eq!(event.properties["api_version"], "v1");
+        // No swap_quoted on the failure path: success and failure stay disjoint so a
+        // success rate computed from these two events is meaningful.
+        assert!(!recording
+            .events()
+            .iter()
+            .any(|event| event.event == "swap_quoted"));
+    }
+
+    /// The guard must run before any data-source call: the whole point is to avoid the
+    /// full-book RPC sweep a same-token pair would otherwise trigger. A data source
+    /// that errors on first use proves it was never reached.
+    #[rocket::async_test]
+    async fn test_same_token_pair_is_rejected_before_touching_the_data_source() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Err(ApiError::Internal("data source must not be reached".into())),
+            orders: Err(ApiError::Internal("data source must not be reached".into())),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let mut req = quote_request("100");
+        req.output_token = req.input_token;
+
+        assert_error_code(
+            process_swap_quote(&ds, req).await,
+            ApiErrorCode::SwapSameToken,
+        );
+    }
+
+    #[rocket::async_test]
+    async fn test_same_token_failure_is_flagged_in_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+        let mut req = quote_request("100");
+        req.output_token = req.input_token;
+
+        let result = handle_swap_quote(&ds, &test_key(), &analytics, req).await;
+        assert_error_code(result, ApiErrorCode::SwapSameToken);
+
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_quote_failed")
+            .expect("swap_quote_failed event");
+        assert_eq!(event.properties["same_token"], true);
+        assert_eq!(event.properties["error_code"], "SWAP_SAME_TOKEN");
+        assert_eq!(event.properties["status_code"], 400);
+    }
+
+    #[rocket::async_test]
+    async fn test_handle_swap_quote_v2_captures_failure_analytics() {
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            calldata_result: Err(ApiError::Internal("unused".into())),
+        };
+        let recording = RecordingSink::new();
+        let analytics = Analytics::new(Arc::new(recording.clone()));
+
+        let mut request = quote_v2_request(SwapCalldataMode::BuyUpTo, "5");
+        request.taker = Some(TAKER);
+        let result = handle_swap_quote_v2(&ds, &test_key(), &analytics, request).await;
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
+
+        let event = recording
+            .events()
+            .into_iter()
+            .find(|event| event.event == "swap_quote_failed")
+            .expect("swap_quote_failed event");
+        assert_eq!(event.properties["api_version"], "v2");
+        assert_eq!(event.properties["requested_amount"], "5");
+        assert_eq!(event.properties["error_code"], "SWAP_NO_LIQUIDITY");
+        assert!(event.properties.get("taker").is_none());
     }
 
     #[rocket::async_test]


### PR DESCRIPTION
## Why

A swap client that fails **100% of the time** is currently indistinguishable from one sending no traffic at all.

- `swap_quoted` / `swap_calldata_generated` fire only on success
- `api_request` fires on failures but carries no request body

So a broken integration produces zero diagnosable signal.

This surfaced in production: an integrator (`terminal1`) spent **five days getting a 404 on every single `/v1/swap/quote` call** — 177 attempts, 0 successes — and nobody noticed, because the Growth "Demand" tab reads `swap_quoted` and therefore saw them as *absent* rather than *failing*.

Working out the cause required matching latency fingerprints against manually replayed requests, since nothing recorded what they sent:

| Client | 404s | p50 latency |
|---|---:|---:|
| terminal1 | 177 | 14,009 ms |
| st0x.io | 43 | 1,079 ms |

161 of terminal1's 177 failures sit in a 12–20s band. Replaying all 34 tokens in both directions found exactly one request shape that reproduces it — `USDC → USDC`, at 14.9–18.2s. Everything else either succeeds or fails in under 1.1s.

## What

**1. Failure events on all four swap endpoints.** `swap_quote_failed` and `swap_calldata_failed` carry the requested pair, amount, denomination, mode, `api_version`, and the wire `error_code` / `status_code`.

- `same_token` is precomputed, because that failure mode is invisible in aggregate — spotting it otherwise means grouping on two address columns, which is exactly the step nobody takes.
- Success and failure events stay disjoint, so a per-client success rate is well defined and alertable.
- Calldata attribution failures feed the same event: the caller ends up with no calldata either way.

**2. Reject `inputToken == outputToken` up front,** with a new `SWAP_SAME_TOKEN` code (HTTP 400).

Such a request is always a caller bug, but not a cheap one. The token is individually supported so `validate_supported_tokens` passes, and the pair matches every order holding that token — for a stablecoin leg that is the entire book, which then gets quoted over RPC before the simulation finds no executable leg and returns "no liquidity". A ~15s round trip answering a malformed question with a misleading answer. It is also a cheap amplification vector: one request costs a full-book RPC sweep.

Measured, via the site proxy:

| Request | Result |
|---|---|
| `USDC → USDC` (20 orders) | 404 in ~15,000 ms |
| `wtTSLA → wtTSLA` (3 orders) | 404 in ~1,072 ms |
| `USDC → wt`, 34 tokens | 32 × 200 in ~1.0–1.6s |
| `wt → USDC`, 34 tokens | 33 × 200, max 3.8s |

`RaindexError::SameTokenPair` also now maps to `SWAP_SAME_TOKEN` instead of being flattened into the generic invalid-parameters bucket, so it stays diagnosable if it ever surfaces from deeper in the SDK.

**3. `ApiError::code()` / `public_message()` extracted** so the HTTP responder and analytics report an error identically — a drift there would let a dashboard disagree with what the caller actually received.

## Notes for review

- **No new PII.** Token addresses are public contract addresses and amounts are trade sizes — the same class of data the success events already emit. `taker` appears only on calldata failures, and only where the success event already carried it.
- **Negligible volume.** Failures are rare (177 + 43 over five days).
- The `SwapFailure` snapshot is gated on `analytics.is_enabled()`, so a disabled sink still builds nothing.

## Testing

375 tests pass (12 new). `nix develop -c rainix-rs-static` (clippy + fmt) is clean.

New coverage: failure events fire on the error path with the right pair/code/status for v1 and v2; success and failure remain disjoint; the guard rejects a same-token pair *before* touching the data source (proved with a data source that errors on first use); `SWAP_SAME_TOKEN` serialization and 400 mapping; `code()`/`public_message()` across every `ApiError` variant.

## Follow-ups (not in this PR)

- A PostHog alert on per-client quote success rate — the point of the new events.
- Terminal1 still needs telling; this PR makes the next occurrence visible, it does not fix their integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787907382&installation_model_id=19370&pr_number=167&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F167&signature=e1967793dedf8224b60eb3e466608be4170302ae78e94efeafb4216c89ae8a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Same-token swap requests are rejected early with a clear `SWAP_SAME_TOKEN` error and HTTP 400 response.
  * Validation applies consistently to quote and calldata requests across supported API versions.
  * Error responses now provide more consistent public error codes and messages.

* **Analytics**
  * Failed quote and calldata requests now include relevant request, API-version, and error details.
  * Successful swap events now include API-version metadata.

* **Documentation**
  * Updated analytics and error documentation with supported events, privacy handling, and error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->