### PR TITLE
fix: treat Float dust underfills as fullyFilled (ST0-31)

### DIFF
--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -25,8 +25,51 @@ use rain_orderbook_common::take_orders::{
 };
 use rocket::serde::json::Json;
 use rocket::State;
-use std::ops::Div;
+use std::ops::{Div, Sub};
 use tracing::Instrument;
+
+/// Relative shortfall at or below this is treated as a full fill.
+///
+/// Raindex / Float walks often return `target − ε` (e.g. `0.05` vs
+/// `0.049999…`). Exact `Float::eq` then falsely reports `fullyFilled: false`
+/// and the DEX UI shows a liquidity warning. 1e-9 is far below any real
+/// partial fill while covering typical dust.
+const FILL_DUST_RELATIVE: &str = "0.000000001";
+
+/// True when `achieved` meets `target`, or undershoots only by Float dust.
+fn is_fully_filled(achieved: Float, target: Float) -> Result<bool, ApiError> {
+    if achieved.gte(target).map_err(|error| {
+        tracing::error!(%error, "failed to compare swap quote fill amount (gte)");
+        quote_failed_error()
+    })? {
+        return Ok(true);
+    }
+
+    let target_is_zero = target.is_zero().map_err(|error| {
+        tracing::error!(%error, "failed to check zero target fill amount");
+        quote_failed_error()
+    })?;
+    if target_is_zero {
+        return Ok(false);
+    }
+
+    let shortfall = target.sub(achieved).map_err(|error| {
+        tracing::error!(%error, "failed to compute swap quote fill shortfall");
+        quote_failed_error()
+    })?;
+    let relative = shortfall.div(target).map_err(|error| {
+        tracing::error!(%error, "failed to compute relative fill shortfall");
+        quote_failed_error()
+    })?;
+    let dust = Float::parse(FILL_DUST_RELATIVE.to_string()).map_err(|error| {
+        tracing::error!(%error, "failed to parse fill dust threshold");
+        quote_failed_error()
+    })?;
+    relative.lte(dust).map_err(|error| {
+        tracing::error!(%error, "failed to compare relative fill shortfall");
+        quote_failed_error()
+    })
+}
 
 #[utoipa::path(
     post,
@@ -384,10 +427,7 @@ async fn process_swap_quote_v2(
     } else {
         simulation.total_input
     };
-    let fully_filled = achieved_amount.eq(target_amount).map_err(|error| {
-        tracing::error!(%error, "failed to compare swap quote fill amount");
-        quote_failed_error()
-    })?;
+    let fully_filled = is_fully_filled(achieved_amount, target_amount)?;
     if is_exact_mode && !fully_filled {
         let requested = target_amount.format().map_err(|error| {
             tracing::error!(%error, "failed to format requested quote amount");
@@ -527,6 +567,32 @@ mod tests {
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
     use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
     use crate::types::swap::{SwapCalldataMode, SwapDenomination};
+
+    #[test]
+    fn is_fully_filled_treats_dust_underfill_as_complete() {
+        let target = Float::parse("0.05".to_string()).unwrap();
+        let dust_short = Float::parse(
+            "0.04999999999999999999999999999999999999999999999999999999999999999".to_string(),
+        )
+        .unwrap();
+        assert!(is_fully_filled(dust_short, target).unwrap());
+        assert!(is_fully_filled(target, target).unwrap());
+    }
+
+    #[test]
+    fn is_fully_filled_keeps_real_partials_incomplete() {
+        let target = Float::parse("0.05".to_string()).unwrap();
+        let partial = Float::parse("0.049".to_string()).unwrap(); // 2% short — not dust
+        assert!(!is_fully_filled(partial, target).unwrap());
+    }
+
+    #[test]
+    fn is_fully_filled_accepts_overfill() {
+        let target = Float::parse("0.05".to_string()).unwrap();
+        let over = Float::parse("0.05000000000000001".to_string()).unwrap();
+        assert!(is_fully_filled(over, target).unwrap());
+    }
+
     use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::address;
     use async_trait::async_trait;


### PR DESCRIPTION
## Summary
- `fullyFilled` used exact `Float::eq`, so sells like `0.05` with `estimatedInput` `0.049999…` returned `false` and the DEX UI warned about missing liquidity.
- Treat fills as complete when achieved ≥ target, or when relative shortfall ≤ `1e-9`.
- Unit tests cover dust underfill, real partial, and overfill.

Linear: https://linear.app/makeitrain/issue/ST0-31/restapi-fullyfilled-false-on-dust-shortfall-false-liquidity-warning
@findolor please review.

## Test plan
- [x] `nix develop -c cargo test is_fully_filled`
- [x] `nix develop -c cargo fmt` + `rainix-rs-static`
- [ ] Manual: sell wtMSTR ~0.05 on trade UI against this API — quote should show `fullyFilled: true` (no false liquidity banner) when the book can fill


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788979116&installation_model_id=19370&pr_number=170&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F170&signature=6e86086ffe673c5cf6074753abdb719f0b828b4761c1039c3508145b485cc9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->