### PR TITLE
perf: batch oracle quote contexts

### DIFF
--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -523,11 +523,12 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
         .unwrap();
 
     let oracle_body = services.oracle_bodies.lock().unwrap()[0].clone();
-    let oracle_request = <(OrderV4, U256, U256, Address)>::abi_decode(&oracle_body).unwrap();
-    assert_eq!(oracle_request.0, order);
-    assert_eq!(oracle_request.1, U256::ZERO);
-    assert_eq!(oracle_request.2, U256::ZERO);
-    assert_eq!(oracle_request.3, owner);
+    let oracle_request = <Vec<(OrderV4, U256, U256, Address)>>::abi_decode(&oracle_body).unwrap();
+    assert_eq!(oracle_request.len(), 1);
+    assert_eq!(oracle_request[0].0, order);
+    assert_eq!(oracle_request[0].1, U256::ZERO);
+    assert_eq!(oracle_request[0].2, U256::ZERO);
+    assert_eq!(oracle_request[0].3, owner);
 
     services.oracle_available.store(false, Ordering::SeqCst);
     let error = process_swap_calldata(&data_source, request)


### PR DESCRIPTION
## Dependent PRs

- Raindex bounded oracle HTTP client (merge first): https://github.com/rainlanguage/raindex/pull/2825
- Raindex batched oracle context preparation (merge second): https://github.com/rainlanguage/raindex/pull/2826

## Motivation

The REST application's order-quote passes can require many oracle contexts at once. Issuing one HTTP request per context adds avoidable connection and request overhead even when the contexts share the same oracle endpoint.

## Solution

- Bump `lib/rain.orderbook` from `0fa60a6` to `4ae9e1a02`.
- Send one ABI batch request per exact oracle URL and scatter the returned contexts back to their quote pairs.
- Preserve bounded concurrency across distinct oracle endpoints with a limit of 8.
- Remove the previous per-context concurrent HTTP request path while leaving chain quote batching unchanged.

## Verification

- `nix develop -c cargo check`
- Upstream quote crate test suite — 63 passed
- Upstream strict Clippy checks
- Repository pre-commit hooks
- `git diff --check`
- Live local REST API validation against Base:
  - `/v2/swap/quote` returned HTTP 200 and `fullyFilled: true` for wtCOIN, wtNVDA, and wtMSTR.
  - Batch telemetry reduced 55 oracle contexts to 2 HTTP requests; 54 contexts succeeded and one legacy oracle endpoint returned HTTP 404.
  - A request-scoped quote recorded one oracle context in one batch request and completed successfully.
