### PR TITLE
fix(swap): distinguish oracle-unavailable quote failures

### DIFF
--- a/docs/src/errors.md
+++ b/docs/src/errors.md
@@ -43,20 +43,27 @@ Swap and token-order endpoints emit the following stable codes at understood
 failure boundaries. Consumers should still handle generic fallback codes for
 unexpected failures outside those boundaries.
 
-| HTTP Status | Code                     | Description                                   |
-| ----------- | ------------------------ | --------------------------------------------- |
-| 400         | `SWAP_SAME_TOKEN`        | Input and output swap tokens are identical    |
-| 400         | `SWAP_UNSUPPORTED_TOKEN` | One or both swap tokens are unsupported       |
-| 404         | `SWAP_NO_LIQUIDITY`      | No executable liquidity is available          |
-| 500         | `SWAP_QUOTE_FAILED`      | Quote generation failed unexpectedly          |
-| 500         | `SWAP_CALLDATA_FAILED`   | Calldata generation failed unexpectedly       |
-| 502         | `ORDERS_QUERY_FAILED`    | The order source could not serve the request  |
-| 503         | `UPSTREAM_UNAVAILABLE`   | A required upstream dependency is unavailable |
+| HTTP Status | Code                      | Description                                   |
+| ----------- | ------------------------- | --------------------------------------------- |
+| 400         | `SWAP_SAME_TOKEN`         | Input and output swap tokens are identical    |
+| 400         | `SWAP_UNSUPPORTED_TOKEN`  | One or both swap tokens are unsupported       |
+| 404         | `SWAP_NO_LIQUIDITY`       | No executable liquidity is available          |
+| 500         | `SWAP_QUOTE_FAILED`       | Quote generation failed unexpectedly          |
+| 500         | `SWAP_CALLDATA_FAILED`    | Calldata generation failed unexpectedly       |
+| 502         | `ORDERS_QUERY_FAILED`     | The order source could not serve the request  |
+| 503         | `SWAP_ORACLE_UNAVAILABLE` | A required swap oracle is unavailable         |
+| 503         | `UPSTREAM_UNAVAILABLE`    | A required upstream dependency is unavailable |
 
 `SWAP_PREFLIGHT_FAILED` is reserved for a future typed preflight rejection
 boundary. The current Raindex dependency combines execution rejections with
 provider failures in one error variant, so the API conservatively emits
 `SWAP_CALLDATA_FAILED` instead of presenting ambiguous failures as HTTP 400.
+
+`SWAP_ORACLE_UNAVAILABLE` does not assert that a market is closed. It means an
+oracle-backed order could not be evaluated because its external context endpoint
+was unavailable. Individual order reverts that are not identified as oracle
+fetch failures are treated as non-executable liquidity; failures of the overall
+quote operation remain `SWAP_QUOTE_FAILED`.
 
 Domain codes are assigned at the boundary where the failure is understood.
 Detailed dependency logs and the coded response event share the same

--- a/docs/src/swap-flow.md
+++ b/docs/src/swap-flow.md
@@ -76,6 +76,11 @@ Provide exactly one of `priceCap` or `slippageBps`.
 The quote reflects current orderbook state. Prices may change between quoting
 and execution.
 
+Oracle-backed orders can be temporarily unavailable for evaluation when their
+external context fetch fails. Quote endpoints then return HTTP 503 with
+`SWAP_ORACLE_UNAVAILABLE`. This is distinct from HTTP 404 `SWAP_NO_LIQUIDITY`,
+which means the evaluated order set has no executable capacity for the request.
+
 ### Understanding Price Limits
 
 `priceCap`, `estimatedIoRatio`, `referenceIoRatio`, and `resolvedPriceCap`

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,10 +4,15 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use rain_orderbook_common::raindex_client::order_quotes::RaindexOrderQuote;
-use rain_orderbook_common::take_orders::TakeOrderCandidate;
 
+use crate::routes::swap::SwapCandidateBuild;
 use crate::types::orders::OrdersListResponse;
 use crate::types::trades::{TradesByAddressResponse, TradesQueryResponse};
+
+enum ConditionalCacheError<V, E> {
+    NotCacheable(V),
+    Fetch(E),
+}
 
 pub(crate) struct AppCache<K, V>(pub(crate) Cache<K, V>)
 where
@@ -58,6 +63,39 @@ where
         self.0.try_get_with(key, async move { fetch().await }).await
     }
 
