### PR TITLE
fix: refresh oracle signed context before returning swap calldata

### DIFF
--- a/src/routes/swap/calldata.rs
+++ b/src/routes/swap/calldata.rs
@@ -20,15 +20,20 @@ use crate::types::swap::{
     SwapCalldataRequest, SwapCalldataResponse, SwapCalldataV2Request, SwapCalldataV2RequestBody,
     SwapCalldataV2Response,
 };
-use alloy::primitives::{keccak256, Address, Bytes, Signature};
+use alloy::primitives::{keccak256, Address, Bytes, Signature, B256};
 use alloy::sol_types::{SolCall, SolValue};
+use futures::{stream, StreamExt, TryStreamExt};
 use rain_math_float::Float;
-use rain_orderbook_bindings::IRaindexV6::takeOrders4Call;
+use rain_orderbook_bindings::IRaindexV6::{takeOrders4Call, OrderV4};
+use rain_orderbook_common::oracle::{encode_oracle_body_batch, fetch_signed_context_batch};
 use rain_orderbook_common::raindex_client::take_orders::TakeOrdersRequest;
 use rain_orderbook_common::take_orders::TakeOrdersMode;
 use rocket::serde::json::Json;
 use rocket::State;
+use std::collections::BTreeMap;
 use tracing::Instrument;
+
+const ORACLE_REFRESH_CONCURRENCY_LIMIT: usize = 8;
 
 #[utoipa::path(
     post,
