### PR TITLE
Fix executable swap liquidity reporting

### DIFF
--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -1252,20 +1252,42 @@ mod tests {
 
     #[rocket::async_test]
     async fn test_process_swap_calldata_v2_spend_up_to_preserves_request() {
-        let (ds, captured_request) = capture_ds(ready_response(), HashMap::new());
-        let result = process_swap_calldata_v2(
-            &ds,
-            calldata_v2_request(SwapCalldataMode::SpendUpTo, "75", "3"),
-        )
-        .await
-        .unwrap();
+        // Exact request and surviving-leg input from production block 49,797,519.
+        let executable_input =
+            "0.04310434222334697689407343024988324343123847171843280166595003948319";
+        let response = SwapCalldataResponse {
+            estimated_input: executable_input.to_string(),
+            ..ready_response()
+        };
+        let (ds, captured_request) = capture_ds(response, HashMap::new());
+        let mut incident_request = calldata_v2_request(
+            SwapCalldataMode::SpendUpTo,
+            "0.05",
+            "0.010507140312878644839541586318708372026337414326508889434455784294694",
+        );
+        incident_request.taker = address!("D2843D9E7738d46D90CB6Dff8D6C83db58B9c165");
+        incident_request.input_token = WT_MSTR;
+        incident_request.output_token = USDC;
+        let result = process_swap_calldata_v2(&ds, incident_request)
+            .await
+            .unwrap();
         let request = captured_take_orders_request(&captured_request);
 
+        assert_eq!(request.taker, "0xD2843D9E7738d46D90CB6Dff8D6C83db58B9c165");
+        assert_eq!(request.sell_token, WT_MSTR.to_string());
+        assert_eq!(request.buy_token, USDC.to_string());
         assert_eq!(request.mode, TakeOrdersMode::SpendUpTo);
-        assert_eq!(request.amount, "75");
-        assert_eq!(request.price_cap, "3");
+        assert_eq!(request.amount, "0.05");
+        assert_eq!(
+            request.price_cap,
+            "0.010507140312878644839541586318708372026337414326508889434455784294694"
+        );
+        assert_eq!(result.calldata.estimated_input, executable_input);
         assert_eq!(result.calldata.denomination, SwapDenomination::Wrapped);
-        assert_eq!(result.resolved_price_cap, "3");
+        assert_eq!(
+            result.resolved_price_cap,
+            "0.010507140312878644839541586318708372026337414326508889434455784294694"
+        );
     }
 
     #[rocket::async_test]

--- a/src/routes/swap/mod.rs
+++ b/src/routes/swap/mod.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use rain_orderbook_common::raindex_client::orders::{
     GetOrdersFilters, GetOrdersTokenFilter, RaindexOrder,
 };
-use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
+use rain_orderbook_common::raindex_client::take_orders::{TakeOrdersInfo, TakeOrdersRequest};
 use rain_orderbook_common::raindex_client::types::ChainIds;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use rain_orderbook_common::raindex_client::RaindexError;
@@ -277,21 +277,7 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
                 }],
             })
         } else if let Some(take_orders_info) = result.take_orders_info() {
-            let expected_sell = take_orders_info.expected_sell().format().map_err(|e| {
-                tracing::error!(error = %e, "failed to format expected sell");
-                ApiError::coded(
-                    ApiErrorCode::SwapCalldataFailed,
-                    "swap calldata could not be generated",
-                )
-            })?;
-            Ok(SwapCalldataResponse {
-                to: take_orders_info.raindex(),
-                data: take_orders_info.calldata().clone(),
-                value: alloy::primitives::U256::ZERO,
-                estimated_input: expected_sell,
-                denomination: SwapDenomination::Wrapped,
-                approvals: vec![],
-            })
+            swap_calldata_response_from_take_orders_info(&take_orders_info)
         } else {
             tracing::error!("calldata provider returned an unexpected result state");
             Err(ApiError::coded(
@@ -319,6 +305,27 @@ impl<'a> SwapDataSource for RaindexSwapDataSource<'a> {
         persist_wrap_ratio_snapshots_best_effort(self.pool, &responses).await;
         Ok(wrap_ratio_values_from_responses(responses))
     }
+}
+
+fn swap_calldata_response_from_take_orders_info(
+    take_orders_info: &TakeOrdersInfo,
+) -> Result<SwapCalldataResponse, ApiError> {
+    let expected_sell = take_orders_info.expected_sell().format().map_err(|e| {
+        tracing::error!(error = %e, "failed to format expected sell");
+        ApiError::coded(
+            ApiErrorCode::SwapCalldataFailed,
+            "swap calldata could not be generated",
+        )
+    })?;
+
+    Ok(SwapCalldataResponse {
+        to: take_orders_info.raindex(),
+        data: take_orders_info.calldata().clone(),
+        value: alloy::primitives::U256::ZERO,
+        estimated_input: expected_sell,
+        denomination: SwapDenomination::Wrapped,
+        approvals: vec![],
+    })
 }
 
 /// Reject a swap whose input and output token are the same, before any order lookup.
@@ -434,12 +441,13 @@ pub fn routes_v2() -> Vec<Route> {
 mod tests {
     use super::{
         ensure_distinct_tokens, map_raindex_error, snapshot_swap_context,
-        swap_candidates_cache_key, swap_chain_ids,
+        swap_calldata_response_from_take_orders_info, swap_candidates_cache_key, swap_chain_ids,
     };
     use crate::analytics::Analytics;
     use crate::error::{ApiError, ApiErrorCode};
     use alloy::primitives::address;
     use rain_orderbook_common::raindex_client::orders::RaindexOrder;
+    use rain_orderbook_common::raindex_client::take_orders::TakeOrdersInfo;
     use rain_orderbook_common::raindex_client::RaindexError;
     use rain_orderbook_common::rpc_client::RpcClientError;
     use serde_json::json;
@@ -512,6 +520,41 @@ mod tests {
     #[test]
     fn test_swap_orders_are_scoped_to_calldata_chain() {
         assert_eq!(swap_chain_ids().0, vec![crate::CHAIN_ID]);
+    }
+
+    #[test]
+    fn test_take_orders_info_maps_executable_incident_input() {
+        // After preflight removed the reverting leg, this was the only executable input.
+        let expected_sell =
+            "0.04310434222334697689407343024988324343123847171843280166595003948319";
+        let expected_sell_float = rain_math_float::Float::parse(expected_sell.to_string())
+            .expect("parse incident executable input");
+        let effective_price = rain_math_float::Float::parse(
+            "0.010405262850569590820343337005442828611770549820812206944645896242997".to_string(),
+        )
+        .expect("parse incident effective price");
+        let max_sell_cap =
+            rain_math_float::Float::parse("0.05".to_string()).expect("parse incident maximum sell");
+        let take_orders_info: TakeOrdersInfo = serde_json::from_value(json!({
+            "raindex": "0xe522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D",
+            "calldata": "0xabcdef",
+            "effectivePrice": effective_price,
+            "prices": [effective_price],
+            "expectedSell": expected_sell_float,
+            "maxSellCap": max_sell_cap
+        }))
+        .expect("deserialize SDK take-orders result");
+
+        let response = swap_calldata_response_from_take_orders_info(&take_orders_info)
+            .expect("map ready SDK result");
+
+        assert_eq!(response.estimated_input, expected_sell);
+        assert_eq!(
+            response.to,
+            address!("e522cB4a5fCb2eb31a52Ff41a4653d85A4fd7C9D")
+        );
+        assert_eq!(response.data.as_ref(), [0xab, 0xcd, 0xef]);
+        assert!(response.approvals.is_empty());
     }
 
     #[test]

--- a/src/routes/swap/quote.rs
+++ b/src/routes/swap/quote.rs
@@ -18,15 +18,21 @@ use crate::types::swap::{
     SwapQuoteRequest, SwapQuoteResponse, SwapQuoteV2Request, SwapQuoteV2RequestBody,
     SwapQuoteV2Response,
 };
-use alloy::primitives::Address;
+use alloy::primitives::{fixed_bytes, Address};
 use rain_math_float::Float;
 use rain_orderbook_common::take_orders::{
     simulate_buy_over_candidates, ParsedTakeOrdersMode, TakeOrdersMode,
 };
 use rocket::serde::json::Json;
 use rocket::State;
-use std::ops::Div;
+use std::ops::{Div, Sub};
 use tracing::Instrument;
+
+// Up-to modes can be microscopically under target because DecimalFloat arithmetic
+// rounds. One part per billion is presentation dust; exact modes remain strict.
+const FULL_FILL_RELATIVE_TOLERANCE: Float = Float::from_raw(fixed_bytes!(
+    "fffffff700000000000000000000000000000000000000000000000000000001"
+));
 
 #[utoipa::path(
     post,
@@ -384,10 +390,7 @@ async fn process_swap_quote_v2(
     } else {
         simulation.total_input
     };
-    let fully_filled = achieved_amount.eq(target_amount).map_err(|error| {
-        tracing::error!(%error, "failed to compare swap quote fill amount");
-        quote_failed_error()
-    })?;
+    let fully_filled = is_quote_fully_filled(achieved_amount, target_amount, is_exact_mode)?;
     if is_exact_mode && !fully_filled {
         let requested = target_amount.format().map_err(|error| {
             tracing::error!(%error, "failed to format requested quote amount");
@@ -443,6 +446,33 @@ async fn process_swap_quote_v2(
         fully_filled,
         resolved_price_cap,
     })
+}
+
+fn is_quote_fully_filled(
+    achieved: Float,
+    target: Float,
+    is_exact_mode: bool,
+) -> Result<bool, ApiError> {
+    if is_exact_mode {
+        return achieved.eq(target).map_err(|error| {
+            tracing::error!(%error, "failed to compare exact swap quote fill amount");
+            quote_failed_error()
+        });
+    }
+
+    let relative_shortfall = target
+        .sub(achieved)
+        .and_then(|shortfall| shortfall.div(target))
+        .map_err(|error| {
+            tracing::error!(%error, "failed to compute relative swap quote fill shortfall");
+            quote_failed_error()
+        })?;
+    relative_shortfall
+        .lte(FULL_FILL_RELATIVE_TOLERANCE)
+        .map_err(|error| {
+            tracing::error!(%error, "failed to compare relative swap quote fill shortfall");
+            quote_failed_error()
+        })
 }
 
 enum QuoteV2PriceLimit<'a> {
@@ -569,6 +599,41 @@ mod tests {
             reference_io_ratio: None,
             denomination: SwapDenomination::Wrapped,
         }
+    }
+
+    #[test]
+    fn test_full_fill_tolerance_accepts_incident_rounding_dust() {
+        let achieved = Float::parse(
+            "0.04999999999999999999999999999999999999999999999999999999999999999999".to_string(),
+        )
+        .unwrap();
+        let target = Float::parse("0.05".to_string()).unwrap();
+
+        assert!(is_quote_fully_filled(achieved, target, false).unwrap());
+        assert!(!is_quote_fully_filled(achieved, target, true).unwrap());
+    }
+
+    #[test]
+    fn test_full_fill_tolerance_rejects_incident_executable_shortfall() {
+        let achieved = Float::parse(
+            "0.04310434222334697689407343024988324343123847171843280166595003948319".to_string(),
+        )
+        .unwrap();
+        let target = Float::parse("0.05".to_string()).unwrap();
+
+        assert!(!is_quote_fully_filled(achieved, target, false).unwrap());
+    }
+
+    #[test]
+    fn test_full_fill_tolerance_accepts_boundary_and_overfill() {
+        let target = Float::parse("1".to_string()).unwrap();
+        let boundary = Float::parse("0.999999999".to_string()).unwrap();
+        let beyond = Float::parse("0.9999999989".to_string()).unwrap();
+        let overfill = Float::parse("1.01".to_string()).unwrap();
+
+        assert!(is_quote_fully_filled(boundary, target, false).unwrap());
+        assert!(!is_quote_fully_filled(beyond, target, false).unwrap());
+        assert!(is_quote_fully_filled(overfill, target, false).unwrap());
     }
 
     fn assert_error_code<T>(result: Result<T, ApiError>, expected: ApiErrorCode) {

--- a/src/routes/swap/slippage.rs
+++ b/src/routes/swap/slippage.rs
@@ -112,7 +112,7 @@ pub(crate) fn select_best_raindex_simulation(
         let replace = match &best {
             None => true,
             Some((best_raindex, best_simulation)) => {
-                is_better_simulation(raindex, &simulation, *best_raindex, best_simulation)?
+                is_better_simulation(mode, raindex, &simulation, *best_raindex, best_simulation)?
             }
         };
         if replace {
@@ -127,11 +127,27 @@ pub(crate) fn select_best_raindex_simulation(
 }
 
 fn is_better_simulation(
+    mode: ParsedTakeOrdersMode,
     raindex: Address,
     simulation: &SimulationResult,
     best_raindex: Address,
     best_simulation: &SimulationResult,
 ) -> Result<bool, ApiError> {
+    let primary = selection_primary(simulation, mode);
+    let best_primary = selection_primary(best_simulation, mode);
+    if primary
+        .gt(best_primary)
+        .map_err(map_float_comparison_error)?
+    {
+        return Ok(true);
+    }
+    if !primary
+        .eq(best_primary)
+        .map_err(map_float_comparison_error)?
+    {
+        return Ok(false);
+    }
+
     if simulation
         .total_output
         .gt(best_simulation.total_output)
@@ -158,6 +174,14 @@ fn is_better_simulation(
             }
         }
         _ => Ok(raindex < best_raindex),
+    }
+}
+
+fn selection_primary(simulation: &SimulationResult, mode: ParsedTakeOrdersMode) -> Float {
+    if mode.is_exact_mode() && !mode.is_buy_mode() {
+        simulation.total_input
+    } else {
+        simulation.total_output
     }
 }
 
@@ -244,6 +268,38 @@ mod tests {
             vec![candidate(1, "5", "1"), candidate(1, "5", "2")],
             TakeOrdersMode::SpendExact,
             "8",
+            100,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "2.02");
+    }
+
+    #[test]
+    fn spend_exact_prefers_the_raindex_that_fills_the_input_target() {
+        let cap = resolve_slippage_price_cap(
+            vec![candidate(1, "5", "0.5"), candidate(2, "10", "2")],
+            TakeOrdersMode::SpendExact,
+            "10",
+            100,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(cap.format().unwrap(), "2.02");
+    }
+
+    #[test]
+    fn spend_exact_breaks_equal_input_ties_with_higher_output() {
+        let cap = resolve_slippage_price_cap(
+            vec![
+                candidate(1, "10", "1"),
+                candidate(2, "10", "0.5"),
+                candidate(2, "2.5", "2"),
+            ],
+            TakeOrdersMode::SpendExact,
+            "10",
             100,
             None,
         )


### PR DESCRIPTION
## Dependent PRs

- Rainix CI prerequisite (merge first): https://github.com/rainlanguage/rainix/pull/295
- Raindex SDK fix (merge second): https://github.com/rainlanguage/raindex/pull/2829

## Motivation

Production request `dec8bcc1-0b40-4b57-ba27-8e3212cdc596` initially simulated almost `0.05` input across two legs. One leg reverted during preflight, but the old SDK retry returned calldata with stale aggregate totals. REST therefore advertised `estimatedInput` near `0.05` even though only `0.04310434222334697689407343024988324343123847171843280166595003948319` remained executable.

Separately, DecimalFloat rounding can leave an “up to” quote microscopically below its target even when it is effectively filled.

## Solution

- Bump `rain.orderbook` to the preflight rebuild and reselection fix.
- Map the rebuilt SDK `expectedSell` value directly to REST `estimatedInput`.
- Treat a relative shortfall up to `1e-9` as presentation dust only for `SpendUpTo` and `BuyUpTo` `fullyFilled` reporting.
- Keep `SpendExact` and `BuyExact` strict so REST cannot claim a fill below the contract minimum.
- Align REST Raindex selection with the SDK: `SpendExact` ranks by filled input, then output, then worst price and address.
- Add SDK-boundary and exact incident-request regression coverage.

## Exact incident verification

The regression uses the logged Base taker, wtMSTR/USDC pair, `SpendUpTo` amount `0.05`, exact price cap, and surviving executable input from block 49,797,519.

A live replay of the exact request against current chain state returned:

- `/v2/swap/quote`: HTTP 200, `estimatedInput` `0.04999999999999999999999999999999999999999999999999999999999999999999`, `fullyFilled: true`.
- `/v2/swap/calldata`: HTTP 200 approval response because the wallet's current allowance is insufficient.

The public API has no historical block parameter, so the original block-specific failing preflight cannot be replayed live today. The upstream deterministic regression reconstructs the logged two-leg values and proves the rebuilt result drops the failed leg and reports the surviving `0.043104...` input instead of the stale near-`0.05` total.

## Checks

- `nix develop -c cargo check`
- `nix develop -c cargo test` — 438 passed
- `nix develop -c rainix-rs-static`
- `git diff --check`
- Three staged local review rounds, including two DeepSeek V4 Flash reviews per round