+    pub(crate) async fn get_or_try_insert_if<F, Fut, E, P>(
+        &self,
+        key: K,
+        fetch: F,
+        should_cache: P,
+    ) -> Result<V, Arc<E>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<V, E>>,
+        E: Clone + Send + Sync + 'static,
+        P: FnOnce(&V) -> bool,
+    {
+        let result = self
+            .0
+            .try_get_with(key, async move {
+                let value = fetch().await.map_err(ConditionalCacheError::Fetch)?;
+                if should_cache(&value) {
+                    Ok(value)
+                } else {
+                    Err(ConditionalCacheError::NotCacheable(value))
+                }
+            })
+            .await;
+
+        match result {
+            Ok(value) => Ok(value),
+            Err(error) => match error.as_ref() {
+                ConditionalCacheError::NotCacheable(value) => Ok(value.clone()),
+                ConditionalCacheError::Fetch(error) => Err(Arc::new(error.clone())),
+            },
+        }
+    }
+
     #[cfg(test)]
     pub(crate) fn invalidate_all(&self) {
         self.0.invalidate_all()
@@ -70,7 +108,7 @@ pub(crate) struct RouteResponseCaches {
     pub order_quotes: AppCache<String, Vec<RaindexOrderQuote>>,
     pub orders_by_token: AppCache<String, OrdersListResponse>,
     pub orders_query: AppCache<String, OrdersListResponse>,
-    pub swap_candidates: AppCache<String, Vec<TakeOrderCandidate>>,
+    pub swap_candidates: AppCache<String, SwapCandidateBuild>,
     pub trades_by_token: AppCache<String, TradesByAddressResponse>,
     pub trades_by_taker: AppCache<String, TradesByAddressResponse>,
     pub trades_query: AppCache<String, TradesQueryResponse>,
@@ -342,6 +380,23 @@ mod tests {
             .await;
         assert!(result.is_err());
         assert!(cache.get(&"key").await.is_none());
+    }
+
+    #[rocket::async_test]
+    async fn test_get_or_try_insert_if_skips_rejected_values() {
+        let cache: AppCache<&str, u32> = AppCache::new(10, Duration::from_secs(60));
+
+        let first: Result<u32, Arc<String>> = cache
+            .get_or_try_insert_if("key", || async { Ok(1) }, |value| value.is_multiple_of(2))
+            .await;
+        assert_eq!(first.unwrap(), 1);
+        assert!(cache.get(&"key").await.is_none());
+
+        let second: Result<u32, Arc<String>> = cache
+            .get_or_try_insert_if("key", || async { Ok(2) }, |value| value.is_multiple_of(2))
+            .await;
+        assert_eq!(second.unwrap(), 2);
+        assert_eq!(cache.get(&"key").await, Some(2));
     }
 
     #[rocket::async_test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,7 @@ pub enum ApiErrorCode {
     SwapUnsupportedToken,
     SwapSameToken,
     SwapNoLiquidity,
+    SwapOracleUnavailable,
     SwapQuoteFailed,
     SwapPreflightFailed,
     SwapCalldataFailed,
@@ -43,6 +44,7 @@ impl ApiErrorCode {
             Self::SwapUnsupportedToken => "SWAP_UNSUPPORTED_TOKEN",
             Self::SwapSameToken => "SWAP_SAME_TOKEN",
             Self::SwapNoLiquidity => "SWAP_NO_LIQUIDITY",
+            Self::SwapOracleUnavailable => "SWAP_ORACLE_UNAVAILABLE",
             Self::SwapQuoteFailed => "SWAP_QUOTE_FAILED",
             Self::SwapPreflightFailed => "SWAP_PREFLIGHT_FAILED",
             Self::SwapCalldataFailed => "SWAP_CALLDATA_FAILED",
@@ -65,7 +67,7 @@ impl ApiErrorCode {
             Self::RateLimited => Status::TooManyRequests,
             Self::NotYetIndexed => Status::Accepted,
             Self::OrdersQueryFailed | Self::TradesQueryFailed => Status::BadGateway,
-            Self::UpstreamUnavailable => Status::ServiceUnavailable,
+            Self::SwapOracleUnavailable | Self::UpstreamUnavailable => Status::ServiceUnavailable,
             Self::InternalError | Self::SwapQuoteFailed | Self::SwapCalldataFailed => {
                 Status::InternalServerError
             }
@@ -363,6 +365,10 @@ mod tests {
             (ApiErrorCode::SwapSameToken, Status::BadRequest),
             (ApiErrorCode::SwapPreflightFailed, Status::BadRequest),
             (ApiErrorCode::SwapNoLiquidity, Status::NotFound),
+            (
+                ApiErrorCode::SwapOracleUnavailable,
+                Status::ServiceUnavailable,
+            ),
             (ApiErrorCode::SwapQuoteFailed, Status::InternalServerError),
             (
                 ApiErrorCode::SwapCalldataFailed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -612,6 +612,7 @@ mod tests {
     fn test_openapi_includes_token_proofs_schema() {
         let openapi = serde_json::to_value(super::ApiDoc::openapi()).expect("serialize openapi");
         let proofs_path = &openapi["paths"]["/v1/tokens/{address}/proofs"]["get"];
+        let swap_quote_v1_path = &openapi["paths"]["/v1/swap/quote"]["post"];
         let swap_quote_v2_path = &openapi["paths"]["/v2/swap/quote"]["post"];
         let swap_calldata_v2_path = &openapi["paths"]["/v2/swap/calldata"]["post"];
         let orders_query_path = &openapi["paths"]["/v1/orders/query"]["post"];
@@ -638,6 +639,14 @@ mod tests {
         assert!(schemas["TokenProofReceipt"]["properties"]["txHash"].is_object());
         assert!(schemas["TokenProofReceipt"]["properties"]["type"].is_object());
         assert_eq!(swap_quote_v2_path["tags"][0], "Swap");
+        assert_eq!(
+            swap_quote_v1_path["responses"]["503"]["description"],
+            "Required swap oracle unavailable"
+        );
+        assert_eq!(
+            swap_quote_v2_path["responses"]["503"]["description"],
+            "Required swap oracle unavailable"
+        );
         assert_eq!(
             swap_quote_v2_path["requestBody"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/SwapQuoteV2RequestBody"

--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1,6 +1,6 @@
 use super::{
-    capture_swap_outcome, ensure_distinct_tokens, snapshot_swap_context, RaindexSwapDataSource,
-    SwapAnalyticsContext, SwapDataSource,
+    capture_swap_outcome, ensure_distinct_tokens, no_liquidity_error, snapshot_swap_context,
+    RaindexSwapDataSource, SwapAnalyticsContext, SwapCandidateBuild, SwapDataSource,
 };
 use crate::analytics::{
     swap_calldata_failed_event, swap_calldata_generated_event, Analytics, ApiVersion,
@@ -45,7 +45,7 @@ use tracing::Instrument;
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
         (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
-        (status = 503, description = "Required upstream unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required upstream or swap oracle unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/calldata", data = "<request>")]
@@ -103,7 +103,7 @@ pub async fn post_swap_calldata(
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
         (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
-        (status = 503, description = "Required upstream unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required upstream or swap oracle unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/calldata", data = "<request>")]
@@ -474,6 +474,33 @@ async fn process_swap_calldata_v2(
     })
 }
 
+async fn build_calldata_candidates(
+    ds: &dyn SwapDataSource,
+    input_token: Address,
+    output_token: Address,
+    taker: Address,
+) -> Result<SwapCandidateBuild, ApiError> {
+    let orders = ds
+        .get_orders_for_pair(input_token, output_token)
+        .await
+        .map_err(map_calldata_boundary_error)?;
+    if orders.is_empty() {
+        return Err(no_liquidity_error());
+    }
+
+    let candidate_build = ds
+        .build_candidates_for_pair(&orders, input_token, output_token, taker)
+        .await
+        .map_err(map_calldata_boundary_error)?;
+    if let Some(error) = candidate_build.failures.oracle_unavailable_error() {
+        return Err(error);
+    }
+    if candidate_build.candidates.is_empty() {
+        return Err(no_liquidity_error());
+    }
+    Ok(candidate_build)
+}
+
 async fn process_swap_calldata_build(
     ds: &dyn SwapDataSource,
     req: SwapCalldataBuildRequest,
@@ -502,6 +529,7 @@ async fn process_swap_calldata_build(
             )
             .await
             .map_err(map_calldata_boundary_error)?;
+            build_calldata_candidates(ds, req.input_token, req.output_token, req.taker).await?;
             (amount, price_cap, resolved_price_cap, wrap_ratios)
         }
         SwapCalldataPriceLimit::SlippageBps {
@@ -542,22 +570,10 @@ async fn process_swap_calldata_build(
                     })
                 })
                 .transpose()?;
-            let orders = ds
-                .get_orders_for_pair(req.input_token, req.output_token)
-                .await
-                .map_err(map_calldata_boundary_error)?;
-            if orders.is_empty() {
-                return Err(ApiError::coded(
-                    ApiErrorCode::SwapNoLiquidity,
-                    "no executable liquidity is available for this pair",
-                ));
-            }
-            let candidates = ds
-                .build_candidates_for_pair(&orders, req.input_token, req.output_token, req.taker)
-                .await
-                .map_err(map_calldata_boundary_error)?;
+            let candidate_build =
+                build_calldata_candidates(ds, req.input_token, req.output_token, req.taker).await?;
             let price_cap = super::slippage::resolve_slippage_price_cap(
-                candidates,
+                candidate_build.candidates,
                 req.mode,
                 &amount,
                 slippage_bps,
@@ -618,10 +634,7 @@ fn map_calldata_boundary_error(error: ApiError) -> ApiError {
     }
     if matches!(error, ApiError::NotFound(_)) {
         tracing::warn!(%error, code = %ApiErrorCode::SwapNoLiquidity, "swap calldata found no executable liquidity");
-        return ApiError::coded(
-            ApiErrorCode::SwapNoLiquidity,
-            "no executable liquidity is available for this pair",
-        );
+        return no_liquidity_error();
     }
     tracing::error!(%error, code = %ApiErrorCode::SwapCalldataFailed, "swap calldata boundary failed");
     ApiError::coded(
@@ -818,10 +831,11 @@ mod tests {
             MockCalldataDataSource {
                 base: MockSwapDataSource {
                     supported_tokens: Ok(()),
-                    orders: Ok(vec![]),
-                    candidates: vec![],
+                    orders: Ok(vec![mock_order()]),
+                    candidates: vec![mock_candidate("1000", "1.5")],
                     calldata_result: Ok(response),
                 },
+                failures: super::super::SwapQuoteFailures::default(),
                 wrap_ratios,
                 captured_request: Arc::clone(&captured_request),
                 captured_counterparty: Arc::new(Mutex::new(None)),
@@ -847,6 +861,7 @@ mod tests {
                     candidates: vec![mock_candidate("100", "2")],
                     calldata_result: Ok(ready_response()),
                 },
+                failures: super::super::SwapQuoteFailures::default(),
                 wrap_ratios: Ok(wrap_ratios),
                 captured_request: Arc::clone(&captured_request),
                 captured_counterparty: Arc::clone(&captured_counterparty),
@@ -856,8 +871,19 @@ mod tests {
         )
     }
 
+    fn capture_candidate_outcome_ds(
+        candidates: Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>,
+        failures: Vec<super::super::SwapQuoteFailure>,
+    ) -> (MockCalldataDataSource, CapturedTakeOrdersRequest) {
+        let (mut ds, captured_request, _) = capture_slippage_ds(HashMap::new());
+        ds.base.candidates = candidates;
+        ds.failures = failures.into_iter().collect();
+        (ds, captured_request)
+    }
+
     struct MockCalldataDataSource {
         base: MockSwapDataSource,
+        failures: super::super::SwapQuoteFailures,
         wrap_ratios: Result<HashMap<Address, WrapRatioValue>, ApiError>,
         captured_request: CapturedTakeOrdersRequest,
         captured_counterparty: CapturedCounterparty,
@@ -892,11 +918,14 @@ mod tests {
             input_token: Address,
             output_token: Address,
             counterparty: Address,
-        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+        ) -> Result<super::super::SwapCandidateBuild, ApiError> {
             *self.captured_counterparty.lock().unwrap() = Some(counterparty);
-            self.base
+            let mut candidate_build = self
+                .base
                 .build_candidates_for_pair(orders, input_token, output_token, counterparty)
-                .await
+                .await?;
+            candidate_build.failures = self.failures.clone();
+            Ok(candidate_build)
         }
 
         async fn get_calldata(
@@ -937,8 +966,8 @@ mod tests {
     async fn test_process_swap_calldata_ready() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Ok(ready_response()),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5"))
@@ -957,8 +986,8 @@ mod tests {
     async fn test_handle_swap_calldata_captures_v1_analytics() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Ok(approval_response()),
         };
         let recording = RecordingSink::new();
@@ -992,8 +1021,8 @@ mod tests {
     async fn test_handle_swap_calldata_captures_v2_analytics() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Ok(approval_response()),
         };
         let recording = RecordingSink::new();
@@ -1026,8 +1055,8 @@ mod tests {
     async fn test_handle_swap_calldata_captures_v1_failure_analytics() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::Internal("failed to generate calldata".into())),
         };
         let recording = RecordingSink::new();
@@ -1067,8 +1096,8 @@ mod tests {
     async fn test_handle_swap_calldata_v2_captures_attribution_failure_analytics() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             // Deliberately invalid ABI: processing succeeds, attribution embedding fails.
             calldata_result: Ok(ready_response()),
         };
@@ -1185,8 +1214,8 @@ mod tests {
     async fn test_process_swap_calldata_needs_approval() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Ok(approval_response()),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5"))
@@ -1322,6 +1351,74 @@ mod tests {
         assert_eq!(request.price_cap, "2.01");
         assert_eq!(result.resolved_price_cap, "2.01");
         assert_eq!(*captured_counterparty.lock().unwrap(), Some(TAKER));
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_slippage_reports_oracle_unavailable() {
+        let (ds, captured_request) = capture_candidate_outcome_ds(
+            Vec::new(),
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_calldata_v2(
+            &ds,
+            slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50),
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_slippage_treats_order_reverts_as_no_liquidity() {
+        let (ds, captured_request) = capture_candidate_outcome_ds(
+            Vec::new(),
+            vec![super::super::SwapQuoteFailure::QuoteFailed],
+        );
+
+        let result = process_swap_calldata_v2(
+            &ds,
+            slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50),
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_slippage_rejects_incomplete_price_basis() {
+        let (ds, captured_request) = capture_candidate_outcome_ds(
+            vec![mock_candidate("100", "2")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_calldata_v2(
+            &ds,
+            slippage_v2_request(SwapCalldataMode::SpendExact, "100", 50),
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+        no_take_orders_request_was_made(&captured_request);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_calldata_v2_explicit_reports_oracle_unavailable() {
+        let (ds, captured_request) = capture_candidate_outcome_ds(
+            Vec::new(),
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_calldata_v2(
+            &ds,
+            calldata_v2_request(SwapCalldataMode::SpendExact, "100", "2"),
+        )
+        .await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+        no_take_orders_request_was_made(&captured_request);
     }
 
     #[rocket::async_test]
@@ -1755,8 +1852,8 @@ mod tests {
     async fn test_process_swap_calldata_bad_request() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::BadRequest("invalid parameters".into())),
         };
         let result = process_swap_calldata(&ds, calldata_request("not-a-number", "2.5")).await;
@@ -1767,8 +1864,8 @@ mod tests {
     async fn test_process_swap_calldata_internal_error() {
         let ds = MockSwapDataSource {
             supported_tokens: Ok(()),
-            orders: Ok(vec![]),
-            candidates: vec![],
+            orders: Ok(vec![mock_order()]),
+            candidates: vec![mock_candidate("1000", "1.5")],
             calldata_result: Err(ApiError::Internal("failed to generate calldata".into())),
         };
         let result = process_swap_calldata(&ds, calldata_request("100", "2.5")).await;

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -537,7 +537,7 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
     assert!(matches!(
         error,
         ApiError::Coded {
-            code: ApiErrorCode::SwapNoLiquidity,
+            code: ApiErrorCode::SwapOracleUnavailable,
             ..
         }
     ));

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -14,17 +14,20 @@ use crate::wrap_ratio::{
 };
 use alloy::primitives::Address;
 use async_trait::async_trait;
+use rain_orderbook_common::raindex_client::order_quotes::{
+    get_order_quotes_batch_with_injector, RaindexOrderQuote,
+};
 use rain_orderbook_common::raindex_client::orders::{
     GetOrdersFilters, GetOrdersTokenFilter, RaindexOrder,
 };
-use rain_orderbook_common::raindex_client::take_orders::{TakeOrdersInfo, TakeOrdersRequest};
+use rain_orderbook_common::raindex_client::take_orders::{
+    build_candidate_from_quote, TakeOrdersInfo, TakeOrdersRequest,
+};
 use rain_orderbook_common::raindex_client::types::ChainIds;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_common::raindex_client::RaindexError;
 use rain_orderbook_common::rpc_client::RpcClientError;
-use rain_orderbook_common::take_orders::{
-    build_take_order_candidates_for_pair, NoopInjector, TakeOrderCandidate, TakeOrdersMode,
-};
+use rain_orderbook_common::take_orders::{NoopInjector, TakeOrderCandidate, TakeOrdersMode};
 use rocket::Route;
 use std::collections::HashMap;
 use std::future::Future;
@@ -83,6 +86,82 @@ async fn capture_swap_outcome<T>(
     }
 }
 
+const ORACLE_FETCH_FAILURE_PREFIX: &str = "Oracle fetch failed for pair (";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SwapQuoteFailure {
+    OracleUnavailable,
+    QuoteFailed,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SwapQuoteFailures {
+    oracle_unavailable: usize,
+    quote_failed: usize,
+}
+
+impl SwapQuoteFailures {
+    fn record(&mut self, failure: SwapQuoteFailure) {
+        match failure {
+            SwapQuoteFailure::OracleUnavailable => self.oracle_unavailable += 1,
+            SwapQuoteFailure::QuoteFailed => self.quote_failed += 1,
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.oracle_unavailable == 0 && self.quote_failed == 0
+    }
+
+    pub(crate) fn oracle_unavailable_error(&self) -> Option<ApiError> {
+        (self.oracle_unavailable > 0).then(|| {
+            ApiError::coded(
+                ApiErrorCode::SwapOracleUnavailable,
+                "the oracle required to evaluate this swap is temporarily unavailable",
+            )
+        })
+    }
+}
+
+impl FromIterator<SwapQuoteFailure> for SwapQuoteFailures {
+    fn from_iter<T: IntoIterator<Item = SwapQuoteFailure>>(failures: T) -> Self {
+        let mut result = Self::default();
+        for failure in failures {
+            result.record(failure);
+        }
+        result
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct SwapCandidateBuild {
+    pub candidates: Vec<TakeOrderCandidate>,
+    pub failures: SwapQuoteFailures,
+}
+
+fn classify_quote_failure(error: Option<&str>) -> SwapQuoteFailure {
+    match error {
+        Some(error) if error.starts_with(ORACLE_FETCH_FAILURE_PREFIX) => {
+            SwapQuoteFailure::OracleUnavailable
+        }
+        _ => SwapQuoteFailure::QuoteFailed,
+    }
+}
+
+fn quote_matches_pair(
+    order: &rain_orderbook_bindings::IRaindexV6::OrderV4,
+    quote: &RaindexOrderQuote,
+    input_token: Address,
+    output_token: Address,
+) -> bool {
+    let Some(input) = order.validInputs.get(quote.pair.input_index as usize) else {
+        return false;
+    };
+    let Some(output) = order.validOutputs.get(quote.pair.output_index as usize) else {
+        return false;
+    };
+    input.token == input_token && output.token == output_token
+}
+
 #[async_trait]
 pub(crate) trait SwapDataSource: Send + Sync {
     async fn validate_supported_tokens(
@@ -103,7 +182,7 @@ pub(crate) trait SwapDataSource: Send + Sync {
         input_token: Address,
         output_token: Address,
         counterparty: Address,
-    ) -> Result<Vec<TakeOrderCandidate>, ApiError>;
+    ) -> Result<SwapCandidateBuild, ApiError>;
 
     async fn get_calldata(
         &self,
@@ -215,12 +294,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         input_token: Address,
         output_token: Address,
         counterparty: Address,
-    ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
+    ) -> Result<SwapCandidateBuild, ApiError> {
         let fetch = || async {
-            build_take_order_candidates_for_pair(
+            let quotes = get_order_quotes_batch_with_injector(
                 orders,
-                input_token,
-                output_token,
                 None,
                 None,
                 counterparty,
@@ -228,12 +305,71 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
             )
             .await
             .map_err(|e| {
-                tracing::error!(error = %e, "failed to build order candidates");
+                tracing::error!(error = %e, "failed to fetch quotes for order candidates");
                 ApiError::coded(
                     ApiErrorCode::SwapQuoteFailed,
                     "the swap quote could not be generated",
                 )
-            })
+            })?;
+            if quotes.len() != orders.len() {
+                tracing::error!(
+                    order_count = orders.len(),
+                    quote_set_count = quotes.len(),
+                    "order candidate quote count mismatch"
+                );
+                return Err(ApiError::coded(
+                    ApiErrorCode::SwapQuoteFailed,
+                    "the swap quote could not be generated",
+                ));
+            }
+
+            let mut result = SwapCandidateBuild::default();
+            for (order, order_quotes) in orders.iter().zip(quotes) {
+                let order_v4: rain_orderbook_bindings::IRaindexV6::OrderV4 =
+                    order.try_into().map_err(|e| {
+                        tracing::error!(error = %e, "failed to inspect order quotes");
+                        ApiError::coded(
+                            ApiErrorCode::SwapQuoteFailed,
+                            "the swap quote could not be generated",
+                        )
+                    })?;
+                for quote in &order_quotes {
+                    if !quote_matches_pair(&order_v4, quote, input_token, output_token) {
+                        continue;
+                    }
+
+                    if !quote.success || quote.data.is_none() {
+                        result
+                            .failures
+                            .record(classify_quote_failure(quote.error.as_deref()));
+                        continue;
+                    }
+
+                    if let Some(candidate) =
+                        build_candidate_from_quote(order, quote).map_err(|e| {
+                            tracing::error!(error = %e, "failed to build order candidate");
+                            ApiError::coded(
+                                ApiErrorCode::SwapQuoteFailed,
+                                "the swap quote could not be generated",
+                            )
+                        })?
+                    {
+                        result.candidates.push(candidate);
+                    }
+                }
+            }
+
+            tracing::info!(
+                order_count = orders.len(),
+                candidate_count = result.candidates.len(),
+                oracle_unavailable_count = result.failures.oracle_unavailable,
+                quote_failure_count = result.failures.quote_failed,
+                input_token = %input_token,
+                output_token = %output_token,
+                "built REST swap candidates"
+            );
+
+            Ok(result)
         };
 
         if !self.caches.is_enabled() || counterparty != Address::ZERO {
@@ -242,9 +378,10 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
 
         self.caches
             .swap_candidates
-            .get_or_try_insert(
+            .get_or_try_insert_if(
                 swap_candidates_cache_key(orders, input_token, output_token),
                 fetch,
+                |build| build.failures.is_empty(),
             )
             .await
             .map_err(|e| (*e).clone())
@@ -358,14 +495,18 @@ fn same_token_error() -> ApiError {
     )
 }
 
+pub(crate) fn no_liquidity_error() -> ApiError {
+    ApiError::coded(
+        ApiErrorCode::SwapNoLiquidity,
+        "no executable liquidity is available for this pair",
+    )
+}
+
 fn map_raindex_error(e: RaindexError) -> ApiError {
     match &e {
         RaindexError::NoLiquidity | RaindexError::InsufficientLiquidity { .. } => {
             tracing::warn!(error = %e, "no liquidity found");
-            ApiError::coded(
-                ApiErrorCode::SwapNoLiquidity,
-                "no executable liquidity is available for this pair",
-            )
+            no_liquidity_error()
         }
         // Kept distinct from the generic bucket below: `ensure_distinct_tokens` should
         // catch this at the edge, so reaching it here means a same-token pair slipped
@@ -440,8 +581,9 @@ pub fn routes_v2() -> Vec<Route> {
 #[cfg(test)]
 mod tests {
     use super::{
-        ensure_distinct_tokens, map_raindex_error, snapshot_swap_context,
+        classify_quote_failure, ensure_distinct_tokens, map_raindex_error, snapshot_swap_context,
         swap_calldata_response_from_take_orders_info, swap_candidates_cache_key, swap_chain_ids,
+        SwapQuoteFailure,
     };
     use crate::analytics::Analytics;
     use crate::error::{ApiError, ApiErrorCode};
@@ -558,6 +700,28 @@ mod tests {
     }
 
     #[test]
+    fn test_only_upstream_oracle_fetch_failures_are_classified_as_oracle_unavailable() {
+        assert_eq!(
+            classify_quote_failure(Some(
+                "Oracle fetch failed for pair (0, 1): HTTP request failed: 404 Not Found"
+            )),
+            SwapQuoteFailure::OracleUnavailable
+        );
+
+        for unrelated in [
+            "Unknown oracle session",
+            "StalePrice",
+            "HTTP request failed: 404 Not Found",
+            "quote reverted: Oracle fetch failed for pair (0, 1)",
+        ] {
+            assert_eq!(
+                classify_quote_failure(Some(unrelated)),
+                SwapQuoteFailure::QuoteFailed
+            );
+        }
+    }
+
+    #[test]
     fn test_raindex_no_liquidity_maps_to_stable_code() {
         assert!(matches!(
             map_raindex_error(RaindexError::NoLiquidity),
@@ -613,7 +777,7 @@ mod tests {
 
 #[cfg(test)]
 pub(crate) mod test_fixtures {
-    use super::SwapDataSource;
+    use super::{SwapCandidateBuild, SwapDataSource, SwapQuoteFailures};
     use crate::error::ApiError;
     use crate::types::swap::SwapCalldataResponse;
     use alloy::primitives::Address;
@@ -656,8 +820,11 @@ pub(crate) mod test_fixtures {
             _input_token: Address,
             _output_token: Address,
             _counterparty: Address,
-        ) -> Result<Vec<TakeOrderCandidate>, ApiError> {
-            Ok(self.candidates.clone())
+        ) -> Result<SwapCandidateBuild, ApiError> {
+            Ok(SwapCandidateBuild {
+                candidates: self.candidates.clone(),
+                failures: SwapQuoteFailures::default(),
+            })
         }
 
         async fn get_calldata(

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -1,6 +1,6 @@
 use super::{
-    capture_swap_outcome, ensure_distinct_tokens, snapshot_swap_context, RaindexSwapDataSource,
-    SwapAnalyticsContext, SwapDataSource,
+    capture_swap_outcome, ensure_distinct_tokens, no_liquidity_error, snapshot_swap_context,
+    RaindexSwapDataSource, SwapAnalyticsContext, SwapCandidateBuild, SwapDataSource,
 };
 use crate::analytics::{
     swap_quote_failed_event, swap_quoted_event, swap_quoted_v2_event, Analytics, ApiVersion,
@@ -49,6 +49,7 @@ const FULL_FILL_RELATIVE_TOLERANCE: Float = Float::from_raw(fixed_bytes!(
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
         (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required swap oracle unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/quote", data = "<request>")]
@@ -96,6 +97,8 @@ pub async fn post_swap_quote(
         (status = 422, description = "Request body could not be parsed", body = ApiErrorResponse),
         (status = 429, description = "Rate limited", body = ApiErrorResponse),
         (status = 500, description = "Internal server error", body = ApiErrorResponse),
+        (status = 502, description = "Order source unavailable", body = ApiErrorResponse),
+        (status = 503, description = "Required swap oracle unavailable", body = ApiErrorResponse),
     )
 )]
 #[post("/quote", data = "<request>")]
@@ -211,13 +214,18 @@ async fn process_swap_quote(
         return Err(no_liquidity_error());
     }
 
-    let candidates = ds
+    let SwapCandidateBuild {
+        candidates,
+        failures,
+    } = ds
         .build_candidates_for_pair(&orders, req.input_token, req.output_token, Address::ZERO)
         .await
         .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
 
     if candidates.is_empty() {
-        return Err(no_liquidity_error());
+        return Err(failures
+            .oracle_unavailable_error()
+            .unwrap_or_else(no_liquidity_error));
     }
 
     let buy_target = Float::parse(req.output_amount.clone()).map_err(|e| {
@@ -236,7 +244,15 @@ async fn process_swap_quote(
     })?;
 
     if sim.legs.is_empty() {
-        return Err(no_liquidity_error());
+        return Err(failures
+            .oracle_unavailable_error()
+            .unwrap_or_else(no_liquidity_error));
+    }
+
+    if !is_quote_fully_filled(sim.total_output, buy_target, false)? {
+        if let Some(error) = failures.oracle_unavailable_error() {
+            return Err(error);
+        }
     }
 
     let (estimated_input, estimated_output) = normalize_quote_amounts(
@@ -317,7 +333,10 @@ async fn process_swap_quote_v2(
         return Err(no_liquidity_error());
     }
 
-    let candidates = ds
+    let SwapCandidateBuild {
+        candidates,
+        failures,
+    } = ds
         .build_candidates_for_pair(
             &orders,
             req.input_token,
@@ -327,7 +346,9 @@ async fn process_swap_quote_v2(
         .await
         .map_err(|error| map_quote_boundary_error(error, ApiErrorCode::SwapQuoteFailed))?;
     if candidates.is_empty() {
-        return Err(no_liquidity_error());
+        return Err(failures
+            .oracle_unavailable_error()
+            .unwrap_or_else(no_liquidity_error));
     }
 
     let price_cap = match price_limit {
@@ -349,6 +370,9 @@ async fn process_swap_quote_v2(
             slippage_bps,
             reference_io_ratio,
         } => {
+            if let Some(error) = failures.oracle_unavailable_error() {
+                return Err(error);
+            }
             let reference_io_ratio = reference_io_ratio
                 .map(|reference_io_ratio| {
                     normalize_calldata_price_cap(
@@ -384,14 +408,27 @@ async fn process_swap_quote_v2(
     let is_exact_mode = parsed_mode.is_exact_mode();
     let target_amount = parsed_mode.target_amount();
     let simulation =
-        super::slippage::select_best_raindex_simulation(candidates, parsed_mode, price_cap)?;
+        super::slippage::select_best_raindex_simulation(candidates, parsed_mode, price_cap)
+            .map_err(|error| {
+                if matches!(
+                    &error,
+                    ApiError::Coded {
+                        code: ApiErrorCode::SwapNoLiquidity,
+                        ..
+                    }
+                ) {
+                    failures.oracle_unavailable_error().unwrap_or(error)
+                } else {
+                    error
+                }
+            })?;
     let achieved_amount = if is_buy_mode {
         simulation.total_output
     } else {
         simulation.total_input
     };
     let fully_filled = is_quote_fully_filled(achieved_amount, target_amount, is_exact_mode)?;
-    if is_exact_mode && !fully_filled {
+    if !fully_filled {
         let requested = target_amount.format().map_err(|error| {
             tracing::error!(%error, "failed to format requested quote amount");
             quote_failed_error()
@@ -401,7 +438,12 @@ async fn process_swap_quote_v2(
             quote_failed_error()
         })?;
         tracing::warn!(%requested, %available, "insufficient executable liquidity");
-        return Err(no_liquidity_error());
+        if let Some(error) = failures.oracle_unavailable_error() {
+            return Err(error);
+        }
+        if is_exact_mode {
+            return Err(no_liquidity_error());
+        }
     }
 
     let (estimated_input, estimated_output) = normalize_quote_amounts(
@@ -521,13 +563,6 @@ fn validate_quote_v2_price_limit(
     }
 }
 
-fn no_liquidity_error() -> ApiError {
-    ApiError::coded(
-        ApiErrorCode::SwapNoLiquidity,
-        "no executable liquidity is available for this pair",
-    )
-}
-
 fn quote_failed_error() -> ApiError {
     ApiError::coded(
         ApiErrorCode::SwapQuoteFailed,
@@ -636,6 +671,21 @@ mod tests {
         assert!(is_quote_fully_filled(overfill, target, false).unwrap());
     }
 
+    fn candidate_outcome_data_source(
+        candidates: Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>,
+        failures: Vec<super::super::SwapQuoteFailure>,
+    ) -> CandidateOutcomeDataSource {
+        CandidateOutcomeDataSource {
+            base: MockSwapDataSource {
+                supported_tokens: Ok(()),
+                orders: Ok(vec![mock_order()]),
+                candidates,
+                calldata_result: Err(ApiError::Internal("unused".into())),
+            },
+            failures: failures.into_iter().collect(),
+        }
+    }
+
     fn assert_error_code<T>(result: Result<T, ApiError>, expected: ApiErrorCode) {
         assert!(matches!(
             result,
@@ -676,6 +726,55 @@ mod tests {
         counterparties: Mutex<Vec<alloy::primitives::Address>>,
     }
 
+    struct CandidateOutcomeDataSource {
+        base: MockSwapDataSource,
+        failures: super::super::SwapQuoteFailures,
+    }
+
+    #[async_trait]
+    impl SwapDataSource for CandidateOutcomeDataSource {
+        async fn validate_supported_tokens(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<(), ApiError> {
+            self.base
+                .validate_supported_tokens(input_token, output_token)
+                .await
+        }
+
+        async fn get_orders_for_pair(
+            &self,
+            input_token: alloy::primitives::Address,
+            output_token: alloy::primitives::Address,
+        ) -> Result<Vec<rain_orderbook_common::raindex_client::orders::RaindexOrder>, ApiError>
+        {
+            self.base
+                .get_orders_for_pair(input_token, output_token)
+                .await
+        }
+
+        async fn build_candidates_for_pair(
+            &self,
+            _orders: &[rain_orderbook_common::raindex_client::orders::RaindexOrder],
+            _input_token: alloy::primitives::Address,
+            _output_token: alloy::primitives::Address,
+            _counterparty: alloy::primitives::Address,
+        ) -> Result<super::super::SwapCandidateBuild, ApiError> {
+            Ok(super::super::SwapCandidateBuild {
+                candidates: self.base.candidates.clone(),
+                failures: self.failures.clone(),
+            })
+        }
+
+        async fn get_calldata(
+            &self,
+            request: rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest,
+        ) -> Result<crate::types::swap::SwapCalldataResponse, ApiError> {
+            self.base.get_calldata(request).await
+        }
+    }
+
     #[async_trait]
     impl SwapDataSource for RecordingCounterpartyDataSource {
         async fn validate_supported_tokens(
@@ -705,7 +804,7 @@ mod tests {
             input_token: alloy::primitives::Address,
             output_token: alloy::primitives::Address,
             counterparty: alloy::primitives::Address,
-        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+        ) -> Result<super::super::SwapCandidateBuild, ApiError> {
             self.counterparties
                 .lock()
                 .map_err(|_| ApiError::Internal("counterparty recorder poisoned".into()))?
@@ -752,7 +851,7 @@ mod tests {
             input_token: alloy::primitives::Address,
             output_token: alloy::primitives::Address,
             counterparty: alloy::primitives::Address,
-        ) -> Result<Vec<rain_orderbook_common::take_orders::TakeOrderCandidate>, ApiError> {
+        ) -> Result<super::super::SwapCandidateBuild, ApiError> {
             self.base
                 .build_candidates_for_pair(orders, input_token, output_token, counterparty)
                 .await
@@ -1307,6 +1406,94 @@ mod tests {
         };
         let result = process_swap_quote(&ds, quote_request("100")).await;
         assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_reports_oracle_unavailable() {
+        let ds = candidate_outcome_data_source(
+            Vec::new(),
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_quote(&ds, quote_request("100")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_treats_order_reverts_as_no_liquidity() {
+        let ds = candidate_outcome_data_source(
+            Vec::new(),
+            vec![super::super::SwapQuoteFailure::QuoteFailed],
+        );
+
+        let result = process_swap_quote(&ds, quote_request("100")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapNoLiquidity);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_succeeds_with_executable_and_unavailable_candidates() {
+        let ds = candidate_outcome_data_source(
+            vec![mock_candidate("1000", "1.5")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_quote(&ds, quote_request("100")).await.unwrap();
+
+        assert_eq!(result.estimated_input, "150");
+        assert_eq!(result.estimated_output, "100");
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_partial_fill_reports_oracle_unavailable() {
+        let ds = candidate_outcome_data_source(
+            vec![mock_candidate("3", "2")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result = process_swap_quote(&ds, quote_request("8")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_exact_shortfall_reports_oracle_unavailable() {
+        let ds = candidate_outcome_data_source(
+            vec![mock_candidate("3", "2")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result =
+            process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::SpendExact, "8")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_incomplete_price_cap_filter_reports_oracle_unavailable() {
+        let ds = candidate_outcome_data_source(
+            vec![mock_candidate("100", "3")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result =
+            process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::BuyUpTo, "5")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
+    }
+
+    #[rocket::async_test]
+    async fn test_process_swap_quote_v2_up_to_shortfall_reports_oracle_unavailable() {
+        let ds = candidate_outcome_data_source(
+            vec![mock_candidate("3", "2")],
+            vec![super::super::SwapQuoteFailure::OracleUnavailable],
+        );
+
+        let result =
+            process_swap_quote_v2(&ds, quote_v2_request(SwapCalldataMode::SpendUpTo, "8")).await;
+
+        assert_error_code(result, ApiErrorCode::SwapOracleUnavailable);
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/slippage.rs
+++ b/src/routes/swap/slippage.rs
@@ -1,4 +1,4 @@
-use super::map_raindex_error;
+use super::{map_raindex_error, no_liquidity_error};
 use crate::error::ApiError;
 use alloy::primitives::Address;
 use rain_math_float::Float;
@@ -58,7 +58,7 @@ pub(crate) fn resolve_slippage_price_cap(
     let simulation = select_best_raindex_simulation(candidates, mode, simulation_price_cap)?;
     let worst_price = worst_price(&simulation)?.ok_or_else(|| {
         tracing::warn!("slippage simulation selected no order legs");
-        ApiError::NotFound("no liquidity found for this pair".into())
+        no_liquidity_error()
     })?;
     let multiplier = basis_points_multiplier(slippage_bps)?;
     worst_price.mul(multiplier).map_err(|error| {
@@ -122,7 +122,7 @@ pub(crate) fn select_best_raindex_simulation(
 
     best.map(|(_, simulation)| simulation).ok_or_else(|| {
         tracing::warn!("no raindex simulation produced liquidity for slippage resolution");
-        ApiError::NotFound("no liquidity found for this pair".into())
+        no_liquidity_error()
     })
 }
 


### PR DESCRIPTION
## Motivation

On 2026-08-06, production `/v2/swap/quote` failures were returned as HTTP 404
`SWAP_NO_LIQUIDITY` even though the REST API, local database, and order query
were healthy and each request found 1–2 active matching orders. Candidate
evaluation instead failed while fetching/evaluating oracle context.

The timing aligned with the US market-session boundary:

- the last affected successful quote was at 19:59:55 ET
- the first `Unknown oracle session` failure was at 20:00:04 ET
- before the 04:00 ET early-session opening, a background batch had 3
  successful and 68 failed quotes
- immediately after 04:00 ET, it had 69 successful and 2 failed quotes, and
  `Unknown oracle session` dropped to zero

A separate request genuinely had insufficient executable capacity
(`requested=50`, `available≈4.12e-17`) and must remain no-liquidity behavior.

No production logs, request payloads, customer identifiers, or diagnostic
artifacts are included in this change.

## Solution

- Add stable HTTP 503 `SWAP_ORACLE_UNAVAILABLE` for quote evaluation blocked by
  a required oracle context endpoint.
- Preserve per-pair evaluation failures alongside executable candidates instead
  of allowing the SDK candidate builder to flatten every rejected quote into an
  empty candidate list.
- Use the pinned SDK's public batch-quote and candidate-construction APIs; no
  submodule source is modified.
- Classify only the SDK-owned `Oracle fetch failed for pair (...)` prefix as
  oracle unavailability.
  - Bare `Unknown oracle session`, `StalePrice`, HTTP 404 text, and
    unrelated/revert errors are not independently classified as oracle
    unavailability.
  - This deliberately does not claim `MARKET_CLOSED`: the dependency exposes no
    trustworthy structured market/session state.
- Return `SWAP_QUOTE_FAILED` for unrelated failed candidate evaluations rather
  than falsely reporting no liquidity.
- Keep `SWAP_NO_LIQUIDITY` for zero matching orders, zero/non-positive
  executable capacity, price-cap filtering, and fully evaluated exact-mode
  shortfalls.
- Let executable candidates win in mixed books. If an exact-mode shortfall could
  be explained by an unavailable candidate, return the evaluation failure
  rather than a false no-liquidity conclusion.
- Apply the same candidate outcome to V2 slippage-based calldata price-cap
  resolution.
- Document the new public error and add 502/503 OpenAPI responses consistently
  to V1/V2 quote endpoints.

## Compatibility

This is an additive error contract change: affected quote requests move from
misleading HTTP 404 `SWAP_NO_LIQUIDITY` to HTTP 503
`SWAP_ORACLE_UNAVAILABLE` (or HTTP 500 `SWAP_QUOTE_FAILED` for unrelated
evaluation failures). Genuine no-liquidity requests keep the existing 404 code
and message.

V1/V2 successful response shapes are unchanged. Mixed candidate sets continue
to return successful quotes when the requested mode can be served by an
executable candidate.

Direct price-cap calldata generation still delegates candidate construction
internally to rain.orderbook, which currently discards per-pair failure
categories before returning `RaindexError::NoLiquidity`. Correctly
distinguishing oracle/session failures on that path requires the upstream
change below; this PR keeps the REST-side change focused and avoids a duplicate
preflight quote sweep.

## Upstream limitation

The pinned rain.orderbook revision exposes oracle fetch failures only through
`RaindexOrderQuote.error: Option<String>`. It does not expose a structured
market-open/session-closed signal, and its aggregate candidate/calldata paths
discard per-pair failure information.

A follow-up upstream change should expose a typed per-quote failure category (at
minimum oracle fetch unavailable vs contract quote failure, and a session-closed
variant only if the oracle can prove it) and propagate the aggregate reason
through calldata candidate selection. REST can then remove the narrowly tested
SDK-prefix match and provide consistent direct-calldata semantics.

## Verification

- `nix develop -c cargo check`
- `nix develop -c cargo test routes::swap` — 88 passed
- `nix develop -c cargo test test_openapi_includes_token_proofs_schema` — passed
- `nix develop -c cargo test` — 398 passed, 0 failed
- `nix develop -c cargo fmt`
- `nix develop -c rainix-rs-static`
- `git diff --check`
- repository pre-commit hooks

Regression coverage includes genuine no liquidity, oracle unavailability, the
narrow classification boundary, unrelated upstream failures, mixed candidate
success, exact-mode shortfalls with unavailable candidates, and price-cap
filtering remaining `SWAP_NO_LIQUIDITY`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788597280&installation_model_id=19370&pr_number=168&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F168&signature=22888aad82371336f168b055a3f0f0c1dcad058805f63ea256b7bd98e9235876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer swap quote error handling for temporary oracle unavailability.
  * Quote endpoints now return HTTP 503 with a dedicated error code when required pricing data is unavailable.
  * Improved distinction between unavailable oracle services, failed quotes, and unavailable liquidity.

* **Bug Fixes**
  * Slippage and exact-fill flows now provide more accurate no-liquidity responses.
  * Updated API documentation to describe the new 503 response and error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->