@@ -619,13 +624,185 @@ async fn process_swap_calldata_build(
         .get_calldata(take_req)
         .await
         .map_err(map_calldata_boundary_error)?;
-    let calldata =
+    let mut calldata =
         normalize_calldata_response(&wrap_ratios, req.denomination, req.input_token, response)
             .map_err(map_calldata_boundary_error)?;
+    refresh_oracle_signed_context(
+        ds,
+        &mut calldata,
+        req.input_token,
+        req.output_token,
+        req.taker,
+    )
+    .await
+    .map_err(map_calldata_boundary_error)?;
     Ok(SwapCalldataBuildResult {
         calldata,
         resolved_price_cap,
     })
+}
+
+/// Replace oracle signed context in executable takeOrders calldata with a
+/// freshly fetched frame. Quote/preflight reuse a frame that can already be
+/// near expiry (~20s TTL) by the time the response is returned.
+async fn refresh_oracle_signed_context(
+    ds: &dyn SwapDataSource,
+    calldata: &mut SwapCalldataResponse,
+    input_token: Address,
+    output_token: Address,
+    taker: Address,
+) -> Result<(), ApiError> {
+    if !calldata.approvals.is_empty() || calldata.data.is_empty() {
+        return Ok(());
+    }
+    let Ok(mut decoded) = takeOrders4Call::abi_decode(&calldata.data) else {
+        return Ok(());
+    };
+    if decoded
+        .config
+        .orders
+        .iter()
+        .all(|order| order.signedContext.is_empty())
+    {
+        return Ok(());
+    }
+
+    struct RefreshItem {
+        order_index: usize,
+        order_hash: B256,
+        order: OrderV4,
+        input_io_index: u32,
+        output_io_index: u32,
+    }
+
+    let orders = ds.get_orders_for_pair(input_token, output_token).await?;
+    let mut batches = BTreeMap::<String, Vec<RefreshItem>>::new();
+    for (order_index, order_config) in decoded.config.orders.iter().enumerate() {
+        if order_config.signedContext.is_empty() {
+            continue;
+        }
+        let encoded_order = Bytes::from(order_config.order.abi_encode());
+        let order_hash = B256::from(keccak256(&encoded_order));
+        let Some(order) = orders
+            .iter()
+            .find(|order| order.order_hash() == order_hash || order.order_bytes() == encoded_order)
+        else {
+            tracing::error!(
+                %order_hash,
+                pair_orders = orders.len(),
+                "cannot refresh oracle context; order missing from pair query"
+            );
+            return Err(ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            ));
+        };
+        let Some(oracle_url) = order.oracle_url() else {
+            tracing::error!(
+                %order_hash,
+                "cannot refresh oracle context; order has no oracle URL"
+            );
+            return Err(ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            ));
+        };
+        let input_io_index = u32::try_from(order_config.inputIOIndex).map_err(|error| {
+            tracing::error!(%error, %order_hash, "takeOrders inputIOIndex does not fit u32");
+            ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            )
+        })?;
+        let output_io_index = u32::try_from(order_config.outputIOIndex).map_err(|error| {
+            tracing::error!(%error, %order_hash, "takeOrders outputIOIndex does not fit u32");
+            ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            )
+        })?;
+        batches.entry(oracle_url).or_default().push(RefreshItem {
+            order_index,
+            order_hash,
+            order: order_config.order.clone(),
+            input_io_index,
+            output_io_index,
+        });
+    }
+
+    let oracle_endpoint_count = batches.len();
+    let refreshed_batches = stream::iter(batches)
+        .map(|(oracle_url, items)| async move {
+            let body = encode_oracle_body_batch(
+                items
+                    .iter()
+                    .map(|item| {
+                        (
+                            &item.order,
+                            item.input_io_index,
+                            item.output_io_index,
+                            taker,
+                        )
+                    })
+                    .collect(),
+            );
+            let expected_count = items.len();
+            let fresh = fetch_signed_context_batch(&oracle_url, body, expected_count)
+                .await
+                .map_err(|error| {
+                    tracing::error!(
+                        %error,
+                        oracle_request_count = expected_count,
+                        "failed to refresh oracle signed context before returning calldata"
+                    );
+                    ApiError::coded(
+                        ApiErrorCode::SwapCalldataFailed,
+                        "swap calldata could not be generated",
+                    )
+                })?;
+
+            Ok::<_, ApiError>(items.into_iter().zip(fresh).collect::<Vec<_>>())
+        })
+        .buffer_unordered(ORACLE_REFRESH_CONCURRENCY_LIMIT)
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    let mut refreshed = 0usize;
+    for (item, fresh) in refreshed_batches.into_iter().flatten() {
+        let Some(order_config) = decoded.config.orders.get_mut(item.order_index) else {
+            tracing::error!(
+                order_index = item.order_index,
+                order_hash = %item.order_hash,
+                "oracle refresh target is missing from decoded calldata"
+            );
+            return Err(ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            ));
+        };
+        let Some(oracle_context) = order_config.signedContext.first_mut() else {
+            tracing::error!(
+                order_index = item.order_index,
+                order_hash = %item.order_hash,
+                "oracle refresh target has no signed context"
+            );
+            return Err(ApiError::coded(
+                ApiErrorCode::SwapCalldataFailed,
+                "swap calldata could not be generated",
+            ));
+        };
+        *oracle_context = fresh;
+        refreshed += 1;
+    }
+    if refreshed > 0 {
+        tracing::info!(
+            refreshed,
+            oracle_endpoint_count,
+            "refreshed oracle signed context in swap calldata"
+        );
+        calldata.data = Bytes::from(decoded.abi_encode());
+    }
+    Ok(())
 }
 
 fn map_calldata_boundary_error(error: ApiError) -> ApiError {
@@ -652,15 +829,24 @@ mod tests {
     use crate::analytics::{Analytics, RecordingSink};
     use crate::auth::AuthenticatedKey;
     use crate::routes::swap::test_fixtures::MockSwapDataSource;
-    use crate::test_helpers::{mock_candidate, mock_order, TestClientBuilder};
+    use crate::test_helpers::{mock_candidate, mock_order, order_json, TestClientBuilder};
     use crate::types::common::Approval;
     use crate::types::swap::{SwapCalldataMode, SwapDenomination};
     use crate::wrap_ratio::WrapRatioValue;
     use alloy::primitives::{address, Address, Bytes, U256};
+    use alloy::sol_types::SolValue;
     use async_trait::async_trait;
+    use rain_orderbook_bindings::IRaindexV6::{
+        SignedContextV1, TakeOrderConfigV4, TakeOrdersConfigV5,
+    };
+    use rain_orderbook_common::raindex_client::orders::RaindexOrder;
     use rocket::http::{ContentType, Status};
+    use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     const USDC: Address = address!("833589fCD6eDb6E08f4c7C32D4f71b54bdA02913");
     const WETH: Address = address!("4200000000000000000000000000000000000006");
@@ -806,6 +992,274 @@ mod tests {
                 approval_data: Bytes::from(vec![0x09, 0x5e, 0xa7, 0xb3]),
             }],
         }
