### PR TITLE
chore: bump raindex for block explorer metadata

### DIFF
--- a/src/routes/swap/calldata/oracle_integration_tests.rs
+++ b/src/routes/swap/calldata/oracle_integration_tests.rs
@@ -525,7 +525,10 @@ async fn test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution()
         .unwrap();
 
     let oracle_body = services.oracle_bodies.lock().unwrap()[0].clone();
-    let oracle_request = <(OrderV4, U256, U256, Address)>::abi_decode(&oracle_body).unwrap();
+    let oracle_requests = <Vec<(OrderV4, U256, U256, Address)>>::abi_decode(&oracle_body).unwrap();
+    let [oracle_request] = oracle_requests.as_slice() else {
+        panic!("expected exactly one batched oracle request");
+    };
     assert_eq!(oracle_request.0, order);
     assert_eq!(oracle_request.1, U256::ZERO);
     assert_eq!(oracle_request.2, U256::ZERO);


### PR DESCRIPTION
## Why
The multichain REST API branch must consume the raindex settings model that understands optional registry-provided block explorer metadata.

## What changed
- advance `lib/rain.orderbook` to the reviewed SDK commit
- update the oracle integration assertion for the SDK batch-request encoding introduced since the previous pinned revision
- keep this PR stacked directly on the existing multichain API PR #151

## Validation
- `nix develop -c cargo check --locked`
- `nix develop -c rainix-rs-static`
- `nix develop -c cargo test --locked` (440 passed)
- `nix build .#st0x-docs --no-link`
- `nix develop -c cargo test --features oracle-integration-tests test_v1_and_v2_calldata_preserve_oracle_and_embed_api_key_attribution`

## Dependencies
- parent: https://github.com/ST0x-Technology/st0x.rest.api/pull/151
- raindex SDK: https://github.com/rainlanguage/raindex/pull/2833
- spec: https://github.com/rainlanguage/specs/pull/54

## Scope
This does not add a REST `/networks` route. The website will read network and explorer metadata through the registry SDK after the npm release.