+    }
+
+    fn test_signed_context(value: u64) -> SignedContextV1 {
+        SignedContextV1 {
+            signer: TAKER,
+            context: vec![B256::from(U256::from(value))],
+            signature: Bytes::from(vec![value as u8; 65]),
+        }
+    }
+
+    fn oracle_calldata_response(orders: Vec<OrderV4>) -> SwapCalldataResponse {
+        let orders = orders
+            .into_iter()
+            .map(|order| TakeOrderConfigV4 {
+                order,
+                inputIOIndex: U256::ZERO,
+                outputIOIndex: U256::ZERO,
+                signedContext: vec![test_signed_context(1)],
+            })
+            .collect();
+        let data = takeOrders4Call {
+            config: TakeOrdersConfigV5 {
+                minimumIO: U256::ZERO.into(),
+                maximumIO: U256::from(1).into(),
+                maximumIORatio: U256::from(1).into(),
+                orders,
+                IOIsInput: true,
+                data: Bytes::new(),
+            },
+        }
+        .abi_encode();
+        SwapCalldataResponse {
+            to: ORDERBOOK,
+            data: Bytes::from(data),
+            value: U256::ZERO,
+            estimated_input: "1".to_string(),
+            denomination: SwapDenomination::Wrapped,
+            approvals: vec![],
+        }
+    }
+
+    fn raindex_order_for(order: &OrderV4, oracle_url: Option<&str>) -> RaindexOrder {
+        let encoded_order = Bytes::from(order.abi_encode());
+        let mut value = order_json();
+        value["orderBytes"] = json!(encoded_order);
+        value["orderHash"] = json!(keccak256(&encoded_order));
+        value["parsedMeta"] = oracle_url.map_or_else(
+            || json!([]),
+            |url| json!([{"RaindexSignedContextOracleV1": url}]),
+        );
+        serde_json::from_value(value).expect("deserialize oracle test order")
+    }
+
+    struct BatchOracleServer {
+        base_url: String,
+        calls: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+        batch_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl BatchOracleServer {
+        async fn start() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind batch oracle");
+            let address = listener.local_addr().expect("batch oracle address");
+            let calls = Arc::new(AtomicUsize::new(0));
+            let in_flight = Arc::new(AtomicUsize::new(0));
+            let max_in_flight = Arc::new(AtomicUsize::new(0));
+            let batch_sizes = Arc::new(Mutex::new(Vec::new()));
+
+            let server_calls = Arc::clone(&calls);
+            let server_in_flight = Arc::clone(&in_flight);
+            let server_max_in_flight = Arc::clone(&max_in_flight);
+            let server_batch_sizes = Arc::clone(&batch_sizes);
+            tokio::spawn(async move {
+                loop {
+                    let Ok((mut socket, _)) = listener.accept().await else {
+                        break;
+                    };
+                    let calls = Arc::clone(&server_calls);
+                    let in_flight = Arc::clone(&server_in_flight);
+                    let max_in_flight = Arc::clone(&server_max_in_flight);
+                    let batch_sizes = Arc::clone(&server_batch_sizes);
+                    tokio::spawn(async move {
+                        let Some(body) = read_test_request_body(&mut socket).await else {
+                            return;
+                        };
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let current = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_in_flight.fetch_max(current, Ordering::SeqCst);
+                        let requests = <Vec<(OrderV4, U256, U256, Address)>>::abi_decode(&body)
+                            .expect("decode batch oracle request");
+                        batch_sizes
+                            .lock()
+                            .expect("batch sizes lock")
+                            .push(requests.len());
+                        tokio::time::sleep(Duration::from_millis(100)).await;
+                        let response = json!(requests
+                            .iter()
+                            .map(|_| json!({
+                                "signer": TAKER,
+                                "context": [B256::from(U256::from(99))],
+                                "signature": Bytes::from(vec![99u8; 65]),
+                            }))
+                            .collect::<Vec<_>>())
+                        .to_string();
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        write_test_response(&mut socket, &response).await;
+                    });
+                }
+            });
+
+            Self {
+                base_url: format!("http://{address}"),
+                calls,
+                max_in_flight,
+                batch_sizes,
+            }
+        }
+
+        fn url(&self, path: &str) -> String {
+            format!("{}{path}", self.base_url)
+        }
+    }
+
+    async fn read_test_request_body(socket: &mut tokio::net::TcpStream) -> Option<Vec<u8>> {
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 8192];
+        let (header_end, content_length) = loop {
+            let read = socket.read(&mut chunk).await.ok()?;
+            if read == 0 {
+                return None;
+            }
+            request.extend_from_slice(&chunk[..read]);
+            if let Some(header_end) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                let header_end = header_end + 4;
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        let (name, value) = line.split_once(':')?;
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                    .unwrap_or_default();
+                break (header_end, content_length);
+            }
+        };
+        while request.len() < header_end + content_length {
+            let read = socket.read(&mut chunk).await.ok()?;
+            if read == 0 {
+                return None;
+            }
+            request.extend_from_slice(&chunk[..read]);
+        }
+        Some(request[header_end..header_end + content_length].to_vec())
+    }
+
+    async fn write_test_response(socket: &mut tokio::net::TcpStream, body: &str) {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write batch oracle response");
+    }
+
+    #[rocket::async_test]
+    async fn test_refresh_oracle_context_batches_by_url_and_runs_endpoints_concurrently() {
+        let server = BatchOracleServer::start().await;
+        let mut first_order = mock_candidate("1", "1").order;
+        first_order.nonce = U256::from(1).into();
+        let mut second_order = first_order.clone();
+        second_order.nonce = U256::from(2).into();
+        let mut third_order = first_order.clone();
+        third_order.nonce = U256::from(3).into();
+        let first_url = server.url("/first");
+        let second_url = server.url("/second");
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![
+                raindex_order_for(&first_order, Some(&first_url)),
+                raindex_order_for(&second_order, Some(&first_url)),
+                raindex_order_for(&third_order, Some(&second_url)),
+            ]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+        let mut calldata = oracle_calldata_response(vec![first_order, second_order, third_order]);
+
+        refresh_oracle_signed_context(&ds, &mut calldata, USDC, WETH, TAKER)
+            .await
+            .expect("refresh batched oracle contexts");
+
+        assert_eq!(server.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(server.max_in_flight.load(Ordering::SeqCst), 2);
+        let mut batch_sizes = server.batch_sizes.lock().expect("batch sizes lock").clone();
+        batch_sizes.sort_unstable();
+        assert_eq!(batch_sizes, vec![1, 2]);
+        let decoded =
+            takeOrders4Call::abi_decode(&calldata.data).expect("decode refreshed calldata");
+        for order in decoded.config.orders {
+            assert_eq!(
+                order.signedContext[0].context,
+                test_signed_context(99).context
+            );
+        }
+    }
+
+    #[rocket::async_test]
+    async fn test_refresh_oracle_context_fails_when_order_cannot_be_resolved() {
+        let order = mock_candidate("1", "1").order;
+        let mut calldata = oracle_calldata_response(vec![order]);
+        let original_data = calldata.data.clone();
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+
+        let result = refresh_oracle_signed_context(&ds, &mut calldata, USDC, WETH, TAKER).await;
+
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
+        assert_eq!(calldata.data, original_data);
+    }
+
+    #[rocket::async_test]
+    async fn test_refresh_oracle_context_fails_when_order_has_no_oracle_url() {
+        let order = mock_candidate("1", "1").order;
+        let mut calldata = oracle_calldata_response(vec![order.clone()]);
+        let original_data = calldata.data.clone();
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![raindex_order_for(&order, None)]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+
+        let result = refresh_oracle_signed_context(&ds, &mut calldata, USDC, WETH, TAKER).await;
+
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
+        assert_eq!(calldata.data, original_data);
+    }
+
+    #[rocket::async_test]
+    #[tracing_test::traced_test]
+    async fn test_refresh_oracle_context_does_not_log_raw_oracle_url() {
+        const SECRET: &str = "unique-refresh-secret-do-not-log";
+        let order = mock_candidate("1", "1").order;
+        let oracle_url =
+            format!("ftp://user:password@example.com/oracle?api_key={SECRET}#fragment");
+        let ds = MockSwapDataSource {
+            supported_tokens: Ok(()),
+            orders: Ok(vec![raindex_order_for(&order, Some(&oracle_url))]),
+            candidates: vec![],
+            calldata_result: Ok(ready_response()),
+        };
+        let mut calldata = oracle_calldata_response(vec![order]);
+
+        let result = refresh_oracle_signed_context(&ds, &mut calldata, USDC, WETH, TAKER).await;
+
+        assert_error_code(result, ApiErrorCode::SwapCalldataFailed);
+        assert!(!logs_contain(SECRET));
     }
 
     fn wrap_ratio(share_address: Address, assets_per_share: &str) -> WrapRatioValue {

--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -17,7 +17,7 @@ use rain_orderbook_common::dotrain_order::DotrainOrder;
 use rain_orderbook_common::raindex_client::RaindexClient;
 use raindex_test_fixtures::LocalEvm;
 use serde_json::{json, Value};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -31,16 +31,25 @@ struct MockSwapServices {
 }
 
 impl MockSwapServices {
+    #[allow(dead_code)]
     async fn start(oracle_response: Value) -> Self {
+        Self::start_sequence(vec![oracle_response]).await
+    }
+
+    async fn start_sequence(oracle_responses: Vec<Value>) -> Self {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let subgraph_order = Arc::new(RwLock::new(None));
         let oracle_available = Arc::new(AtomicBool::new(true));
         let oracle_bodies = Arc::new(Mutex::new(Vec::new()));
+        let oracle_responses = Arc::new(Mutex::new(oracle_responses));
+        let oracle_call_index = Arc::new(AtomicUsize::new(0));
 
         let orders = Arc::clone(&subgraph_order);
         let available = Arc::clone(&oracle_available);
         let bodies = Arc::clone(&oracle_bodies);
+        let responses = Arc::clone(&oracle_responses);
+        let call_index = Arc::clone(&oracle_call_index);
         tokio::spawn(async move {
             loop {
                 let Ok((mut socket, _)) = listener.accept().await else {
@@ -49,7 +58,8 @@ impl MockSwapServices {
                 let orders = Arc::clone(&orders);
                 let available = Arc::clone(&available);
                 let bodies = Arc::clone(&bodies);
-                let oracle_response = oracle_response.clone();
+                let responses = Arc::clone(&responses);
+                let call_index = Arc::clone(&call_index);
                 tokio::spawn(async move {
                     let Some((path, body)) = read_request(&mut socket).await else {
                         return;
@@ -57,7 +67,11 @@ impl MockSwapServices {
                     let (status, response) = match path.as_str() {
                         "/oracle" if available.load(Ordering::SeqCst) => {
                             bodies.lock().unwrap().push(body);
-                            ("200 OK", oracle_response.to_string())
+                            let idx = call_index.fetch_add(1, Ordering::SeqCst);
+                            let responses = responses.lock().unwrap();
+                            let response =
+                                responses[idx.min(responses.len().saturating_sub(1))].to_string();
+                            ("200 OK", response)
                         }
                         "/oracle" => {
                             bodies.lock().unwrap().push(body);
@@ -330,18 +344,37 @@ fn subgraph_order_json(order: &OrderV4, order_hash: B256, meta: &[u8], raindex: 
 async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution() {
     let mut local_evm = LocalEvm::new().await;
     let oracle_signer = PrivateKeySigner::from(local_evm.anvil.keys()[0].clone());
-    let oracle_context = B256::from(U256::from(42));
-    let oracle_signature = oracle_signer
-        .sign_message(keccak256(oracle_context).as_slice())
-        .await
-        .unwrap();
-    let oracle_signature = Bytes::from(oracle_signature.as_bytes().to_vec());
+    let stale_oracle_context = B256::from(U256::from(42));
+    let fresh_oracle_context = B256::from(U256::from(99));
+    let stale_oracle_signature = Bytes::from(
+        oracle_signer
+            .sign_message(keccak256(stale_oracle_context).as_slice())
+            .await
+            .unwrap()
+            .as_bytes()
+            .to_vec(),
+    );
+    let fresh_oracle_signature = Bytes::from(
+        oracle_signer
+            .sign_message(keccak256(fresh_oracle_context).as_slice())
+            .await
+            .unwrap()
+            .as_bytes()
+            .to_vec(),
+    );
     let oracle_signer_address = oracle_signer.address();
-    let services = MockSwapServices::start(json!([{
-        "signer": oracle_signer_address,
-        "context": [oracle_context],
-        "signature": oracle_signature,
-    }]))
+    let services = MockSwapServices::start_sequence(vec![
+        json!([{
+            "signer": oracle_signer_address,
+            "context": [stale_oracle_context],
+            "signature": stale_oracle_signature,
+        }]),
+        json!([{
+            "signer": oracle_signer_address,
+            "context": [fresh_oracle_context],
+            "signature": fresh_oracle_signature,
+        }]),
+    ])
     .await;
     let owner = local_evm.signer_wallets[0].default_signer().address();
     let input = local_evm
@@ -450,8 +483,12 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
     assert_eq!(decoded.config.orders[0].signedContext.len(), 2);
     let signed_context = &decoded.config.orders[0].signedContext[0];
     assert_eq!(signed_context.signer, oracle_signer_address);
-    assert_eq!(signed_context.context[0], oracle_context);
-    assert_eq!(signed_context.signature, oracle_signature);
+    assert_eq!(signed_context.context[0], fresh_oracle_context);
+    assert_eq!(signed_context.signature, fresh_oracle_signature);
+    assert!(
+        services.oracle_bodies.lock().unwrap().len() >= 2,
+        "calldata should refetch signed context after quote/preflight"
+    );
 
     let attributed_context = &decoded.config.orders[0].signedContext[1];
     assert_eq!(
@@ -507,8 +544,8 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
     assert_eq!(v2_decoded.config.orders[0].signedContext.len(), 2);
     let v2_oracle_context = &v2_decoded.config.orders[0].signedContext[0];
     assert_eq!(v2_oracle_context.signer, oracle_signer_address);
-    assert_eq!(v2_oracle_context.context[0], oracle_context);
-    assert_eq!(v2_oracle_context.signature, oracle_signature);
+    assert_eq!(v2_oracle_context.context[0], fresh_oracle_context);
+    assert_eq!(v2_oracle_context.signature, fresh_oracle_signature);
     let v2_context = &v2_decoded.config.orders[0].signedContext[1];
     assert_eq!(v2_context.context[1], v2_attribution.api_key_hash);
 


### PR DESCRIPTION
## Summary
- Fixes [ST0-25](https://linear.app/makeitrain/issue/ST0-25/restapi-refresh-oracle-signed-context-raise-ui-key-rpm-past-oracle): `/v2/swap/calldata` reused the oracle signed frame from quote/preflight, so takeOrders could revert `Past oracle expiry` (~20s TTL) after wallet confirmation.
- After the SDK builds executable calldata, refetch the oracle signed context and replace `signedContext[0]` so the returned frame starts a fresh TTL. Attribution is still appended after this step.
- Latest reproduction: https://basescan.org/tx/0xd0a999a04c094c6cdf5d608b3102311789e448788134fc65916aac7dd7637252 (frame expired 6s before inclusion).

This does **not** lengthen `quote_staleness_seconds` or raise the UI API key RPM. Wallet confirm + inclusion can still outlive a 20s frame; those are follow-ups on pricing/oracle and rate-limit config.

## Test plan
- [x] `nix develop -c cargo test --features oracle-integration-tests test_v1_and_v2_calldata_preserve_oracle` — returned context is the **last** oracle fetch, not the quote-time one
- [x] `nix develop -c cargo test --bin st0x_rest_api routes::swap::calldata::tests` (48 passed)
- [x] `nix develop -c rainix-rs-static`
- [ ] Preview: first-time USDC market buy should still prompt approve then take; takeOrders calldata should have a publish/expiry stamped at response time, not quote time


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.rest.api/pr/173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789209876&installation_model_id=19370&pr_number=173&repository=ST0x-Technology%2Fst0x.rest.api&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.rest.api%2Fpull%2F173&signature=194ba6a7d920059f49ed8ceb99b043293108dd70a617b2337ebfe1b1bb3b40cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->